### PR TITLE
refactor: 비교하기 페이지 개선 및 버그 수정

### DIFF
--- a/apps/knockdog/app/compare-complete/page.tsx
+++ b/apps/knockdog/app/compare-complete/page.tsx
@@ -20,7 +20,7 @@ import {
   DogServiceSection,
 } from '@features/compare';
 import type { KindergartenComparison } from '@entities/compare';
-import { CircleAvatar, serializeCategories, resolveIds, s3ToUrl } from '@entities/compare';
+import { SelectedCell, serializeCategories, resolveIds, s3ToUrl } from '@entities/compare';
 import { SafeArea } from '@shared/ui/safe-area';
 
 // FIXME: 페이지 단에서 useSearchParams를 사용하고 있어서 임시로 Suspense로 감싸서 처리 했습니다. 확인 후 수정 필요합니다
@@ -33,32 +33,6 @@ export default function Page() {
     </SafeArea>
   );
 }
-/* =========================
- * SMALL PARTS
- * ========================= */
-
-function SelectedCell({
-  name,
-  type,
-  avatar,
-  className,
-}: {
-  name: string;
-  type: string;
-  avatar?: string;
-  className?: string;
-}) {
-  return (
-    <div className={`flex min-w-0 items-center gap-2 px-4 py-5 ${className}`}>
-      <CircleAvatar size={40} src={avatar} alt={name} />
-      <div className='flex min-w-0 flex-col gap-0.5 leading-none'>
-        <p className='h3-extrabold truncate'>{name}</p>
-        <p className='text-text-tertiary body2-semibold truncate'>{type}</p>
-      </div>
-    </div>
-  );
-}
-
 /* =========================
  * SUMMARY PARTS
  * ========================= */

