### PR TITLE
feat: 비교하기 페이지 북마크 목록 FilterBar 구현 및 적용

### DIFF
--- a/apps/knockdog/app/compare/page.tsx
+++ b/apps/knockdog/app/compare/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Layout from '../(main)/layout';
 import { IconButton } from '@knockdog/ui';
 import { Header } from '@widgets/Header';
-import { useBookmarksQuery, CompareListItem } from '@features/bookmarked-list';
+import { useBookmarksQuery, CompareListItem, FilterBar } from '@features/bookmarked-list';
 import type { CTag, ReferencePointType } from '@entities/compare';
 import { serializeCategories } from '@entities/compare';
 import type { DistanceInfo } from '@entities/bookmark';
@@ -31,6 +31,7 @@ function parseDistanceToKm(distance: string): number {
 export default function ComparePage() {
   const router = useRouter();
   const [refPoint, setRefPoint] = useState<ReferencePointType>('HOME');
+  const [showMemoOnly, setShowMemoOnly] = useState(false);
 
   const { data: bookmarks = [], isLoading, error } = useBookmarksQuery();
 
@@ -58,6 +59,16 @@ export default function ComparePage() {
     });
   }, [bookmarks, refPoint]);
 
+  // TODO: Bookmark API 수정 후 반영하기
+  const filteredBookmarks = sortedBookmarks;
+  // const filteredBookmarks = useMemo(() => {
+  //   if (!showMemoOnly) return sortedBookmarks;
+  //   return sortedBookmarks.filter((kindergarten) => kindergarten.firstMemoAt != null);
+  // }, [sortedBookmarks, showMemoOnly]);
+
+  const toggleShowMemoOnly = () => {
+    setShowMemoOnly((prev) => !prev);
+  };
   /* =========================
    * DEV 로그인 (토큰 갱신 → localStorage 저장)
    * ========================= */
