### PR TITLE
fix(knockdog): container 높이 계산을 JS → CSS(calc) 방식으로 변경하여 렌더 타이밍 문제 해결

### DIFF
--- a/apps/knockdog/app/(home)/ui/MapBottomSheet.tsx
+++ b/apps/knockdog/app/(home)/ui/MapBottomSheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import Link from 'next/link';
 import { RemoveScroll } from 'react-remove-scroll';
 import { BottomSheet, Icon } from '@knockdog/ui';
@@ -8,23 +8,18 @@ import { cn } from '@knockdog/ui/lib';
 import { DogSchoolList } from '@features/dog-school';
 
 import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
-import {
-  getViewportSize,
-  useBottomSheetSnapIndex,
-  useIsomorphicLayoutEffect,
-} from '@shared/lib';
+import { useBottomSheetSnapIndex } from '@shared/lib';
 
 // 최소 스냅포인트: 149px(바텀시트 최소 높이) + 68px(바텀바 높이) + 1px(보더)
-// 최대 스냅포인트: 화면높이 - 48px(검색바 높이) + 8px(여백)
+// 최대 스냅포인트: 화면높이 - 64px(검색바 높이) - 8px(여백)
 const MIN_SNAP_POINT = BOTTOM_BAR_HEIGHT + 149;
-const MAX_SNAP_POINT = getViewportSize().height - 64 + 8;
+const MAX_SNAP_POINT_OFFSET = 64 - 8;
 
 export default function MapBottomSheet() {
   const snapPoints = [`${MIN_SNAP_POINT}px`, 0.5, 1];
   const { snapIndex, setSnapIndex, isFullExtended } = useBottomSheetSnapIndex();
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const [container, setContainer] = useState<HTMLElement | null>(null);
 
   const activeSnapPoint = snapPoints[snapIndex] ?? snapPoints[0];
 
@@ -34,12 +29,6 @@ export default function MapBottomSheet() {
       setSnapIndex(index as 0 | 1 | 2);
     }
   };
-
-  useIsomorphicLayoutEffect(() => {
-    if (containerRef.current) {
-      setContainer(containerRef.current);
-    }
-  }, []);
 
   return (
     <>
@@ -88,7 +77,7 @@ export default function MapBottomSheet() {
         ref={containerRef}
         className='pointer-events-none absolute bottom-0 w-full'
         style={{
-          height: `${MAX_SNAP_POINT}px`,
+          height: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)`,
         }}
       >
         <BottomSheet.Root
@@ -98,7 +87,7 @@ export default function MapBottomSheet() {
           snapPoints={snapPoints}
           activeSnapPoint={activeSnapPoint}
           setActiveSnapPoint={handleSnapChange}
-          container={container}
+          container={containerRef.current}
         >
           <RemoveScroll forwardProps>
             <BottomSheet.Content


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

> 바텀시트의 높이는 뷰포트 사이즈(window.innerHeight)를 기준으로 계산되도록 되어 있으나,
뷰포트가 변경되었을 때 해당 높이가 정상적으로 재계산되지 않는 문제를 해결합니다.
https://jira-knockdog.atlassian.net/browse/KDDEV-102?atlOrigin=eyJpIjoiNGM0YTAzZmU4MTM5NGZkODhlNGU2YmVkMDEyOTRlOWMiLCJwIjoiaiJ9

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- container height를 calc(100vh - ${offset}px) 형태로 직접 스타일에 명시하여 브라우저가 계산하도록 변경
- 기존에 useViewportSize 훅과 useMemo를 조합하여 JS로 계산하던 height 방식을 제거
→  React render phase와 DOM commit 사이의 시점 차이에서 발생하던 타이밍 이슈 해결

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

vaul 라이브러리의 내부 오프셋 계산 방식과 리액트 렌더링 사이클에 대한 이해가 필요했던 이슈였음 😅
트러블 슈팅 정리 → [React 렌더 타이밍에 따른 DOM 참조 이슈 해결](https://jira-knockdog.atlassian.net/browse/KDDEV-102?focusedCommentId=10204)

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->

| 기존 | 해결 후 |
|------|---|
|  <video src="https://github.com/user-attachments/assets/13dfbbe1-e448-4be5-b624-701b430a91f0" /> | <video src="https://github.com/user-attachments/assets/471c4155-3dd0-486f-945c-1cd2faf58b66" />  |







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 바텀시트 컨테이너의 높이 계산 방식이 단순화되었습니다.
  * 내부 코드가 정리되어 불필요한 동작 및 사용하지 않는 코드가 제거되었습니다.  
  * 사용자에게 보이는 기능이나 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->