### PR TITLE
ci: CI workflow에서 Dependabot인 경우 무시하도록 수정

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,8 +2,9 @@ repo:
   - all:
       - changed-files:
           - any-glob-to-any-file: ['**']
-          - all-globs-to-all-files: '!apps/**'
-          - all-globs-to-all-files: '!packages/**'
+          - all-globs-to-all-files:
+              - '!apps/**'
+              - '!packages/**'
 
 'app:web':
   - changed-files:
@@ -15,8 +16,9 @@ repo:
 
 'packages:config':
   - changed-files:
-      - any-glob-to-any-file: ['packages/config-eslint/**']
-      - any-glob-to-any-file: ['packages/config-typescript/**']
+      - any-glob-to-any-file:
+          - 'packages/config-eslint/**'
+          - 'packages/config-typescript/**'
 
 'packages:ui':
   - changed-files:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+
+    # Dependabot 봇인 경우 Preview 배포 스킵
+    if: github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: read
       deployments: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   labeler:
+    if: github.event.pull_request.base.ref != 'main'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

Dependabot PR은 라벨링과 Preview 배포 작업이 수행되지 않도록 수정하는 작업입니다.
> https://jira-knockdog.atlassian.net/browse/KDDEV-108?atlOrigin=eyJpIjoiY2NiZTJmYjFiMzk0NGE5ZDk0YzJjYmY3Mzg3OTgwY2UiLCJwIjoiaiJ9

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- [dependabot 봇인 경우 Preview 배포 스킵](https://github.com/PetCampus-Inc/daeng_v2_front/commit/9a186c6140eeff07e6d6a85e93659d9bf60dc040)
- [main 으로 병합하는 PR인 경우 라벨링 스킵](https://github.com/PetCampus-Inc/daeng_v2_front/commit/b3e02a0e0e18c9a41467ee1e3f0959a22fdf0174)