--- a/apps/knockdog/app/compare-complete/page.tsx
+++ b/apps/knockdog/app/compare-complete/page.tsx
@@ -88,7 +88,7 @@ function CompareCompletePage() {
   const operatingSlideData = createOperatingScheduleSlide(left, right);
 
   return (
-    <div className='flex h-screen flex-col bg-white'>
+    <div className='flex h-screen flex-col bg-white pb-16'>
       <Header>
         <Header.LeftSection>
           <Header.BackButton />

--- a/apps/knockdog/src/entities/compare/index.ts
+++ b/apps/knockdog/src/entities/compare/index.ts
@@ -40,3 +40,4 @@ export { CircleAvatar } from './ui/CircleAvatar';
 export { StackedCircleAvatars } from './ui/StackedCircleAvatars';
 export { Label } from './ui/Label';
 export { Badge } from './ui/Badge';
+export { SelectedCell } from './ui/SelectedCell';

--- a/apps/knockdog/src/entities/compare/ui/CircleAvatar.tsx
+++ b/apps/knockdog/src/entities/compare/ui/CircleAvatar.tsx
@@ -14,9 +14,9 @@ export function CircleAvatar({
 }) {
   return (
     <Avatar style={{ width: size, height: size }} className={className}>
-      <AvatarImage src={src} alt={alt} />
+      <AvatarImage src={src} alt={alt} className='object-cover' />
       <AvatarFallback>
-        <Image src='/images/img_default_image.png' alt='default' width={size} height={size} />
+        <Image src='/images/img_default_image.png' alt='default' width={size} height={size} className='object-cover' />
       </AvatarFallback>
     </Avatar>
   );

--- a/apps/knockdog/src/entities/compare/ui/Label.tsx
+++ b/apps/knockdog/src/entities/compare/ui/Label.tsx
@@ -1,16 +1,16 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from '@knockdog/ui';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 
 export function Label({
   children,
   tooltip,
   className = '',
-}: PropsWithChildren<{ tooltip?: string; className?: string }>) {
+}: PropsWithChildren<{ tooltip?: ReactNode; className?: string }>) {
   return (
     <div className={`text-text-primary body2-semibold mx-auto flex w-fit items-center gap-1 ${className}`}>
       {children}
       {tooltip && (
-        <Tooltip className='flex items-center'>
+        <Tooltip className='flex items-center' placement='top-left'>
           <TooltipTrigger />
           <TooltipContent>{tooltip}</TooltipContent>
         </Tooltip>

--- a/apps/knockdog/src/entities/compare/ui/SelectedCell.tsx
+++ b/apps/knockdog/src/entities/compare/ui/SelectedCell.tsx
@@ -1,0 +1,20 @@
+import { CircleAvatar } from './CircleAvatar';
+
+interface SelectedCellProps {
+  name: string;
+  type: string;
+  avatar?: string;
+  className?: string;
+}
+
+export function SelectedCell({ name, type, avatar, className }: SelectedCellProps) {
+  return (
+    <div className={`flex min-w-0 items-center gap-2 px-4 py-5 ${className}`}>
+      <CircleAvatar size={40} src={avatar} alt={name} />
+      <div className='flex min-w-0 flex-col gap-0.5 leading-none'>
+        <p className='h3-extrabold truncate'>{name}</p>
+        <p className='text-text-tertiary body2-semibold truncate'>{type}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/knockdog/src/features/compare/lib/getValetKindergartens.ts
+++ b/apps/knockdog/src/features/compare/lib/getValetKindergartens.ts
@@ -9,11 +9,11 @@ export function getValetKindergartens(
 
   const valetProviders: SimpleComparisonItem[] = [];
 
-  if (left?.service?.includes('VALET')) {
+  if (left?.service?.includes('PICKDROP')) {
     valetProviders.push(mapToSimpleItem(left));
   }
 
-  if (right?.service?.includes('VALET')) {
+  if (right?.service?.includes('PICKDROP')) {
     valetProviders.push(mapToSimpleItem(right));
   }
 

--- a/apps/knockdog/src/features/compare/ui/PricingSection.tsx
+++ b/apps/knockdog/src/features/compare/ui/PricingSection.tsx
@@ -5,10 +5,16 @@ import type { KindergartenComparison } from '@entities/compare';
 import { Label, Badge, CircleAvatar, Description, s3ToUrl } from '@entities/compare';
 
 function PricingLabel({ className = '' }: { className?: string }) {
-  const tooltipText =
-    '여기서 보여드리는 금액은 두 곳의 이용료를 ‘1시간 기준’으로 맞춰 비교한 값이에요. 요금제가 달라도 시간을 기준으로 동일하게 환산해 얼마나 차이가 나는지 쉽게 볼 수 있게 정리했어요. 실제 비용은 요일이나 이용 방식에 따라 조금 달라질 수 있으므로, 정확한 비용은 업체로 문의해주세요.';
+  const tooltip = (
+    <div>
+      <p>여기서 보여드리는 금액은 두 곳의 이용료를 ‘1시간 기준’으로 맞춰 비교한 값이에요.</p>
+      <p>요금제가 달라도 시간을 기준으로 동일하게 환산해 얼마나 차이가 나는지 쉽게 볼 수 있게 정리했어요.</p>
+      <p>실제 비용은 요일이나 이용 방식에 따라 조금 달라질 수 있으므로, 정확한 비용은 업체로 문의해주세요.</p>
+    </div>
+  );
+
   return (
-    <Label tooltip={tooltipText} className={className}>
+    <Label tooltip={tooltip} className={className}>
       이용 요금
     </Label>
   );


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 리팩토링
  - 페이지 컴포넌트에서 SelectedCell을 `entities/compare`로 분리
  - 이용요금 툴팁 개선

- 버그 수정
  - `VALET` → `PICKDROP`로 픽드랍 서비스 키 수정
  - CircleAvatar에 `object-cover` 클래스 추가하여 이미지 비율 깨짐 방지
  - 페이지 하단 여백 추가