### PR TITLE
ci: vercel deploy workflow 추가 (production/staging/preview)

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,35 @@
+name: 'Deploy Preview'
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute diff
+        uses: dorny/paths-filter@v3
+        id: compute_diff
+        with:
+          filters: |
+            app:
+              - 'apps/knockdog/**'
+              - 'packages/**'
+
+      - name: Deploy to Vercel (Preview)
+        if: steps.compute_diff.outputs.app == 'true'
+        uses: mountainash/deploy-to-vercel-action@v2.5.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          PRODUCTION: false
+          GITHUB_DEPLOYMENT_ENV: Preview

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,22 @@
+name: 'Deploy Production'
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel (Production)
+        uses: mountainash/deploy-to-vercel-action@v2.5.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          PRODUCTION: true
+          GITHUB_DEPLOYMENT_ENV: Production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,49 @@
+name: Deploy Staging
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel (Staging)
+        id: vercel-deploy
+        uses: mountainash/deploy-to-vercel-action@v2.5.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          PRODUCTION: false
+          GITHUB_DEPLOYMENT_ENV: Staging
+
+      - name: Create Comment
+        if: ${{ steps.vercel-deploy.outputs.DEPLOYMENT_CREATED }}
+        uses: phulsechinmay/rewritable-pr-comment@v0.3.0
+        with:
+          message: |
+            ✅ **Staging Preview has been deployed to Vercel.**
+
+            <table>
+              <tr>
+                <th>👀 Preview</th>
+                <td><a href='${{ steps.vercel-deploy.outputs.PREVIEW_URL }}'>${{ steps.vercel-deploy.outputs.PREVIEW_URL }}</a></td>
+              </tr>
+              <tr>
+                <th>🔍 Inspector</th>
+                <td><a href='${{ steps.vercel-deploy.outputs.DEPLOYMENT_INSPECTOR_URL }}'>${{ steps.vercel-deploy.outputs.DEPLOYMENT_INSPECTOR_URL }}</a></td>
+              </tr>
+            </table>
+
+            [View Workflow Logs](${ LOG_URL })
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_IDENTIFIER: vercel-deploy-${{ github.event.number }}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

GitHub Actions기반의 CI 배포 워크플로우를 도입합니다.
각 브랜치 이벤트에 따라 Vercel에 Preview / Staging / Production 배포가 자동으로 이루어지도록 구성합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### 브랜치 전략
브랜치명 | 용도
-- | --
main | 실제 운영 배포 (Production)
develop | 기능 통합 (Development, Staging)
feature/* | 기능 개발 단위 브랜치


#### 배포 전략
이벤트 | 환경 | 설명
-- | -- | --
feature → develop PR 생성 및 커밋 추가 | Preview | 기능 단위 프리뷰 생성용 (자동 배포)
develop → main PR 생성 및 커밋 추가 | Preview(Staging) | 운영 반영 전 사전체크용 배포
main에 직접 push 또는 PR 병합 | Production | 운영 도메인으로 실제 서비스 배포

- `paths-filter`를 사용해 변경된 코드가 실제 앱에 영향을 줄 때만 배포가 발생하도록 구성
- 환경에 따라 `GITHUB_DEPLOYMENT_ENV` 값을 Preview / Staging / Production으로 구분

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

**vercel 프로젝트는 petcampus.knockdog@gmail.com 계정으로 확인하심 됩니다**
https://vercel.com/petcampus-projects

지금은 pr시에 프리뷰 생성되는거까지만 필요하긴한데,, 배포전략 고민해볼 겸 연습겸 운영 배포까지 고려해봣습니당 ^.^
