### PR TITLE
refactor: Marker anchor를 CSS로 위치 설정

### DIFF
--- a/packages/react-naver-map/src/hooks/useNaverEvent.ts
+++ b/packages/react-naver-map/src/hooks/useNaverEvent.ts
@@ -47,10 +47,10 @@ export const useNaverEvent = <T extends object>(
   useIsomorphicLayoutEffect(() => {
     if (!target || !callback) return;
 
-    const listener = naver.maps.Event.addListener(target, type, callback);
+    const listener = naver.maps?.Event.addListener(target, type, callback);
 
     return () => {
-      naver.maps.Event.removeListener(listener);
+      naver.maps?.Event.removeListener(listener);
     };
   }, [target, type, callback]);
 };

--- a/packages/react-naver-map/src/utils/getMarkerAnchorTransform.ts
+++ b/packages/react-naver-map/src/utils/getMarkerAnchorTransform.ts
@@ -1,0 +1,55 @@
+export type MarkerAnchor =
+  | 'center'
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'left-center'
+  | 'left-top'
+  | 'left-bottom'
+  | 'right-top'
+  | 'right-center'
+  | 'right-bottom'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+export function getTranslatePercentByPosition(pos: MarkerAnchor | undefined): { xPercent: number; yPercent: number } {
+  const p: MarkerAnchor = pos ?? 'bottom-center';
+  switch (p) {
+    case 'center':
+      return { xPercent: -50, yPercent: -50 };
+    case 'top-left':
+      return { xPercent: 0, yPercent: 0 };
+    case 'top-center':
+      return { xPercent: -50, yPercent: 0 };
+    case 'top-right':
+      return { xPercent: -100, yPercent: 0 };
+    case 'left-center':
+      return { xPercent: 0, yPercent: -50 };
+    case 'left-top':
+      return { xPercent: 0, yPercent: 0 };
+    case 'left-bottom':
+      return { xPercent: 0, yPercent: -100 };
+    case 'right-top':
+      return { xPercent: -100, yPercent: 0 };
+    case 'right-center':
+      return { xPercent: -100, yPercent: -50 };
+    case 'right-bottom':
+      return { xPercent: -100, yPercent: -100 };
+    case 'bottom-left':
+      return { xPercent: 0, yPercent: -100 };
+    case 'bottom-center':
+      return { xPercent: -50, yPercent: -100 };
+    case 'bottom-right':
+      return { xPercent: -100, yPercent: -100 };
+    default:
+      return { xPercent: -50, yPercent: -100 };
+  }
+}
+
+export function getMarkerAnchorTransform(align: MarkerAnchor | undefined, offsetX: number, offsetY: number): string {
+  const { xPercent, yPercent } = getTranslatePercentByPosition(align);
+  const x = `calc(${xPercent}% + ${offsetX}px)`;
+  const y = `calc(${yPercent}% + ${offsetY}px)`;
+  return `translate3d(${x}, ${y}, 0)`;
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

> https://jira-knockdog.atlassian.net/browse/KDDEV-140?atlOrigin=eyJpIjoiMWNjMzdkNGI1ZWE5NGFmMTgxMWJmOWU0NWQ1NDZlY2IiLCJwIjoiaiJ9

Marker 아이콘 정렬을 Naver Position+size 기반 대신, CSS 기준점으로 전환합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- HtmlIcon은 내부 앵커(`TOP_LEFT`) 고정, 콘텐츠 래퍼에 transform로 정렬
- `customIcon.align`, `customIcon.offsetX/Y` 추가
- `customIcon` 기본값: align='bottom-center'
- 기존 size/anchor 의존 제거

###  Mirgration
- 변경 전: `customIcon.size`, `customIcon.anchor(=Position|Point)`
- 변경 후: `customIcon.align`, `customIcon.offsetX/Y`
  - size 설정 불필요, anchor 픽셀 좌표 불필요
  - 기존 customIcon.anchor: Position 사용처는 align으로 교체
  - 기존 오프셋은 동일 의미로 offsetX/offsetY에 매핑
