### PR TITLE
fix(knockdog): SSR 렌더링 시 BottomSheet document 에러 해결

### DIFF
--- a/apps/knockdog/app/(home)/page.tsx
+++ b/apps/knockdog/app/(home)/page.tsx
@@ -1,138 +1,20 @@
 'use client';
 
-import { useRef, useState } from 'react';
-import { cn } from '@knockdog/ui/lib';
-import { BottomSheet, Float, FloatingActionButton, Icon } from '@knockdog/ui';
-import { RemoveScroll } from 'react-remove-scroll';
-import Link from 'next/link';
+import dynamic from 'next/dynamic';
 
-import { DogSchoolListWidget } from '@widgets/dogschool-list';
 import { NaverMap } from '@shared/ui/naver-map';
-import { getViewportSize, useIsomorphicLayoutEffect } from '@shared/lib';
-import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
 
-// 최소 스냅포인트: 149px(바텀시트 최소 높이) + 68px(바텀바 높이) + 1px(보더)
-// 최대 스냅포인트: 화면높이 - 48px(검색바 높이) + 8px(여백)
-const MIN_SNAP_POINT = BOTTOM_BAR_HEIGHT + 149;
-const MAX_SNAP_POINT = getViewportSize().height - 64 + 8;
+const BottomSheet = dynamic(() => import('./ui/MapBottomSheet'), {
+  ssr: false,
+});
 
 export default function Home() {
-  const snapPoints = [`${MIN_SNAP_POINT}px`, 0.5, 1];
-  const [snap, setSnap] = useState<number | string | null>(
-    snapPoints[0] ?? null
-  );
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [container, setContainer] = useState<HTMLElement | null>(null);
-
-  const isFullyExtended = snap === snapPoints[snapPoints.length - 1];
-
-  useIsomorphicLayoutEffect(() => {
-    if (containerRef.current) {
-      setContainer(containerRef.current);
-    }
-  }, []);
-
   return (
     <>
       <NaverMap />
+      {/* 지도 배경 오버레이 */}
       <div className='z-2 bg-primitive-neutral-50/12 pointer-events-none absolute top-0 h-full w-full touch-none' />
-
-      {/* search bar */}
-      <div
-        className={cn(
-          'px-x4 pb-x2 absolute top-0 z-50 w-full pt-[calc(env(safe-area-inset-top)+8px)] transition-colors ease-out',
-          isFullyExtended && 'bg-fill-secondary-0'
-        )}
-      >
-        <Link href='/search'>
-          <div className='radius-r2 border-line-600 bg-fill-secondary-0 px-x4 flex h-[48px] items-center border'>
-            <Icon
-              icon='Search'
-              className='size-x5 text-fill-secondary-700 mr-x2'
-            />
-            <div
-              role='button'
-              aria-label='검색창 열기'
-              className='text-text-tertiary body1-regular flex-1'
-            >
-              업체 또는 주소를 검색하세요
-            </div>
-          </div>
-        </Link>
-      </div>
-
-      {/* chips */}
-      <div className='px-x4 gap-x2 absolute top-[calc(env(safe-area-inset-top)+64px)] z-20 flex w-full'>
-        <button className='radius-r2 py-x2 px-x3_5 gap-x1 border-line-200 bg-fill-secondary-700 body2-semibold text-text-primary-inverse flex shrink-0 items-center border-[1.4px]'>
-          <Icon
-            icon='Note'
-            className='text-fill-primary-500 size-x4 inline-flex items-center justify-center'
-          />
-          메모
-        </button>
-        <button className='radius-r2 py-x2 px-x3_5 gap-x1 border-line-200 bg-fill-secondary-700 body2-semibold text-text-primary-inverse flex shrink-0 items-center border-[1.4px]'>
-          <Icon
-            icon='BookmarkFill'
-            className='text-fill-primary-500 inline-flex size-[16.8px] items-center justify-center'
-          />
-          북마크
-        </button>
-      </div>
-
-      {/* bottom sheet container */}
-      <div
-        ref={containerRef}
-        className='pointer-events-none absolute bottom-0 w-full'
-        style={{
-          height: `${MAX_SNAP_POINT}px`,
-        }}
-      >
-        <BottomSheet.Root
-          defaultOpen
-          dismissible={false}
-          modal={isFullyExtended}
-          snapPoints={snapPoints}
-          activeSnapPoint={snap}
-          setActiveSnapPoint={setSnap}
-          container={container}
-        >
-          <RemoveScroll forwardProps>
-            <BottomSheet.Content
-              className={cn(
-                'shadow-black/6 absolute inset-x-0 h-full shadow-[0px_-2px_10px] focus-visible:outline-none',
-                isFullyExtended && 'rounded-none shadow-none'
-              )}
-            >
-              {!isFullyExtended && (
-                <BottomSheet.Handle className='mt-x3 mb-x1' />
-              )}
-              <div
-                className={cn(
-                  'scrollbar-hide mx-auto h-full w-full',
-                  isFullyExtended ? 'overflow-y-auto' : 'overflow-hidden'
-                )}
-              >
-                <Float
-                  placement='bottom-center'
-                  zIndex={50}
-                  style={{
-                    bottom: `calc(${BOTTOM_BAR_HEIGHT}px + 12px)`,
-                  }}
-                >
-                  <FloatingActionButton
-                    label='지도보기'
-                    size='small'
-                    onClick={() => {
-                      setSnap(snapPoints[0] ?? null);
-                    }}
-                  />
-                </Float>
-                <DogSchoolListWidget />
-              </div>
-            </BottomSheet.Content>
-          </RemoveScroll>
-        </BottomSheet.Root>
-      </div>
+      <BottomSheet />
     </>
   );
 }