@@ -158,40 +169,16 @@ export default function ComparePage() {
             </Header>
 
             {/* Filter Bar */}
-            <div className='flex items-center justify-between border-y border-[#EBEBF0] bg-white px-3 py-2 text-sm text-gray-700'>
-              <label className='flex items-center gap-2'>
-                <span className='inline-block h-2.5 w-2.5 rounded-full bg-orange-500' />
-                메모
-              </label>
-
-              <label className='flex items-center gap-2'>
-                <span className='text-gray-700'>거리기준:</span>
-                <div className='relative'>
-                  <select
-                    value={refPoint}
-                    onChange={(e) => setRefPoint(e.target.value as ReferencePointType)}
-                    className='appearance-none rounded-md border border-[#EBEBF0] bg-white px-3 py-1.5 pr-8 text-sm text-gray-800'
-                    aria-label='거리 기준 선택'
-                  >
-                    <option value='HOME'>집</option>
-                    <option value='WORK'>직장</option>
-                    <option value='OTHER'>기타</option>
-                  </select>
-                  <svg
-                    className='pointer-events-none absolute top-1/2 right-2 h-4 w-4 -translate-y-1/2 text-gray-500'
-                    viewBox='0 0 24 24'
-                    fill='none'
-                    aria-hidden='true'
-                  >
-                    <path d='M6 9l6 6 6-6' stroke='currentColor' strokeWidth='2' strokeLinecap='round' />
-                  </svg>
-                </div>
-              </label>
-            </div>
+            <FilterBar
+              refPoint={refPoint}
+              onChangeRefPoint={setRefPoint}
+              showMemoOnly={showMemoOnly}
+              onMemoToggle={toggleShowMemoOnly}
+            />
 
             {/* List */}
             <div className='flex-1 overflow-y-auto'>
-              {sortedBookmarks.map((kindergarten) => {
+              {filteredBookmarks.map((kindergarten) => {
                 const distInfo = findDistanceByRefPoint(kindergarten.distances, refPoint);
                 const distanceText = distInfo?.distance || '- km';
                 return (

--- a/apps/knockdog/src/features/bookmarked-list/index.ts
+++ b/apps/knockdog/src/features/bookmarked-list/index.ts
@@ -4,3 +4,4 @@ export { useBookmarksQuery } from '../bookmarked-list/api/useBookmarksQuery';
 /** ui */
 export { BookmarkedListItem } from './ui/BookmarkedListItem';
 export { CompareListItem } from './ui/CompareListItem';
+export { FilterBar } from './ui/FilterBar';

--- a/apps/knockdog/src/features/bookmarked-list/ui/DropDown.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/DropDown.tsx
@@ -1,0 +1,116 @@
+import {
+  useFloating,
+  useInteractions,
+  useClick,
+  useDismiss,
+  useRole,
+  useListNavigation,
+  offset,
+  flip,
+  shift,
+  autoUpdate,
+  FloatingFocusManager,
+} from '@floating-ui/react';
+
+import { Icon } from '@knockdog/ui';
+import { useState, useRef } from 'react';
+import { RemoveScroll } from 'react-remove-scroll';
+
+interface DropdownProps<T> {
+  options: { value: T; label: string; displayLabel: string }[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+export function Dropdown<T>({ options, value, onChange }: DropdownProps<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  const selectedIndex = options.findIndex((option) => option.value === value);
+  const selectedOptionDisplayLabel = options[selectedIndex]?.displayLabel;
+
+  const { refs, floatingStyles, context } = useFloating({
+    placement: 'bottom-end',
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    middleware: [offset(0), flip(), shift()],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const listItemsRef = useRef<Array<HTMLLIElement | null>>([]);
+
+  const { getReferenceProps, getFloatingProps, getItemProps } = useInteractions([
+    useClick(context),
+    useDismiss(context, {
+      outsidePress: true,
+      outsidePressEvent: 'pointerdown',
+    }),
+    useRole(context, { role: 'listbox' }),
+    useListNavigation(context, {
+      listRef: listItemsRef,
+      activeIndex,
+      selectedIndex,
+      onNavigate: setActiveIndex,
+    }),
+  ]);
+
+  const handleSelect = (index: number) => {
+    const selectedOption = options[index];
+    if (selectedOption) {
+      onChange(selectedOption.value);
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        type='button'
+        role='combobox'
+        aria-expanded={isOpen}
+        className='relative flex items-center justify-center gap-1'
+      >
+        <span className='body2-bold text-text-primary'>{selectedOptionDisplayLabel}</span>
+        <span className={isOpen ? 'rotate-180' : 'rotate-0'}>
+          <Icon icon='ChevronBottom' className='text-secondary-400 h-5 w-5' />
+        </span>
+      </button>
+
+      {isOpen && (
+        <RemoveScroll forwardProps>
+          <FloatingFocusManager context={context} modal={false}>
+            <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()} className='z-999'>
+              <ul className='py-x1.5 px-x1.5 bg-bg-0 radius-r2 gap-x1.5 flex w-[111px] flex-col shadow-[0px_1px_6px_0px_rgba(16,24,40,0.12)]'>
+                {options.map((option, index) => (
+                  <li
+                    key={String(option.value)}
+                    ref={(node) => {
+                      listItemsRef.current[index] = node;
+                    }}
+                    {...getItemProps({
+                      onClick: (event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        handleSelect(index);
+                      },
+                      role: 'option',
+                      'aria-selected': index === selectedIndex,
+                    })}
+                    className={`gap-x1 px-x1.5 py-x1 radius-r1 hover:bg-fill-secondary-50 flex cursor-pointer items-center transition-colors ${
+                      index === selectedIndex ? 'body2-bold text-text-accent' : 'body2-regular text-text-primary'
+                    }`}
+                  >
+                    <span className='flex-1 truncate'>{option.label}</span>
+                    {index === selectedIndex && <Icon icon='Check' className='size-x4 text-fill-primary-500' />}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </FloatingFocusManager>
+        </RemoveScroll>
+      )}
+    </>
+  );
+}

--- a/apps/knockdog/src/features/bookmarked-list/ui/FilterBar.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/FilterBar.tsx
@@ -1,0 +1,40 @@
+import { Dropdown } from './DropDown';
+import { REFERENCE_POINT_TYPE, type ReferencePointType } from '@entities/compare';
+
+const REFERENCE_POINT_OPTIONS = Object.entries(REFERENCE_POINT_TYPE).map(([value, label]) => ({
+  value: value as ReferencePointType,
+  label,
+  displayLabel: `거리기준: ${label}`,
+}));
+
+interface FilterBarProps {
+  refPoint: ReferencePointType;
+  onChangeRefPoint: (value: ReferencePointType) => void;
+  showMemoOnly: boolean;
+  onMemoToggle: () => void;
+}
+
+export function FilterBar({ refPoint, onChangeRefPoint, showMemoOnly, onMemoToggle }: FilterBarProps) {
+  return (
+    <div className='border-line-200 flex items-center justify-between border-y bg-white px-4 py-2'>
+      <button
+        type='button'
+        aria-label='메모 필터'
+        aria-pressed={showMemoOnly}
+        onClick={onMemoToggle}
+        className='flex items-center gap-0.5 rounded bg-white p-2 transition-colors hover:bg-gray-50'
+      >
+        <div className='flex h-4 w-4 items-center justify-center'>
+          <span
+            className={`inline-block h-2.5 w-2.5 rounded-full transition-colors ${
+              showMemoOnly ? 'bg-fill-primary-500' : 'bg-fill-secondary-400'
+            }`}
+          />
+        </div>
+        <span className='body2-semibold text-text-primary'>메모</span>
+      </button>
+
+      <Dropdown options={REFERENCE_POINT_OPTIONS} value={refPoint} onChange={onChangeRefPoint} />
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교하기 페이지 FilterBar 및 DropDown 컴포넌트 구현
- 비교하기 페이지 북마크 목록에 적용

## 논의할 점
#### 현재 상황

현재 `GET /api/v0/bookmark` API 응답에 첫 메모 등록일(e.g. `firstMemoAt`)가 포함되어 있지 않습니다.

#### 임시 처리 내용

메모 필터 기능을 UI 레벨에서 구현했으나, API 수정 전까지 일부 기능을 임시로 비활성화했습니다:

1. `app/compare/page.tsx`
    - 메모 필터링 로직을 주석처리
    - 필터 버튼 클릭 시 UI 상태(동그라미 색상)만 변경되고 실제 필터링은 동작하지 않음
2. `features/bookmarked-list/ui/BookmarkedListItem.tsx`
    - 메모 뱃지 표시를 임시로 하드코딩 (항상 표시됨)

#### 향후 작업 필요

백엔드에서 북마크 API에 메모 정보가 추가되면:
- 주석 처리된 필터링 로직 활성화
- 메모 뱃지를 실제 데이터 기반으로 표시

코드 내 TODO 주석으로 수정이 필요한 위치를 표시해두었습니다.