### PR TITLE
[Feat/Native-bridge-package] 네이티브 브릿지 프로토콜 패키징 작업

### DIFF
--- a/packages/bridge-core/package.json
+++ b/packages/bridge-core/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@knockdog/bridge-core",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Core types and utilities for bridge communication",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "bunchee src/index.ts --format cjs,esm --dts --out-dir dist",
+    "dev": "bunchee src/index.ts --watch --format cjs,esm --dts --out-dir dist"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "devDependencies": {
+    "@knockdog/typescript-config": "workspace:*",
+    "bunchee": "^5.1.5"
+  }
+}

--- a/packages/bridge-core/src/event-types.ts
+++ b/packages/bridge-core/src/event-types.ts
@@ -1,0 +1,6 @@
+interface BridgeEventMap {
+  'bridge.ready': { nativeVersion: string; methods: string[] };
+  'device.getLatLng': { lat: number; lng: number };
+}
+
+export type { BridgeEventMap };

--- a/packages/bridge-core/src/global.d.ts
+++ b/packages/bridge-core/src/global.d.ts
@@ -1,0 +1,13 @@
+import type { BridgeMessage } from './types';
+
+declare global {
+  interface Window {
+    __bridge: {
+      receive: (msg: BridgeMessage) => void;
+    };
+    ReactNativeWebView?: {
+      postMessage: (message: string) => void;
+    };
+    __bridgeDebug: boolean;
+  }
+}

--- a/packages/bridge-core/src/index.ts
+++ b/packages/bridge-core/src/index.ts
@@ -1,0 +1,4 @@
+export { BRIDGE_VERSION, safeParse, makeId } from './utils';
+export type { BridgeMessage, BridgeRequest, BridgeOk, BridgeError, BridgeEvent } from './types';
+export type { BridgeEventMap } from './event-types';
+export { METHODS } from './methods';

--- a/packages/bridge-core/src/methods.ts
+++ b/packages/bridge-core/src/methods.ts
@@ -1,0 +1,7 @@
+const METHODS = {
+  getLatLng: 'device.getLatLng',
+} as const;
+
+export type MethodName = (typeof METHODS)[keyof typeof METHODS];
+
+export { METHODS };

--- a/packages/bridge-core/src/rpc-schema.ts
+++ b/packages/bridge-core/src/rpc-schema.ts
@@ -1,0 +1,19 @@
+import { METHODS } from './methods';
+
+interface RPCSchema {
+  [METHODS.getLatLng]: {
+    params: {
+      accuracy?: 'balanced' | 'high' | undefined;
+    };
+    result: {
+      lat: number;
+      lng: number;
+    };
+  };
+}
+
+type RPCMethod = keyof RPCSchema;
+type ParamsOf<K extends RPCMethod> = RPCSchema[K]['params'];
+type ResultOf<K extends RPCMethod> = RPCSchema[K]['result'];
+
+export type { RPCSchema, RPCMethod, ParamsOf, ResultOf };

--- a/packages/bridge-core/src/types.ts
+++ b/packages/bridge-core/src/types.ts
@@ -1,0 +1,35 @@
+type BridgeRequest = {
+  id: string;
+  type: 'request';
+  method: string; // e.g. "device.getGeolocation"
+  params?: unknown;
+  meta: { v: string; source: 'web' | 'native'; ts: number };
+};
+
+type BridgeOk = {
+  id: string;
+  type: 'response';
+  ok: true;
+  result: unknown;
+  meta: { v: string; source: 'web' | 'native'; ts: number };
+};
+
+type BridgeError = {
+  id: string;
+  type: 'response';
+  ok: false;
+  error: { code: string; message: string; details?: string };
+  meta: { v: string; source: 'web' | 'native'; ts: number };
+};
+
+type BridgeEvent = {
+  id: string;
+  type: 'event';
+  event: string;
+  payload?: unknown;
+  meta: { v: string; source: 'web' | 'native'; ts: number };
+};
+
+type BridgeMessage = BridgeRequest | BridgeOk | BridgeError | BridgeEvent;
+
+export type { BridgeRequest, BridgeOk, BridgeError, BridgeEvent, BridgeMessage };

