### PR TITLE
ci: 배포 트리거 브랜치를 develop로 전환

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,7 +2,7 @@ name: 'Deploy Production'
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
 
 jobs:
   deploy-prod:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/KDDEV-242?atlOrigin=eyJpIjoiY2JiMGIyOWY0YmQyNDY3N2IxMDk5YWYyOTA2YWEyMmYiLCJwIjoiaiJ9

빠른 배포를 위해 dev 브랜치에 머지 시에 Prod 배포되도록 변경했습니다.