--- a/apps/knockdog/app/(home)/ui/MapBottomSheet.tsx
+++ b/apps/knockdog/app/(home)/ui/MapBottomSheet.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { BottomSheet, Float, FloatingActionButton, Icon } from '@knockdog/ui';
+import { cn } from '@knockdog/ui/lib';
+import React, { useRef, useState } from 'react';
+import { RemoveScroll } from 'react-remove-scroll';
+import Link from 'next/link';
+import { DogSchoolListWidget } from '@widgets/dogschool-list';
+import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
+import { getViewportSize, useIsomorphicLayoutEffect } from '@shared/lib';
+
+// 최소 스냅포인트: 149px(바텀시트 최소 높이) + 68px(바텀바 높이) + 1px(보더)
+// 최대 스냅포인트: 화면높이 - 48px(검색바 높이) + 8px(여백)
+const MIN_SNAP_POINT = BOTTOM_BAR_HEIGHT + 149;
+const MAX_SNAP_POINT = getViewportSize().height - 64 + 8;
+
+export default function MapBottomSheet() {
+  const snapPoints = [`${MIN_SNAP_POINT}px`, 0.5, 1];
+  const [snap, setSnap] = useState<number | string | null>(
+    snapPoints[0] ?? null
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+
+  const isFullyExtended = snap === snapPoints[snapPoints.length - 1];
+
+  useIsomorphicLayoutEffect(() => {
+    if (containerRef.current) {
+      setContainer(containerRef.current);
+    }
+  }, []);
+
+  return (
+    <>
+      <div
+        className={cn(
+          'px-x4 pb-x2 absolute top-0 z-50 w-full pt-[calc(env(safe-area-inset-top)+8px)] transition-colors ease-out',
+          isFullyExtended && 'bg-fill-secondary-0'
+        )}
+      >
+        <Link href='/search'>
+          <div className='radius-r2 border-line-600 bg-fill-secondary-0 px-x4 flex h-[48px] items-center border'>
+            <Icon
+              icon='Search'
+              className='size-x5 text-fill-secondary-700 mr-x2'
+            />
+            <div
+              role='button'
+              aria-label='검색창 열기'
+              className='text-text-tertiary body1-regular flex-1'
+            >
+              업체 또는 주소를 검색하세요
+            </div>
+          </div>
+        </Link>
+      </div>
+
+      {/* chips */}
+      <div className='px-x4 gap-x2 absolute top-[calc(env(safe-area-inset-top)+64px)] z-20 flex w-full'>
+        <button className='radius-r2 py-x2 px-x3_5 gap-x1 border-line-200 bg-fill-secondary-700 body2-semibold text-text-primary-inverse flex shrink-0 items-center border-[1.4px]'>
+          <Icon
+            icon='Note'
+            className='text-fill-primary-500 size-x4 inline-flex items-center justify-center'
+          />
+          메모
+        </button>
+        <button className='radius-r2 py-x2 px-x3_5 gap-x1 border-line-200 bg-fill-secondary-700 body2-semibold text-text-primary-inverse flex shrink-0 items-center border-[1.4px]'>
+          <Icon
+            icon='BookmarkFill'
+            className='text-fill-primary-500 inline-flex size-[16.8px] items-center justify-center'
+          />
+          북마크
+        </button>
+      </div>
+
+      <div
+        ref={containerRef}
+        className='pointer-events-none absolute bottom-0 w-full'
+        style={{
+          height: `${MAX_SNAP_POINT}px`,
+        }}
+      >
+        <BottomSheet.Root
+          defaultOpen
+          dismissible={false}
+          modal={isFullyExtended}
+          snapPoints={snapPoints}
+          activeSnapPoint={snap}
+          setActiveSnapPoint={setSnap}
+          container={container}
+        >
+          <RemoveScroll forwardProps>
+            <BottomSheet.Content
+              className={cn(
+                'shadow-black/6 absolute inset-x-0 h-full shadow-[0px_-2px_10px] focus-visible:outline-none',
+                isFullyExtended && 'rounded-none shadow-none'
+              )}
+            >
+              {!isFullyExtended && (
+                <BottomSheet.Handle className='mt-x3 mb-x1' />
+              )}
+              <div
+                className={cn(
+                  'scrollbar-hide mx-auto h-full w-full',
+                  isFullyExtended ? 'overflow-y-auto' : 'overflow-hidden'
+                )}
+              >
+                <Float
+                  placement='bottom-center'
+                  zIndex={50}
+                  style={{
+                    bottom: `calc(${BOTTOM_BAR_HEIGHT}px + 12px)`,
+                  }}
+                >
+                  <FloatingActionButton
+                    label='지도보기'
+                    size='small'
+                    onClick={() => {
+                      setSnap(snapPoints[0] ?? null);
+                    }}
+                  />
+                </Float>
+                <DogSchoolListWidget />
+              </div>
+            </BottomSheet.Content>
+          </RemoveScroll>
+        </BottomSheet.Root>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

BottomSheet 컴포넌트를 사용하는 페이지에서 SSR 환경에서 발생하는 런타임 에러를 대응하기 위한 수정입니다.
> https://jira-knockdog.atlassian.net/browse/KDDEV-90?atlOrigin=eyJpIjoiZGVkMWFkMTBiMTZmNGFlYWI0NzJhM2EyZGU2NzBiNWQiLCJwIjoiaiJ9

## 작업 내용

### 문제 배경

Next.js 환경에서 BottomSheet 컴포넌트를 사용하는 페이지를 SSR로 렌더링할 경우, 아래와 같은 런타임 에러가 발생합니다.
```
⨯ ReferenceError: document is not defined
at useScaleBackground (.../drawer/dist/index.mjs:713:43)
at Drawer.Content (.../drawer/dist/index.mjs:1405:4)
```

### 원인

BottomSheet는 vaul 라이브러리를 기반으로 하고 있으며, 해당 라이브러리 내부에서 document를 조건 없이 참조하고 있어 SSR 중 예외가 발생합니다.
```ts
useMemo(() => document.body.style.backgroundColor, []);
```

### 해결 방법
vaul 라이브러리는 SSR 환경에 대한 처리가 되어 있지 않으므로,
BottomSheet를 사용하는 컴포넌트를 [dynamic import](https://nextjs.org/docs/app/guides/lazy-loading#skipping-ssr)하고 ssr: false 옵션을 사용하여 클라이언트 환경에서만 렌더링되도록 처리했습니다.