--- a/packages/bridge-core/src/utils.ts
+++ b/packages/bridge-core/src/utils.ts
@@ -1,0 +1,13 @@
+function safeParse(s: string) {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return null;
+  }
+}
+
+const makeId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const BRIDGE_VERSION = '1.0.0';
+
+export { safeParse, makeId, BRIDGE_VERSION };

--- a/packages/bridge-core/tsconfig.json
+++ b/packages/bridge-core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@knockdog/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/bridge-native/package.json
+++ b/packages/bridge-native/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@knockdog/bridge-native",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Native bridge for React Native WebView communication",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "bunchee src/index.ts --format cjs,esm --dts --out-dir dist --external react-native-webview",
+    "dev": "bunchee src/index.ts --watch --format cjs,esm --dts --out-dir dist --external react-native-webview"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "dependencies": {
+    "@knockdog/bridge-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@knockdog/typescript-config": "workspace:*",
+    "bunchee": "^5.1.5"
+  },
+  "peerDependencies": {
+    "react-native-webview": "*"
+  }
+}

--- a/packages/bridge-native/src/index.ts
+++ b/packages/bridge-native/src/index.ts
@@ -1,0 +1,117 @@
+import type { RefObject } from 'react';
+import type { WebView, WebViewMessageEvent } from 'react-native-webview';
+import { BRIDGE_VERSION, safeParse, type BridgeRequest, type BridgeMessage } from '@knockdog/bridge-core';
+
+/** 네이티브에서 실행될 핸들러 타입 (요청 -> 응답) */
+type NativeHandler = (params: unknown) => unknown | Promise<unknown>;
+
+/** 메서드 라우터: method이름에 따라 핸들러를 찾아 실행 */
+class NativeBridgeRouter {
+  private handlers = new Map<string, (params: unknown) => unknown | Promise<unknown>>();
+
+  /** 메서드 등록 ex. device.getGeolocation */
+  register<P = unknown, R = unknown>(method: string, handler: (params: P) => R | Promise<R>) {
+    const wrapped = (params: unknown) => handler(params as P);
+    this.handlers.set(method, wrapped);
+  }
+
+  /** 메서드 제거 ex. device.getGeolocation */
+  unregister(method: string) {
+    this.handlers.delete(method);
+  }
+
+  /** 매소두 존재 여부 */
+  has(method: string) {
+    return this.handlers.has(method);
+  }
+
+  /** 요청 실행 */
+  async handle(req: BridgeRequest) {
+    const h = this.handlers.get(req.method);
+    if (!h) {
+      const error = { code: 'ENOENT', message: `No handler for ${req.method}` };
+      throw error;
+    }
+    return await h(req.params);
+  }
+
+  /** 현재 등록된 메서드 목록 */
+  list() {
+    return [...this.handlers.keys()];
+  }
+}
+
+/** RN -> Web 전송: injectJavaScript로 웹 전역 리시버 호출 */
+function sendToWeb(webRef: RefObject<WebView>, msg: BridgeMessage) {
+  // JSON 안의 </script> 방지 (주로 웹뷰 보안 이슈 회피)
+  const safe = JSON.stringify(msg).replace(/<\/script/gi, '<\\/script');
+  webRef?.current?.injectJavaScript(`window.__bridge?.receive(${safe}); true;`);
+}
+
+/**
+ * 네이티브(WebView 화면)에서 쓸 헬퍼
+ * - onMessage: Web → Native 메시지 수신 핸들러 (WebView prop에 연결)
+ * - sendEvent: Native → Web 이벤트 브로드캐스트
+ * - notifyReady: 브릿지 준비 및 지원 메서드 목록 통지
+ */
+function wireWebView(webRef: RefObject<WebView>, router: NativeBridgeRouter) {
+  /** Web -> Native */
+  const onMessage = async (e: WebViewMessageEvent) => {
+    const raw = e?.nativeEvent?.data;
+    const msg = typeof raw === 'string' ? safeParse(raw) : raw;
+
+    if (!msg || typeof msg !== 'object') return;
+    if (msg.type !== 'request') {
+      return;
+    }
+
+    const req = msg as BridgeRequest;
+
+    // 요청 처리 & 응답 반환
+    try {
+      const result = await router.handle(req);
+      sendToWeb(webRef, {
+        id: req.id,
+        type: 'response',
+        ok: true,
+        result,
+        meta: { v: BRIDGE_VERSION, source: 'native', ts: Date.now() },
+      });
+    } catch (error: unknown) {
+      const { code, message, details } = error as { code: string; message: string; details: string };
+
+      sendToWeb(webRef, {
+        id: req.id,
+        type: 'response',
+        ok: false,
+        error: {
+          code: code ?? 'EUNHANDLED',
+          message: message ?? String(error),
+          details: details,
+        },
+        meta: { v: BRIDGE_VERSION, source: 'native', ts: Date.now() },
+      });
+    }
+  };
+
+  /** Native -> Web (event) */
+  const sendEvent = (event: string, payload?: unknown) => {
+    sendToWeb(webRef, {
+      id: `evt-${Date.now()}`,
+      type: 'event',
+      event,
+      payload,
+      meta: { v: BRIDGE_VERSION, source: 'native', ts: Date.now() },
+    });
+  };
+
+  /** 브릿지 준비 및 지원 메서드 목록 통지 */
+  const notifyReady = () => {
+    sendEvent('bridge.ready', { nativeVersion: BRIDGE_VERSION, methods: router.list() });
+  };
+
+  return { onMessage, sendEvent, notifyReady };
+}
+
+export type { NativeHandler };
+export { NativeBridgeRouter, wireWebView };

