### PR TITLE
ci: github action auto assign & reviwer 설정 추가

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,27 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - im-na0
+  - yeomgahui
+  - south-nova
+  - bbb4756
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# The action will only run if the PR meets the specified filters
+filterLabels:
+  exclude:
+    - wip
+    - dependencies
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip
+  - draft

--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,10 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

> https://jira-knockdog.atlassian.net/browse/KDDEV-81?atlOrigin=eyJpIjoiMDYyZjA2NGQwMjZjNDg3OGE5MmRiNjBjOGVhYjlkZWMiLCJwIjoiaiJ9
리뷰어와 어싸인을 자동적으로 채워주는 워크플로우를 생성합니다




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 새로운 자동 할당 기능이 추가되어, PR 생성 시 리뷰어와 담당자가 자동으로 지정됩니다.
  - "wip", "dependencies" 라벨이 있거나 제목/설명에 "wip", "draft"가 포함된 PR은 자동 할당이 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->