### PR TITLE
fix(knockdog): 로그아웃 간헐적으로 안되는 이슈 수정

### DIFF
--- a/apps/knockdog/src/views/mypage-profile-manage-page/ui/MypageProfileManagePage.tsx
+++ b/apps/knockdog/src/views/mypage-profile-manage-page/ui/MypageProfileManagePage.tsx
@@ -65,7 +65,7 @@ function MypageProfileManagePage() {
             <AlertDialogCancel>취소</AlertDialogCancel>
             <AlertDialogAction
               onClick={async () => {
-                logout();
+                await logout();
                 reset();
               }}
             >

--- a/apps/knockdog/src/views/withdraw-survey-page/ui/WithdrawSurveyPage.tsx
+++ b/apps/knockdog/src/views/withdraw-survey-page/ui/WithdrawSurveyPage.tsx
@@ -7,7 +7,6 @@ import { ActionButton, RadioGroup, RadioGroupItem, Textarea, TextareaInput } fro
 import { useStackNavigation } from '@shared/lib/bridge';
 import { WITHDRAW_REASON_TYPE, type WithdrawReasonType, type WithdrawRequest } from '@entities/user';
 import { withdraw } from '@shared/lib/auth';
-import { route } from '@shared/constants/route';
 
 const REASON_TYPE_PARSER = createParser<WithdrawReasonType>({
   parse: (value: string) => {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

- 로그 아웃이 간헐적으로 안되는 이슈 수정
 -> 로그아웃 처리 전에 stack reset이 실행되어버려서 안되는 경우 발생 -> await 추가해줌 

