### PR TITLE
ci: type-check 단계에서 app/knockdog 만 검사하도록 변경

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -9,7 +9,7 @@ reviewers:
   - im-na0
   - yeomgahui
   - south-nova
-  - bbb4756
+  - JaneChun
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         run: |
           if [ "${{ matrix.command }}" = "build" ]; then
             COMMAND="pnpm build --filter=knockdog..."
+          elif [ "${{ matrix.command }}" = "type-check" ]; then
+            COMMAND="pnpm --filter=knockdog ${{ matrix.command }}"
           else
             COMMAND="pnpm --filter=knockdog ${{ matrix.command }}"
           fi


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

- type-check 단계에서 app/knockdog 만 검사하도록 변경
- auto assign 리뷰어 수정
