### PR TITLE
fix(knockdog): useStackNavigation에서 useSearchParams 제거

### DIFF
--- a/apps/knockdog/src/shared/lib/bridge/useStackNavigation.ts
+++ b/apps/knockdog/src/shared/lib/bridge/useStackNavigation.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useCallback } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useBridge } from './BridgeProvider';
 import { isNativeWebView } from '@shared/lib/device';
 import { METHODS, makeId, BridgeEventMap } from '@knockdog/bridge-core';
@@ -18,16 +18,14 @@ type PushOptions = {
   scroll?: boolean;
 };
 
-function buildHref(pathname: string, query?: Query, searchParams?: URLSearchParams | null) {
-  const params = query ? new URLSearchParams(searchParams || undefined) : new URLSearchParams();
+function buildHref(pathname: string, query?: Query) {
+  const params = new URLSearchParams();
 
   if (query) {
     for (const [key, value] of Object.entries(query)) {
-      if (value === undefined || value === null) {
-        params.delete(key);
-      } else {
-        params.set(key, String(value));
-      }
+      if (value === undefined || value === null) continue;
+
+      params.set(key, String(value));
     }
   }
 
@@ -37,7 +35,6 @@ function buildHref(pathname: string, query?: Query, searchParams?: URLSearchPara
 
 function useStackNavigation() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const bridge = useBridge();
 
   const isNative = useMemo(() => isNativeWebView(), []);
@@ -90,7 +87,7 @@ function useStackNavigation() {
         finalQuery = { ...query, _txId: txId };
       }
 
-      const href = buildHref(pathname, finalQuery, searchParams);
+      const href = buildHref(pathname, finalQuery);
 
       if (replace || method === METHODS.navReplace) {
         router.replace(href, { scroll });
@@ -98,7 +95,7 @@ function useStackNavigation() {
         router.push(href, { scroll });
       }
     },
-    [bridge, router, isNative, searchParams]
+    [bridge, router, isNative]
   );
 
   const push = useCallback(

--- a/apps/knockdog/src/widgets/Header/ui/Header.tsx
+++ b/apps/knockdog/src/widgets/Header/ui/Header.tsx
@@ -27,12 +27,8 @@ export function Header({
     transparent: 'bg-transparent',
   };
 
-  /**
-   *  FIXME: Suspense 사용이유: Header.BackButton 내부에서 useSearchParams를 사용하고 있어, Suspense로 감싸야 함.
-   * Header를 Suspense로 감싸는게 맞는지 논의가 필요함.
-   */
   return (
-    <Suspense>
+    <>
       <header
         className={cn(
           'border-line-100 sticky top-0 z-15 flex h-16 w-full items-center px-4',
@@ -43,9 +39,8 @@ export function Header({
       >
         <div className={cn('flex h-16 w-full items-center')}>{children}</div>
       </header>
-
       {withSpacing && <div className='h-16' />}
-    </Suspense>
+    </>
   );
 }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

`useStackNavigation` 내부에서 사용중인 `useSearchParams`를 제거

## 작업 내용

- `useSearchParams`는 클라이언트 전용 훅으로, SSR과 CSR 값 차이로 인한 hydration error를 유발할 수 있음
- URL query는 options.query 기반으로만 구성하도록 변경
위와 같은 이유로 useSearchParams 제거 

