### PR TITLE
refactor(ui): divider 컴포넌트 디자인 시스템과 일치하도록 수정

### DIFF
--- a/packages/ui/src/components/divider/Divider.stories.tsx
+++ b/packages/ui/src/components/divider/Divider.stories.tsx
@@ -30,13 +30,9 @@ const meta: Meta<typeof Divider> = {
       control: { type: 'radio' },
       options: ['solid', 'dashed', 'dotted'],
     },
-    dividerColor: {
-      control: { type: 'radio' },
-      options: ['default', 'subtle', 'accent'],
-    },
     size: {
       control: { type: 'select' },
-      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      options: ['normal', 'thick'],
     },
   },
 };
@@ -49,8 +45,7 @@ export const Horizontal: Story = {
   args: {
     orientation: 'horizontal',
     variant: 'solid',
-    dividerColor: 'default',
-    size: 'md',
+    size: 'normal',
   },
 };
 
@@ -58,8 +53,7 @@ export const Vertical: Story = {
   args: {
     orientation: 'vertical',
     variant: 'dotted',
-    dividerColor: 'accent',
-    size: 'lg',
+    size: 'thick',
   },
 };
 
@@ -67,7 +61,6 @@ export const DashedSubtle: Story = {
   args: {
     orientation: 'horizontal',
     variant: 'dashed',
-    dividerColor: 'subtle',
-    size: 'sm',
+    size: 'normal',
   },
 };

--- a/packages/ui/src/components/divider/Divider.tsx
+++ b/packages/ui/src/components/divider/Divider.tsx
@@ -13,39 +13,21 @@ const dividerVariants = cva('', {
       horizontal: 'w-full border-t',
       vertical: 'h-full border-l',
     },
-    dividerColor: {
-      default: 'border-line-200',
-      subtle: 'border-line-100',
-      accent: 'border-line-accent',
-    },
   },
   defaultVariants: {
     variant: 'solid',
     orientation: 'horizontal',
-    dividerColor: 'default',
   },
 });
 
 const sizeClasses = {
-  xsmall: {
-    horizontal: 'border-t-1',
-    vertical: 'border-l-1',
+  normal: {
+    horizontal: 'border-t-1 border-line-200',
+    vertical: 'border-l-1 border-line-200',
   },
-  small: {
-    horizontal: 'border-t-4',
-    vertical: 'border-l-4',
-  },
-  medium: {
-    horizontal: 'border-t-8',
-    vertical: 'border-l-8',
-  },
-  large: {
-    horizontal: 'border-t-16',
-    vertical: 'border-l-16',
-  },
-  xlarge: {
-    horizontal: 'border-t-32',
-    vertical: 'border-l-32',
+  thick: {
+    horizontal: 'border-t-8 border-line-100',
+    vertical: 'border-l-8 border-line-100',
   },
 } as const;
 
@@ -61,8 +43,7 @@ const Divider = forwardRef<HTMLDivElement, DividerProps>(
       className,
       variant,
       orientation = 'horizontal',
-      size = 'medium',
-      dividerColor,
+      size = 'normal',
       ...props
     },
     ref
@@ -77,7 +58,6 @@ const Divider = forwardRef<HTMLDivElement, DividerProps>(
           dividerVariants({
             variant,
             orientation,
-            dividerColor,
           }),
           sizeClass,
           className


### PR DESCRIPTION
- divider 컴포넌트의 크기 옵션을 'medium'에서 'normal' 및 'thick'으로 변경
- dividerColor 관련 코드 제거 및 관련 스토리 수정
- 스토리북에서 dividerColor 옵션 제거

<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

Divider 컴포넌트 디자인 시스템과 일치하도록 수정
## 작업 내용

- 기존: size와 dividerColor가 독립적으로 설정되어 사용자가 수동으로 색상을 선택해야 함
- 개선: size 선택에 따라 자동으로 적절한 색상이 적용되도록 변경


## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->

@south-nova @kor-kms @im-na0 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Divider 컴포넌트의 두께 옵션이 'normal'과 'thick' 두 가지로 단순화되었습니다.

* **Refactor**
  * Divider 컴포넌트에서 색상 관련 옵션이 제거되어, 더 간결하게 스타일이 적용됩니다.
  * Storybook에서 dividerColor 옵션이 삭제되고, size 옵션이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->