### PR TITLE
fix(knockdog): useBreedQuery에서 API 응답 처리 개선 및 usePetProfileForm에서 웹뷰 …

### DIFF
--- a/apps/knockdog/src/features/dog-profile/model/useBreedQuery.ts
+++ b/apps/knockdog/src/features/dog-profile/model/useBreedQuery.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { Breed } from './breed.type';
 import { api } from '@shared/api';
-import { ApiResponse } from '@shared/api/model/response';
 
 export const useBreedQuery = () => {
   return useQuery<Breed[]>({
@@ -9,8 +8,8 @@ export const useBreedQuery = () => {
     staleTime: 1000 * 60 * 60 * 24, // 24시간
     gcTime: 1000 * 60 * 60 * 24, // 24시간
     queryFn: async () => {
-      const res = await api.get('breed').json<ApiResponse<Breed[]>>();
-      return res.data;
+      const res = await api.get('breed').json<Breed[]>();
+      return res ?? [];
     },
   });
 };

--- a/apps/knockdog/src/features/dog-profile/model/usePetProfileForm.ts
+++ b/apps/knockdog/src/features/dog-profile/model/usePetProfileForm.ts
@@ -4,6 +4,7 @@ import { useMoveImageMutation } from '@shared/lib/media';
 import { useUserStore } from '@entities/user';
 import type { Breed } from './breed.type';
 import type { Pet } from '@entities/pet';
+import { syncWebViewQuery } from '@shared/lib/sync-webview-query';
 
 interface PetFormData {
   name: string;
@@ -119,6 +120,8 @@ export function usePetProfileForm({ mode, petId, defaultValues, onSuccess, onErr
           weight: data.weight,
         });
       }
+
+      syncWebViewQuery.refetch(['petList']);
 
       onSuccess?.();
     } catch (error) {

--- a/apps/knockdog/src/features/dog-profile/ui/DogCard.tsx
+++ b/apps/knockdog/src/features/dog-profile/ui/DogCard.tsx
@@ -12,6 +12,8 @@ interface DogCardProps {
 }
 
 function DogCard({ name, breed, age, imageUrl, isRepresentative, onClick }: DogCardProps) {
+  const details = [breed, age ? `${age}살` : undefined].filter(Boolean);
+
   return (
     <div
       onClick={onClick}
@@ -28,8 +30,12 @@ function DogCard({ name, breed, age, imageUrl, isRepresentative, onClick }: DogC
           <span className='text-text-primary-inverse'>{name}</span>
         </div>
         <div className='body2-regular text-text-primary-inverse flex max-w-[118px] items-center gap-x-1'>
-          {breed && <span className='truncate'>{breed} • </span>}
-          {age && <span className='shrink-0'>{age}살</span>}
+          {details.map((detail, index) => (
+            <span className='truncate' key={index}>
+              {detail}
+              {index < details.length - 1 && ' • '}
+            </span>
+          ))}
         </div>
       </div>
     </div>


### PR DESCRIPTION
- useBreedQuery에서 API 응답을 ApiResponse에서 직접 Breed[]로 변경하고, null 또는 undefined일 경우 빈 배열 반환하도록 수정.
- usePetProfileForm에서 petList를 동기화하기 위해 syncWebViewQuery.refetch 호출 추가.
- DogCard에서 breed와 age 정보를 동적으로 표시하도록 개선.

