### PR TITLE
fix: 스토리북 chromatic deploy 수정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -41,7 +41,6 @@ jobs:
       # 의존성 설치
       - name: Install Dependency
         run: pnpm install --no-frozen-lockfile # 의존성 버전 불일치 허용
-        working-directory: apps/storybook
 
       # storybook 배포
       - name: Publish Chromatic

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "storybook dev -p 6006",
-    "build:storybook": "storybook build"
+    "build-storybook": "storybook build"
   },
   "keywords": [],
   "author": "",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "dev": "storybook dev -p 6006",
+    "build:storybook": "storybook build"
   },
   "keywords": [],
   "author": "",

--- a/apps/storybook/turbo.json
+++ b/apps/storybook/turbo.json
@@ -2,7 +2,7 @@
   "extends": ["//"],
   "tasks": {
     "build:storybook": {
-      "dependsOn": ["^build-storybook"],
+      "dependsOn": ["^build:storybook"],
       "outputs": ["storybook-static/**"]
     }
   }

--- a/apps/storybook/turbo.json
+++ b/apps/storybook/turbo.json
@@ -1,8 +1,8 @@
 {
   "extends": ["//"],
   "tasks": {
-    "build:storybook": {
-      "dependsOn": ["^build:storybook"],
+    "build-storybook": {
+      "dependsOn": ["^build-storybook"],
       "outputs": ["storybook-static/**"]
     }
   }

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*", "!**/*.stories.{tsx,jsx,mdx}"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**/*"]
     },
-    "build:storybook": {},
+    "build-storybook": {},
     "lint": {
       "dependsOn": ["^lint"]
     },


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- 스토리북 chromatic 의존성 설치 디렉터리 변경 (apps/storybook → root)
내부 의존성에서 "workspace:*"를 사용하고 있기 때문에 
워킹 디렉터리를 루트로 변경합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Storybook 관련 스크립트와 작업(Task) 이름이 일관성 있게 변경되었습니다.
  - 워크플로우에서 의존성 설치 경로가 기본값으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->