### PR TITLE
[Feature/kddev-95] 계정 연동 페이지 퍼블리싱

### DIFF
--- a/apps/knockdog/app/(auth)/account-linking/[method]/page.tsx
+++ b/apps/knockdog/app/(auth)/account-linking/[method]/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { Icon } from '@knockdog/ui';
+import { useHeaderContext } from '@widgets/Header';
+
+export default function AccountLinkingPage() {
+  const { method } = useParams();
+  const { setTitle } = useHeaderContext();
+
+  const isKakao = method === 'kakao';
+  const isGoogle = method === 'google';
+  const isApple = method === 'apple';
+
+  useEffect(() => {
+    setTitle('기존 회원 로그인');
+  }, [setTitle]);
+
+  const methodMap = {
+    kakao: '카카오 계정',
+    google: '구글 계정',
+    apple: 'Apple 계정',
+  };
+
+  return (
+    <div className='mt-[98px] px-4'>
+      <div className='flex flex-col gap-[32px] py-5'>
+        <p className='h1-extrabold'>
+          동일한 이메일로 가입된
+          <br />
+          <span className='text-text-accent'>
+            {methodMap[method as keyof typeof methodMap] || ''}
+          </span>
+          이 있어요!
+        </p>
+        <div className='h-[34px]' />
+
+        <div className='bg-fill-secondary-50 body1-medium flex flex-col rounded-lg p-4 text-center'>
+          petcampus@daum.net
+        </div>
+        <div className='fixed bottom-[58px] left-0 right-0 flex flex-col gap-y-3 bg-white px-4 py-5'>
+          {isKakao && (
+            <button
+              type='button'
+              className='body1-bold text-text-primary flex w-full items-center justify-center gap-x-2 rounded-lg bg-[#FEE500] py-4'
+            >
+              <Icon icon='KakaoLogo' />
+              카카오톡으로 시작하기
+            </button>
+          )}
+          {isGoogle && (
+            <button
+              type='button'
+              className='body1-bold border-line-400 flex w-full items-center justify-center gap-x-2 rounded-lg border py-4'
+            >
+              <Icon icon='GoogleLogo' />
+              구글로 시작하기
+            </button>
+          )}
+
+          {isApple && (
+            <button
+              type='button'
+              className='body1-bold text-text-primary-inverse flex w-full items-center justify-center gap-x-2 rounded-lg border bg-[#000000] py-4'
+            >
+              <Icon icon='AppleLogo' />
+              Apple로 시작하기
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/knockdog/app/(auth)/account-linking/deleted-account/page.tsx
+++ b/apps/knockdog/app/(auth)/account-linking/deleted-account/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useParams } from 'next/navigation';
+import { ActionButton as Button, Icon } from '@knockdog/ui';
+import { useHeaderContext } from '@widgets/Header';
+
+export default function AccountLinkingPage() {
+  const { method } = useParams();
+  const { setTitle } = useHeaderContext();
+
+  const isKakao = method === 'kakao';
+  const isGoogle = method === 'google';
+  const isApple = method === 'apple';
+
+  useEffect(() => {
+    setTitle('계정 연동');
+  }, [setTitle]);
+
+  const methodMap = {
+    kakao: '카카오 계정',
+    google: '구글 계정',
+    apple: 'Apple 계정',
+  };
+
+  return (
+    <div className='mt-[98px] px-4'>
+      <div className='flex flex-col gap-[32px] py-5'>
+        <p className='h1-extrabold'>
+          동일한 이메일로 가입된
+          <br />
+          SNS 연동 해제 계정이 있어요!
+        </p>
+        <p className='h1-extrabold'> 계정을 연동할까요? </p>
+
+        <div className='bg-fill-secondary-50 body1-medium flex flex-col rounded-lg p-4 text-center'>
+          petcampus@daum.net
+        </div>
+        <div className='fixed bottom-[58px] left-0 right-0 flex gap-x-2 px-4 py-5'>
+          <Button variant='secondaryLine' className='w-full'>
+            돌아가기
+          </Button>
+          <Button variant='secondaryFill' className='w-full'>
+            연동하기
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/knockdog/app/(auth)/account-linking/deleted-account/page.tsx
+++ b/apps/knockdog/app/(auth)/account-linking/deleted-account/page.tsx
@@ -1,27 +1,16 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import { useParams } from 'next/navigation';
-import { ActionButton as Button, Icon } from '@knockdog/ui';
+import { ActionButton as Button } from '@knockdog/ui';
+import Link from 'next/link';
 import { useHeaderContext } from '@widgets/Header';
 
-export default function AccountLinkingPage() {
-  const { method } = useParams();
+export default function DeletedAccountPage() {
   const { setTitle } = useHeaderContext();
-
-  const isKakao = method === 'kakao';
-  const isGoogle = method === 'google';
-  const isApple = method === 'apple';
 
   useEffect(() => {
     setTitle('계정 연동');
   }, [setTitle]);
-
-  const methodMap = {
-    kakao: '카카오 계정',
-    google: '구글 계정',
-    apple: 'Apple 계정',
-  };
 
   return (
     <div className='mt-[98px] px-4'>
@@ -37,12 +26,16 @@ export default function AccountLinkingPage() {
           petcampus@daum.net
         </div>
         <div className='fixed bottom-[58px] left-0 right-0 flex gap-x-2 px-4 py-5'>
-          <Button variant='secondaryLine' className='w-full'>
-            돌아가기
-          </Button>
-          <Button variant='secondaryFill' className='w-full'>
-            연동하기
-          </Button>
+          <Link href='/login' className='flex-1'>
+            <Button variant='secondaryLine' className='w-full'>
+              돌아가기
+            </Button>
+          </Link>
+          <Link href='/account-linking' className='flex-1'>
+            <Button variant='secondaryFill' className='w-full'>
+              연동하기
+            </Button>
+          </Link>
         </div>
       </div>
     </div>

--- a/apps/knockdog/app/(auth)/account-linking/page.tsx
+++ b/apps/knockdog/app/(auth)/account-linking/page.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { Icon, ActionButton, TextField, TextFieldInput } from '@knockdog/ui';
+import { useHeaderContext } from '@widgets/Header';
+import { useVerificationTimer } from '@features/auth';
+
+export default function AccountLinkingPage() {
+  // 인증여부
+  const [isVerified, setIsVerified] = useState(false);
+  const { formattedTime, start, stop, status } = useVerificationTimer({
+    duration: 180,
+  });
+
+  const { setTitle } = useHeaderContext();
+
+  useEffect(() => {
+    setTitle('계정 연동');
+  }, [setTitle]);
+
+  return (
+    <div className='mt-[98px] px-4'>
+      <div className='flex flex-col gap-[32px] py-5'>
+        <p className='h1-extrabold'>이메일에서 인증해주세요</p>
+        <div className='flex gap-x-2'>
+          <TextField suffix={formattedTime}>
+            <TextFieldInput placeholder='이메일을 입력해주세요' />
+          </TextField>
+
+          <ActionButton
+            className='w-[80px]'
+            variant='secondaryFill'
+            disabled={status === 'RUNNING'}
+            onClick={() => {
+              start();
+            }}
+          >
+            {status === 'IDLE' ? '인증' : '재전송'}
+          </ActionButton>
+        </div>
+
+        <div className='fixed bottom-[58px] left-0 right-0 px-4'>
+          <div className='mb-[28px] flex items-center justify-center gap-x-1'>
+            <p className='label-semibold text-text-tertiary'>
+              이메일이 오지 않아요
+            </p>
+            <Icon icon='ChevronRight' className='text-text-tertiary h-4 w-4' />
+          </div>
+
+          <ActionButton
+            variant='secondaryFill'
+            disabled={!isVerified}
+            className='my-5 w-full'
+          >
+            완료하기
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/knockdog/app/(auth)/login/page.tsx
+++ b/apps/knockdog/app/(auth)/login/page.tsx
@@ -1,25 +1,30 @@
 import React from 'react';
 import { Icon, Divider } from '@knockdog/ui';
+import Link from 'next/link';
 
 export default function LoginPage() {
   return (
     <div>
       {/* 하단 영역 */}
       <div className='fixed bottom-[78px] left-0 right-0 flex flex-col gap-y-3 bg-white px-4'>
-        <button
-          type='button'
-          className='body1-bold text-text-primary flex w-full items-center justify-center gap-x-2 rounded-lg bg-[#FEE500] py-4'
-        >
-          <Icon icon='KakaoLogo' />
-          카카오톡으로 시작하기
-        </button>
-        <button
-          type='button'
-          className='body1-bold border-line-400 flex w-full items-center justify-center gap-x-2 rounded-lg border py-4'
-        >
-          <Icon icon='GoogleLogo' />
-          구글로 시작하기
-        </button>
+        <Link href='/account-linking/kakao'>
+          <button
+            type='button'
+            className='body1-bold text-text-primary flex w-full items-center justify-center gap-x-2 rounded-lg bg-[#FEE500] py-4'
+          >
+            <Icon icon='KakaoLogo' />
+            카카오톡으로 시작하기
+          </button>
+        </Link>
+        <Link href='/account-linking/deleted-account'>
+          <button
+            type='button'
+            className='body1-bold border-line-400 flex w-full items-center justify-center gap-x-2 rounded-lg border py-4'
+          >
+            <Icon icon='GoogleLogo' />
+            구글로 시작하기
+          </button>
+        </Link>
         <button
           type='button'
           className='body1-bold text-text-primary-inverse flex w-full items-center justify-center gap-x-2 rounded-lg border bg-[#000000] py-4'

--- a/apps/knockdog/src/features/auth/index.ts
+++ b/apps/knockdog/src/features/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './model/useVerificationTimer';

--- a/apps/knockdog/src/features/auth/model/useVerificationTimer.ts
+++ b/apps/knockdog/src/features/auth/model/useVerificationTimer.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+
+export const VERIFICATION_STATUS = {
+  IDLE: 'IDLE', // 초기 상태
+  RUNNING: 'RUNNING', // 시간 진행중
+  PENDING: 'PENDING', // 시간 중지
+  EXPIRED: 'EXPIRED', // 시간 만료
+} as const;
+
+export type VerificationStatus =
+  (typeof VERIFICATION_STATUS)[keyof typeof VERIFICATION_STATUS];
+
+interface VerificationTimerProps {
+  duration: number;
+  onExpired?: () => void | Promise<void>;
+}
+
+export const useVerificationTimer = ({
+  duration,
+  onExpired,
+}: VerificationTimerProps) => {
+  const [status, setStatus] = useState<VerificationStatus>(
+    VERIFICATION_STATUS.IDLE
+  );
+  const [timeLeft, setTimeLeft] = useState(duration);
+  const timerId = useRef<ReturnType<typeof setInterval> | null>(null);
+  const onExpiredRef = useRef(onExpired);
+
+  // 콜백 ref 업데이트
+  useEffect(() => {
+    onExpiredRef.current = onExpired;
+  }, [onExpired]);
+
+  const clearTimer = useCallback(() => {
+    if (timerId.current) {
+      clearInterval(timerId.current);
+      timerId.current = null;
+    }
+  }, []);
+
+  const start = useCallback(() => {
+    if (status === VERIFICATION_STATUS.RUNNING) return;
+
+    setStatus(VERIFICATION_STATUS.RUNNING);
+    setTimeLeft(duration);
+
+    const id = setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          clearTimer();
+          setStatus(VERIFICATION_STATUS.EXPIRED);
+          onExpiredRef.current?.();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    timerId.current = id;
+  }, [duration, clearTimer, status]);
+
+  const stop = useCallback(() => {
+    clearTimer();
+    setStatus(VERIFICATION_STATUS.IDLE);
+  }, [clearTimer]);
+
+  const reset = useCallback(() => {
+    clearTimer();
+    setTimeLeft(duration);
+    setStatus(VERIFICATION_STATUS.IDLE);
+  }, [clearTimer, duration]);
+
+  // 컴포넌트 언마운트시 타이머 정리
+  useEffect(() => {
+    return () => {
+      clearTimer();
+    };
+  }, [clearTimer]);
+
+  // MM:SS 형식으로 시간 포맷팅
+  const formattedTime = useMemo(
+    () =>
+      `${String(Math.floor(timeLeft / 60)).padStart(2, '0')}:${String(
+        timeLeft % 60
+      ).padStart(2, '0')}`,
+    [timeLeft]
+  );
+
+  return {
+    status,
+    timeLeft,
+    formattedTime,
+    start,
+    stop,
+    reset,
+    setStatus,
+  };
+};

--- a/apps/knockdog/src/widgets/Header/ui/Header.tsx
+++ b/apps/knockdog/src/widgets/Header/ui/Header.tsx
@@ -34,9 +34,7 @@ export function Header({
       )}
       {...props}
     >
-      <div className='flex h-[26px] items-center justify-between'>
-        {children}
-      </div>
+      <div className='relative flex h-[26px]'>{children}</div>
     </header>
   );
 }
@@ -57,9 +55,21 @@ function RightSection({ children, ...props }: ComponentProps<'div'>) {
   );
 }
 
+function CenterSection({ children, ...props }: ComponentProps<'div'>) {
+  return (
+    <div
+      className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}
+
 Header.BackButton = BackButton;
 Header.Title = Title;
 Header.RightSection = RightSection;
+Header.CenterSection = CenterSection;
 Header.ShareButton = ShareButton;
 Header.MenuButton = MenuButton;
 Header.CloseButton = CloseButton;

--- a/apps/knockdog/src/widgets/Header/ui/HeaderWrapper.tsx
+++ b/apps/knockdog/src/widgets/Header/ui/HeaderWrapper.tsx
@@ -36,7 +36,7 @@ export function HeaderWrapper() {
           <Header.BackButton />
         </Header.LeftSection>
         <Header.CenterSection>
-          <Header.Title>기존 회원 로그인</Header.Title>
+          <Header.Title>{title}</Header.Title>
         </Header.CenterSection>
       </Header>
     );

--- a/apps/knockdog/src/widgets/Header/ui/HeaderWrapper.tsx
+++ b/apps/knockdog/src/widgets/Header/ui/HeaderWrapper.tsx
@@ -28,5 +28,19 @@ export function HeaderWrapper() {
     );
   }
 
+  const isAccountLinking = pathname.startsWith('/account-linking');
+  if (isAccountLinking) {
+    return (
+      <Header variant={variant}>
+        <Header.LeftSection>
+          <Header.BackButton />
+        </Header.LeftSection>
+        <Header.CenterSection>
+          <Header.Title>기존 회원 로그인</Header.Title>
+        </Header.CenterSection>
+      </Header>
+    );
+  }
+
   return null;
 }

--- a/packages/ui/src/components/text-field/TextField.tsx
+++ b/packages/ui/src/components/text-field/TextField.tsx
@@ -65,7 +65,8 @@ function TextField({ ref, ...props }: TextFieldProps) {
       >
         {prefix}
         {children}
-        {suffix}
+
+        <div className='body2-bold'>{suffix}</div>
       </TextFieldPrimitive.Field>
       {renderFooter && (
         <div className='pt-x2'>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
계정 연동 페이지 퍼블리싱


## 작업 내용

- 삭제된 계정일 경우 화면 퍼블
- 이미 있는 계정일 경우 화면 퍼블
- 인증 timer hook 생성(useVerificationTimer)


## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->

https://github.com/user-attachments/assets/e9e258b3-4c49-4e65-a0d1-ca8e78595862




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 계정 연동 및 인증 관련 신규 페이지 추가: 인증 메소드별 계정 연동, 삭제된 계정 연동 안내, 이메일 인증 플로우 지원.
  * 계정 연동 플로우에서 타이머 기반 이메일 인증 기능 도입.
  * 헤더에 중앙 정렬 섹션 추가 및 계정 연동 경로에 맞는 헤더 레이아웃 적용.

* **기능 개선**
  * 로그인 페이지에서 카카오 및 구글 버튼을 클릭 시 계정 연동 관련 경로로 이동하도록 변경.
  * 입력 필드의 suffix 스타일을 굵은 글씨로 개선.

* **UI 개선**
  * 계정 연동 및 인증 관련 버튼, 안내 메시지, 타이머 등 UI 구성 및 스타일 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->