--- a/packages/bridge-native/tsconfig.json
+++ b/packages/bridge-native/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@knockdog/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/bridge-web/package.json
+++ b/packages/bridge-web/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@knockdog/bridge-web",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Web bridge for communication with native apps",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "bunchee src/index.ts --format cjs,esm --dts --out-dir dist",
+    "dev": "bunchee src/index.ts --watch --format cjs,esm --dts --out-dir dist"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "dependencies": {
+    "@knockdog/bridge-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@knockdog/typescript-config": "workspace:*",
+    "bunchee": "^5.1.5"
+  }
+}

--- a/packages/bridge-web/src/global.d.ts
+++ b/packages/bridge-web/src/global.d.ts
@@ -1,0 +1,13 @@
+import type { BridgeMessage } from '@knockdog/bridge-core';
+
+declare global {
+  interface Window {
+    __bridge: {
+      receive: (msg: BridgeMessage) => void;
+    };
+    ReactNativeWebView?: {
+      postMessage: (message: string) => void;
+    };
+    __bridgeDebug: boolean;
+  }
+}

--- a/packages/bridge-web/src/index.ts
+++ b/packages/bridge-web/src/index.ts
@@ -1,0 +1,106 @@
+import { BRIDGE_VERSION, safeParse, makeId, type BridgeMessage, type BridgeEventMap } from '@knockdog/bridge-core';
+
+type Unsubscribes = () => void;
+type Listener<K extends keyof BridgeEventMap = keyof BridgeEventMap> = (payload: BridgeEventMap[K]) => void;
+
+class WebBridge {
+  private pending = new Map<
+    string,
+    { resolve: (v: unknown) => void; reject: (e: unknown) => void; timer: ReturnType<typeof setTimeout> }
+  >();
+  private listeners = new Map<string, Set<(payload: unknown) => void>>();
+
+  constructor(private timeoutMs = 8000) {
+    // WebView환경이 아닐때 대비
+    if (typeof window !== 'undefined') {
+      window.addEventListener('message', this._onMessage);
+
+      // 웹 쪽 전역 리시버(네이티브가 injectJS로 호출)
+      if (!window.__bridge) {
+        window.__bridge = { receive: (msg: BridgeMessage) => this._handleIncoming(msg) };
+      } else if (window.__bridgeDebug) {
+        console.warn('[WebBridge] window.__bridge 가 이미 설정되어 있습니다; 리시버 덮어씁니다');
+        window.__bridge.receive = (msg) => this._handleIncoming(msg);
+      }
+    }
+  }
+
+  destroy() {
+    if (typeof window !== 'undefined') {
+      window.removeEventListener('message', this._onMessage);
+    }
+
+    this.pending.forEach((p) => p.reject(new Error('bridge_destroyed')));
+    this.pending.clear();
+    this.listeners.clear();
+  }
+
+  on<K extends keyof BridgeEventMap>(event: K, cb: Listener<K>): Unsubscribes {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+
+    this.listeners.get(event)!.add(cb as (payload: unknown) => void);
+    return () => this.listeners.get(event)?.delete(cb as (payload: unknown) => void);
+  }
+
+  async request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    const id = makeId();
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject({ code: 'ETIMEDOUT', message: `timeout ${method}` });
+      }, this.timeoutMs);
+
+      this.pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject: reject as (e: unknown) => void,
+        timer,
+      });
+
+      // Web -> Native
+      window.ReactNativeWebView?.postMessage(
+        JSON.stringify({
+          id,
+          type: 'request',
+          method,
+          params,
+          meta: { v: BRIDGE_VERSION, source: 'web', ts: Date.now() },
+        } satisfies BridgeMessage)
+      );
+    });
+  }
+
+  // Native -> Web (via window.postMessage)
+  private _onMessage = (e: MessageEvent) => {
+    const data = typeof e.data === 'string' ? safeParse(e.data) : e.data;
+    if (data) this._handleIncoming(data);
+  };
+
+  private _handleIncoming(msg: BridgeMessage) {
+    if (msg.type === 'response') {
+      const entry = this.pending.get(msg.id);
+      if (!entry) return;
+
+      clearTimeout(entry.timer);
+      this.pending.delete(msg.id);
+
+      if ('error' in msg) {
+        entry.reject(msg.error);
+      } else {
+        entry.resolve(msg.result);
+      }
+
+      return;
+    } else if (msg.type === 'event') {
+      this._emit(msg.event as keyof BridgeEventMap, msg.payload as BridgeEventMap[keyof BridgeEventMap]);
+    }
+  }
+
+  private _emit<K extends keyof BridgeEventMap>(event: K, payload: BridgeEventMap[K]) {
+    this.listeners.get(event)?.forEach((cb) => cb(payload));
+  }
+}
+
+export { WebBridge };

--- a/packages/bridge-web/tsconfig.json
+++ b/packages/bridge-web/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@knockdog/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

- @knockdog/bridge-core: 브릿지 통신을 위한 핵심 타입 및 유틸리티 추가
- @knockdog/bridge-native: React Native WebView와의 통신을 위한 네이티브 브릿지 구현
- @knockdog/bridge-web: 네이티브 앱과의 통신을 위한 웹 브릿지 구현
- 각 패키지에 TypeScript 설정 및 빌드 스크립트 추가
- 브릿지 이벤트 및 RPC 스키마 정의
- 메서드 라우터 및 메시지 핸들링 로직 구현
## 작업 내용
설계 내용 notion에 정리해 두었는데, 피드백 부탁드려요 

https://www.notion.so/Knockdog-V2-Native-Bridge-27725d5a54f280b7ab4efc138be25b6c?source=copy_link

## 논의할 점


## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
