### PR TITLE
feat: 비교하기 페이지 북마크 목록 UI 개선

### DIFF
--- a/apps/knockdog/app/compare/page.tsx
+++ b/apps/knockdog/app/compare/page.tsx
@@ -5,10 +5,10 @@ import { useRouter } from 'next/navigation';
 import Layout from '../(main)/layout';
 import { IconButton } from '@knockdog/ui';
 import { Header } from '@widgets/Header';
-import { useBookmarksQuery } from '@features/bookmarked-list';
+import { useBookmarksQuery, CompareListItem } from '@features/bookmarked-list';
 import type { CTag, ReferencePointType } from '@entities/compare';
-import { serializeCategories, REFERENCE_POINT_TYPE } from '@entities/compare';
-import type { BookmarkItem, DistanceInfo } from '@entities/bookmark';
+import { serializeCategories } from '@entities/compare';
+import type { DistanceInfo } from '@entities/bookmark';
 import { SafeArea } from '@shared/ui/safe-area';
 
 // Helper: refPoint에 맞는 거리 정보 찾기
@@ -19,7 +19,10 @@ function findDistanceByRefPoint(distances: DistanceInfo[], refPoint: ReferencePo
 // Helper: 거리를 숫자(km)로 파싱
 function parseDistanceToKm(distance: string): number {
   const match = distance.match(/[\d.]+/);
-  return match ? parseFloat(match[0]) : 0;
+  if (!match) {
+    return Infinity;
+  }
+  return Number.parseFloat(match[0]);
 }
 
 /* =========================
@@ -98,7 +101,7 @@ export default function ComparePage() {
   /* =========================
    * 유치원 선택 토글 (최대 2개 유지)
    * ========================= */
-  const toggle = (id: string) => {
+  const toggleCheckbox = (id: string) => {
     setSelectedIds((prev) => {
       // 1. 이미 선택된 유치원일 경우: 해당 슬롯을 비움
       if (prev.left === id) {
@@ -188,17 +191,16 @@ export default function ComparePage() {
 
             {/* List */}
             <div className='flex-1 overflow-y-auto'>
-              {sortedBookmarks.map((c) => {
-                const distInfo = findDistanceByRefPoint(c.distances, refPoint);
-                const distanceText = distInfo?.distance || '-';
+              {sortedBookmarks.map((kindergarten) => {
+                const distInfo = findDistanceByRefPoint(kindergarten.distances, refPoint);
+                const distanceText = distInfo?.distance || '- km';
                 return (
-                  <CompareItem
-                    key={c.id}
-                    center={c}
-                    isSelected={selectedIds.left === c.id || selectedIds.right === c.id}
+                  <CompareListItem
+                    key={kindergarten.id}
+                    kindergarten={kindergarten}
                     distanceText={distanceText}
-                    refPointLabel={REFERENCE_POINT_TYPE[refPoint]}
-                    onToggle={() => toggle(c.id)}
+                    isSelected={selectedIds.left === kindergarten.id || selectedIds.right === kindergarten.id}
+                    onToggle={() => toggleCheckbox(kindergarten.id)}
                   />
                 );
               })}
@@ -263,74 +265,5 @@ export default function ComparePage() {
         </Suspense>
       </SafeArea>
     </Layout>
-  );
-}
-
-/* =========================
- * 유치원 아이템
- * ========================= */
-function CompareItem({
-  center,
-  isSelected,
-  onToggle,
-  distanceText,
-  refPointLabel,
-}: {
-  center: BookmarkItem;
-  isSelected: boolean;
-  onToggle: () => void;
-  distanceText: string;
-  refPointLabel: string;
-}) {
-  const categoryText = serializeCategories(center.categories as CTag[]);
-
-  return (
-    <div className='flex items-start gap-3 border-b border-[#F3F3F7] bg-white px-3 py-3'>
-      <input type='checkbox' checked={isSelected} onChange={onToggle} className='mt-2 accent-yellow-400' />
-      <div className='grid flex-1 grid-cols-[80px_1fr] gap-3'>
-        <div className='h-20 w-20 rounded-lg bg-pink-200' />
-        <div className='min-w-0'>
-          <div className='flex items-start justify-between gap-2'>
-            <h3 className='truncate text-base leading-tight font-bold'>{center.name}</h3>
-            <button aria-label='북마크' className='shrink-0 rounded-md p-1 text-gray-600 hover:bg-gray-100'>
-              <svg className='h-5 w-5' viewBox='0 0 24 24' fill='currentColor'>
-                <path d='M6 2a2 2 0 0 0-2 2v18l8-4 8 4V4a2 2 0 0 0-2-2H6z' />
-              </svg>
-            </button>
-          </div>
-          <div className='mt-0.5 text-sm text-gray-500'>{categoryText}</div>
-          <div className='mt-2 flex items-center gap-2'>
-            <span className='inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-[11px] font-medium text-green-700'>
-              <span className='font-bold'>N</span>
-              <span>리뷰 {center.reviewCount}개</span>
-            </span>
-            <span className='inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-1 text-[11px] text-gray-700'>
-              <svg className='h-3.5 w-3.5' viewBox='0 0 24 24' fill='currentColor'>
-                <path d='M4 3h16v14l-6-3-6 3V3z' />
-              </svg>
-              <span>2025.04.16 메모</span>
-            </span>
-          </div>
-        </div>
-
-        <div className='col-span-2 mt-2 flex items-center gap-3 text-[13px] text-gray-700'>
-          <span className='inline-flex items-center gap-1'>
-            <svg className='h-4 w-4' viewBox='0 0 24 24' fill='currentColor' aria-hidden='true'>
-              <path d='M12 2a7 7 0 00-7 7c0 5.25 7 13 7 13s7-7.75 7-13a7 7 0 00-7-7zm0 9.5a2.5 2.5 0 110-5 2.5 2.5 0 010 5z' />
-            </svg>
-            <span className='font-semibold'>{distanceText}</span>
-            <span className='text-gray-500'>
-              {center.location} · {refPointLabel} 기준
-            </span>
-          </span>
-          <span className='h-3.5 w-px bg-gray-300' aria-hidden='true' />
-          <span className='inline-flex items-center gap-1'>
-            <span className='text-sm'>₩</span>
-            <span className='font-semibold'>이용요금</span>
-            <span>{center.price.toLocaleString()}원부터 ~</span>
-          </span>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/apps/knockdog/src/entities/bookmark/ui/BookmarkToggleIcon.tsx
+++ b/apps/knockdog/src/entities/bookmark/ui/BookmarkToggleIcon.tsx
@@ -7,10 +7,11 @@ import { useBookmarkPostMutation, useBookmarkDeleteMutation } from '../api/useBo
 interface BookmarkToggleIconProps {
   id: string;
   bookmarked: boolean;
+  disabled?: boolean;
   className?: string;
 }
 
-const BookmarkToggleIcon = ({ id, bookmarked, className = '' }: BookmarkToggleIconProps) => {
+const BookmarkToggleIcon = ({ id, bookmarked, disabled = false, className = '' }: BookmarkToggleIconProps) => {
   const [isBookmarked, setIsBookmarked] = useState(bookmarked);
   const { mutate: postBookmark, isPending: isPosting } = useBookmarkPostMutation();
   const { mutate: deleteBookmark, isPending: isDeleting } = useBookmarkDeleteMutation();
@@ -25,7 +26,7 @@ const BookmarkToggleIcon = ({ id, bookmarked, className = '' }: BookmarkToggleIc
     <IconButton
       icon={isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
       className={className}
-      disabled={isMutating}
+      disabled={isMutating || disabled}
       onClick={(event) => {
         event.stopPropagation();
 

--- a/apps/knockdog/src/entities/bookmark/ui/BookmarkToggleIcon.tsx
+++ b/apps/knockdog/src/entities/bookmark/ui/BookmarkToggleIcon.tsx
@@ -7,9 +7,10 @@ import { useBookmarkPostMutation, useBookmarkDeleteMutation } from '../api/useBo
 interface BookmarkToggleIconProps {
   id: string;
   bookmarked: boolean;
+  className?: string;
 }
 
-const BookmarkToggleIcon = ({ id, bookmarked }: BookmarkToggleIconProps) => {
+const BookmarkToggleIcon = ({ id, bookmarked, className = '' }: BookmarkToggleIconProps) => {
   const [isBookmarked, setIsBookmarked] = useState(bookmarked);
   const { mutate: postBookmark, isPending: isPosting } = useBookmarkPostMutation();
   const { mutate: deleteBookmark, isPending: isDeleting } = useBookmarkDeleteMutation();
@@ -23,6 +24,7 @@ const BookmarkToggleIcon = ({ id, bookmarked }: BookmarkToggleIconProps) => {
   return (
     <IconButton
       icon={isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
+      className={className}
       disabled={isMutating}
       onClick={(event) => {
         event.stopPropagation();

--- a/apps/knockdog/src/entities/compare/model/constants/compare.ts
+++ b/apps/knockdog/src/entities/compare/model/constants/compare.ts
@@ -6,6 +6,10 @@ const CTAG_MAP = {
   GROOMING: '미용',
   TRAINING: '훈련',
   PET_SHOP: '강아지 용품',
+  PLAYGROUND: '놀이터',
+  CAFE: '카페',
+  VETERINARY: '동물병원',
+  FITNESS: '피트니스',
 } as const;
 
 const PRODUCT_TYPE = {

--- a/apps/knockdog/src/features/bookmarked-list/index.ts
+++ b/apps/knockdog/src/features/bookmarked-list/index.ts
@@ -3,3 +3,4 @@ export { useBookmarksQuery } from '../bookmarked-list/api/useBookmarksQuery';
 
 /** ui */
 export { BookmarkedListItem } from './ui/BookmarkedListItem';
+export { CompareListItem } from './ui/CompareListItem';

--- a/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
@@ -13,10 +13,16 @@ import { getShortAddress } from '@shared/lib';
 interface BookmarkedListItemProps {
   kindergarten: BookmarkItem;
   distanceText: string;
+  bookmarkDisabled?: boolean;
   className?: string;
 }
 
-function BookmarkedListItem({ kindergarten, distanceText, className }: BookmarkedListItemProps) {
+function BookmarkedListItem({
+  kindergarten,
+  distanceText,
+  bookmarkDisabled = false,
+  className,
+}: BookmarkedListItemProps) {
   const categoryText = serializeCategories(kindergarten.categories as CTag[]);
 
   return (
@@ -40,7 +46,12 @@ function BookmarkedListItem({ kindergarten, distanceText, className }: Bookmarke
               <p className='label-medium text-text-tertiary truncate'>{categoryText}</p>
             </div>
             <div className='shrink-0'>
-              <BookmarkToggleIcon id={kindergarten.id} bookmarked className='text-fill-secondary-700' />
+              <BookmarkToggleIcon
+                id={kindergarten.id}
+                bookmarked
+                disabled={bookmarkDisabled}
+                className='text-fill-secondary-700'
+              />
             </div>
           </div>
 

--- a/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { NaverFill, Note, Won, LocationFill } from '@knockdog/icons';
-import { Avatar, AvatarFallback, AvatarImage } from '@knockdog/ui';
+import { Note, Won, LocationFill } from '@knockdog/icons';
+import { Avatar, AvatarFallback, AvatarImage, Icon } from '@knockdog/ui';
 import Image from 'next/image';
+import { cn } from '@knockdog/ui/lib';
 import type { BookmarkItem } from '@entities/bookmark';
 import { BookmarkToggleIcon } from '@entities/bookmark';
-import { s3ToUrl, serializeCategories } from '@entities/compare';
 import type { CTag } from '@entities/compare';
+import { s3ToUrl, serializeCategories } from '@entities/compare';
 import { getShortAddress } from '@shared/lib';
-import { cn } from '@knockdog/ui/lib';
 
 interface BookmarkedListItemProps {
   kindergarten: BookmarkItem;
@@ -20,7 +20,7 @@ function BookmarkedListItem({ kindergarten, distanceText, className }: Bookmarke
   const categoryText = serializeCategories(kindergarten.categories as CTag[]);
 
   return (
-    <div className={cn('flex flex-1 flex-col gap-3', className)}>
+    <div className={cn('flex min-w-0 flex-1 flex-col gap-3', className)}>
       {/* 썸네일 + 제목 영역 */}
       <div className='flex gap-2'>
         {/* 썸네일 */}
@@ -40,7 +40,7 @@ function BookmarkedListItem({ kindergarten, distanceText, className }: Bookmarke
               <p className='label-medium text-text-tertiary truncate'>{categoryText}</p>
             </div>
             <div className='shrink-0'>
-              <BookmarkToggleIcon id={kindergarten.id} bookmarked />
+              <BookmarkToggleIcon id={kindergarten.id} bookmarked className='text-fill-secondary-700' />
             </div>
           </div>
 
@@ -48,7 +48,7 @@ function BookmarkedListItem({ kindergarten, distanceText, className }: Bookmarke
           <div className='flex items-start gap-1'>
             {/* 네이버 리뷰 배지 */}
             <div className='bg-fill-secondary-50 flex min-w-0 items-center gap-0.5 rounded-lg px-2 py-1'>
-              <NaverFill className='h-4 w-4' />
+              <Icon icon='Naver' className='h-4 w-4' />
               <span className='caption1-semibold text-text-primary shrink-0'>리뷰</span>
               <span className='caption1-semibold text-text-primary truncate'>{kindergarten.reviewCount}개</span>
             </div>
@@ -56,7 +56,7 @@ function BookmarkedListItem({ kindergarten, distanceText, className }: Bookmarke
             {/* 메모 배지 */}
             {/* TODO: 북마크 API 응답에 메모 속성(e.g. memoUpdatedAt)이 추가된 후 수정 필요 */}
             <div className='bg-fill-secondary-50 flex shrink-0 items-center gap-0.5 rounded-lg px-2 py-1'>
-              <Note className='h-4 w-4' />
+              <Note className='text-fill-secondary-700 h-4 w-4' />
               <span className='caption1-semibold text-text-primary'>2025.04.16</span>
               <span className='caption1-semibold text-text-primary'>메모</span>
             </div>
@@ -68,7 +68,7 @@ function BookmarkedListItem({ kindergarten, distanceText, className }: Bookmarke
       <div className='flex items-center gap-2 text-sm'>
         {/* 거리 */}
         <div className='flex min-w-0 items-center gap-1'>
-          <LocationFill className='text-text-tertiary h-4 w-4' />
+          <LocationFill className='text-fill-secondary-500 h-4 w-4' />
           <span className='body2-extrabold text-text-primary'>{distanceText}</span>
           <span className='body2-regular text-text-primary truncate'>{getShortAddress(kindergarten.location)}</span>
         </div>
@@ -78,7 +78,7 @@ function BookmarkedListItem({ kindergarten, distanceText, className }: Bookmarke
 
         {/* 이용요금 */}
         <div className='flex shrink-0 items-center gap-1'>
-          <Won className='text-text-tertiary h-4 w-4' />
+          <Won className='text-fill-secondary-500 h-4 w-4' />
           <span className='body2-extrabold text-text-primary'>이용요금</span>
           <span className='body2-regular text-text-primary'>{kindergarten.price.toLocaleString()}원부터 ~</span>
         </div>

--- a/apps/knockdog/src/features/bookmarked-list/ui/CompareListItem.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/CompareListItem.tsx
@@ -8,7 +8,7 @@ interface CompareListItemProps {
   kindergarten: BookmarkItem;
   isSelected: boolean;
   distanceText: string;
-  onToggle: () => void;
+  onToggle: (checked: boolean) => void;
 }
 
 function CompareListItem({ kindergarten, isSelected, onToggle, distanceText }: CompareListItemProps) {

--- a/apps/knockdog/src/features/bookmarked-list/ui/CompareListItem.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/CompareListItem.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Checkbox } from '@knockdog/ui';
+import { BookmarkedListItem } from './BookmarkedListItem';
+import type { BookmarkItem } from '@entities/bookmark';
+
+interface CompareListItemProps {
+  kindergarten: BookmarkItem;
+  isSelected: boolean;
+  distanceText: string;
+  onToggle: () => void;
+}
+
+function CompareListItem({ kindergarten, isSelected, onToggle, distanceText }: CompareListItemProps) {
+  return (
+    <div className='flex items-start gap-3 bg-white p-5'>
+      <Checkbox size='sm' checked={isSelected} onCheckedChange={onToggle} />
+      <BookmarkedListItem kindergarten={kindergarten} distanceText={distanceText} bookmarkDisabled className='p-0' />
+    </div>
+  );
+}
+
+export { CompareListItem };

--- a/apps/knockdog/src/shared/lib/utils/address.ts
+++ b/apps/knockdog/src/shared/lib/utils/address.ts
@@ -1,14 +1,14 @@
 /**
- * 한국 주소에서 시/도와 시/군/구까지만 추출합니다.
+ * 한국 주소에서 시/도, 시/군, 구까지 추출합니다.
  * @param address 전체 주소 (예: "서울특별시 광진구 능동로 49 2층")
  * @returns 시/도 + 시/군/구 (예: "서울 광진구")
  *
  * @example
  * getShortAddress("서울특별시 광진구 능동로 49 2층") // "서울 광진구"
- * getShortAddress("경기도 성남시 분당구 정자동 123") // "경기 성남시"
+ * getShortAddress("경기도 성남시 분당구 정자동 123") // "경기 성남시 분당구"
  */
 function getShortAddress(address: string): string {
-  if (!address) return '';
+  if (!address) return ''; 
 
   const parts = address.trim().split(' ');
 
@@ -20,9 +20,15 @@ function getShortAddress(address: string): string {
 
   // 시/군/구
   const secondPart = parts[1];
-  if (!secondPart) return firstPart;
+  if (!secondPart) return firstPart; // 예: "서울특별시" → "서울"
 
-  return `${firstPart} ${secondPart}`;
+  // 구 (두 번째 부분이 "시" 또는 "군"으로 끝나는 경우에만)
+  const thirdPart = parts[2];
+  if (thirdPart && /[시군]$/.test(secondPart)) {
+    return `${firstPart} ${secondPart} ${thirdPart}`; // 예: "경기도 성남시 분당구 정자동 123" → "경기도 성남시 분당구"
+  }
+
+  return `${firstPart} ${secondPart}`; // 예: "서울특별시 광진구 능동로 49 2층" → "서울 광진구"
 }
 
 export { getShortAddress };

--- a/apps/knockdog/src/shared/lib/utils/address.ts
+++ b/apps/knockdog/src/shared/lib/utils/address.ts
@@ -5,26 +5,35 @@
  *
  * @example
  * getShortAddress("서울특별시 광진구 능동로 49 2층") // "서울 광진구"
- * getShortAddress("경기도 성남시 분당구 정자동 123") // "경기 성남시 분당구"
+ * getShortAddress("경기도 성남시 분당구 정자동 123") // "경기도 성남시 분당구"
  */
 function getShortAddress(address: string): string {
-  if (!address) return ''; 
+  if (!address) {
+    return '';
+  }
 
   const parts = address.trim().split(' ');
 
-  // 시/도 (특별시, 광역시, 특별자치시, 특별자치도, 도)
-  let firstPart = parts[0];
-  if (!firstPart) return '';
+  let firstPart = parts[0]; // 시/도 (특별시, 광역시, 특별자치시, 특별자치도, 도)
+  if (!firstPart) {
+    return '';
+  }
 
-  firstPart = firstPart.replace(/(특별시|광역시|특별자치시|특별자치도|도)$/, '');
+  firstPart = firstPart.replace(/(특별시|광역시|특별자치시|특별자치도)$/, ''); // 예: "서울특별시" → "서울"
 
-  // 시/군/구
-  const secondPart = parts[1];
-  if (!secondPart) return firstPart; // 예: "서울특별시" → "서울"
+  const secondPart = parts[1]; // 시/군/구
+  if (!secondPart) {
+    return firstPart;
+  }
 
-  // 구 (두 번째 부분이 "시" 또는 "군"으로 끝나는 경우에만)
-  const thirdPart = parts[2];
-  if (thirdPart && /[시군]$/.test(secondPart)) {
+  const thirdPart = parts[2]; // 구/동/읍/면
+
+  if (!thirdPart) {
+    return `${firstPart} ${secondPart}`;
+  }
+
+  // 시/군 + 구 조합인 경우 3단계까지 반환
+  if ((secondPart.endsWith('시') || secondPart.endsWith('군')) && thirdPart.endsWith('구')) {
     return `${firstPart} ${secondPart} ${thirdPart}`; // 예: "경기도 성남시 분당구 정자동 123" → "경기도 성남시 분당구"
   }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교하기 페이지의 북마크 목록 UI를 개선

## 작업 내용
- `CompareListItem` 컴포넌트 추가
  - 체크박스와 `BookmarkedListItem`을 결합한 새로운 컴포넌트
  - 비교하기 페이지에 적용

- `BookmarkedListItem` 개선
  - 유치원 카테고리 joined된 문자열에 truncate 적용
  - 네이버 아이콘 수정
  - 비교 페이지에서 북마크 비활성화 기능을 위한 `bookmarkDisabled` prop 추가

- `BookmarkToggleIcon` 개선
  - `disabled` prop 추가로 비활성화 상태 지원
  - `className` prop 추가로 스타일 커스터마이징 지원

- 주소 포맷팅 개선 (`shared/lib/utils/address.ts`)
  - `getShortAddress` 함수가 도/시/구까지 반환하도록 로직 수정

- 카테고리 타입 확장
  - CTAG_MAP에 4개 카테고리 추가 (`entities/compare/model/constants`)
    - 놀이터 (PLAYGROUND)
    - 카페 (CAFE)
    - 동물병원 (VETERINARY)
    - 피트니스 (FITNESS)
