### PR TITLE
  feat: 지도 검색 결과에 메모 데이터 연동 및 UI 형식 수정

### DIFF
--- a/apps/knockdog/src/entities/kindergarten/model/types.ts
+++ b/apps/knockdog/src/entities/kindergarten/model/types.ts
@@ -9,10 +9,9 @@ interface KindergartenListItem extends Omit<KindergartenListItemDto, 'dist'> {
 export interface KindergartenListItemWithMeta extends KindergartenListItem {
   dist: string; // 포맷된 거리
   memo?: {
-    id: string;
     shopId: string;
     content: string;
-    updatedAt: string;
+    memoDate: string;
   };
   isBookmarked?: boolean;
 }

--- a/apps/knockdog/src/entities/memo/api/memo.ts
+++ b/apps/knockdog/src/entities/memo/api/memo.ts
@@ -1,0 +1,6 @@
+import type { MemoList } from '../model/memo';
+import { api } from '@shared/api';
+
+export function getMemoList() {
+  return api.get('memo/shops').json<MemoList>();
+}

--- a/apps/knockdog/src/entities/memo/config/memoQueries.ts
+++ b/apps/knockdog/src/entities/memo/config/memoQueries.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from '@tanstack/react-query';
+import { getMemoList } from '../api/memo';
+
+export const memoQueries = {
+  keys: {
+    all: () => ['memo'] as const,
+  },
+
+  list: () =>
+    queryOptions({
+      queryKey: memoQueries.keys.all(),
+      queryFn: () => getMemoList(),
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+    }),
+};

--- a/apps/knockdog/src/entities/memo/index.ts
+++ b/apps/knockdog/src/entities/memo/index.ts
@@ -1,9 +1,11 @@
 // api
+export { getMemoList } from './api/memo';
 export { getMemo, type MemoResponse, type MemoPhoto } from './api/getMemo';
 export { updateMemo, type UpdateMemoRequest } from './api/updateMemo';
 
 // config
+export { memoQueries } from './config/memoQueries';
 export { memoQueryKeys, createMemoQueryOptions } from './config/memoQueryKeys';
 
 // model
-export type { Photo } from './model/memo';
+export type { Photo, MemoList } from './model/memo';

--- a/apps/knockdog/src/entities/memo/index.ts
+++ b/apps/knockdog/src/entities/memo/index.ts
@@ -8,4 +8,4 @@ export { memoQueries } from './config/memoQueries';
 export { memoQueryKeys, createMemoQueryOptions } from './config/memoQueryKeys';
 
 // model
-export type { Photo, MemoList } from './model/memo';
+export type { Photo, MemoItem } from './model/memo';

--- a/apps/knockdog/src/entities/memo/model/memo.ts
+++ b/apps/knockdog/src/entities/memo/model/memo.ts
@@ -10,9 +10,11 @@ export interface Memo {
 }
 
 export interface MemoList {
-  memos: {
-    shopId: number;
-    memoDate: string;
-    content: string;
-  }[];
+  memos: MemoItem[];
+}
+
+export interface MemoItem {
+  shopId: string;
+  memoDate: string;
+  content: string;
 }

--- a/apps/knockdog/src/entities/memo/model/memo.ts
+++ b/apps/knockdog/src/entities/memo/model/memo.ts
@@ -8,3 +8,11 @@ export interface Memo {
   content: string;
   updatedAt: string;
 }
+
+export interface MemoList {
+  memos: {
+    shopId: number;
+    memoDate: string;
+    content: string;
+  }[];
+}

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
@@ -65,11 +65,14 @@ export function KindergartenCard(props: KindergartenCardProps) {
                 <Icon icon='Naver' className='size-x4' />
                 <span className='caption1-semibold text-text-primary text-center'>리뷰 {props.reviewCount}개</span>
               </div>
-              <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-[2px]'>
-                <Icon icon='Note' className='size-x4' />
-                <span className='caption1-semibold text-text-primary'>2025.04.16</span>
-                <span className='caption1-semibold text-text-primary'>메모</span>
-              </div>
+
+              {props.memo && (
+                <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-[2px]'>
+                  <Icon icon='Note' className='size-x4' />
+                  <span className='caption1-semibold text-text-primary'>{props.memo.memoDate}</span>
+                  <span className='caption1-semibold text-text-primary'>메모</span>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
@@ -104,7 +104,7 @@ export function KindergartenListItem({
           <div className='bg-fill-secondary-100 px-x3 py-x4 gap-x1 radius-r2 flex w-full flex-col'>
             <div className='gap-x1 flex items-center'>
               <Icon icon='Note' className='size-x4 text-fill-secondary-600' />
-              <span className='caption1-extrabold text-primitive-neutral-700'>{memo.updatedAt} 메모</span>
+              <span className='caption1-extrabold text-primitive-neutral-700'>{memo.memoDate} 메모</span>
             </div>
             <p className='body2-regular text-text-primary line-clamp-2'>{memo.content}</p>
           </div>

--- a/apps/knockdog/src/features/kindergarten-map/api/searchQueries.ts
+++ b/apps/knockdog/src/features/kindergarten-map/api/searchQueries.ts
@@ -7,6 +7,7 @@ import type { SearchState } from '../lib/searchMachine';
 import { boundsSnapshotToBounds } from '../lib/bounds';
 import { getKindergartenAggregation, getKindergartenSearchList, type SortType } from '@entities/kindergarten';
 import type { BookmarkItem } from '@entities/bookmark';
+import type { MemoItem } from '@entities/memo';
 import { isValidCoord, serializeCoords } from '@shared/lib';
 import { serializeBoundSnapshot } from '@entities/kindergarten/lib/serialize';
 import { isValidBoundsSnapshot } from '@entities/kindergarten/lib/is';
@@ -14,7 +15,8 @@ import { isValidBoundsSnapshot } from '@entities/kindergarten/lib/is';
 interface SearchListQueryParams {
   state: SearchState;
   rank?: SortType;
-  bookmarks: BookmarkItem[];
+  bookmarks?: BookmarkItem[];
+  memos?: MemoItem[];
 }
 
 interface AggregationQueryParams {
@@ -90,7 +92,7 @@ export const searchQueries = {
         return lastPage.paging.hasNext ? lastPage.paging.currentPage + 1 : undefined;
       },
       select: (data) => ({
-        pages: data.pages.map(createKindergartenListWithMeta(params.bookmarks ?? [])),
+        pages: data.pages.map(createKindergartenListWithMeta(params.bookmarks ?? [], params.memos ?? [])),
         pageParams: data.pageParams,
       }),
       staleTime: 5 * 60 * 1000,

--- a/apps/knockdog/src/features/kindergarten-map/model/mappers.ts
+++ b/apps/knockdog/src/features/kindergarten-map/model/mappers.ts
@@ -5,17 +5,22 @@ import type {
   KindergartenListItem,
 } from '@entities/kindergarten';
 import type { BookmarkItem } from '@entities/bookmark/model/bookmark';
+import type { MemoItem } from '@entities/memo';
 import { formatDistance } from '@shared/lib';
 
-// FIXME: 향후 실제 API 사용 시 삭제 필요
-interface KindergartenMemo {
-  id: string;
-  shopId: string;
-  content: string;
-  updatedAt: string;
-}
+type KindergartenMemo = MemoItem;
 
 type KindergartenBookmark = Pick<BookmarkItem, 'id'> & { shopId?: string };
+
+/**
+ * YYYY-MM-DD to YYYY.MM.DD
+ */
+function formatMemoDate(memo: KindergartenMemo): KindergartenMemo {
+  return {
+    ...memo,
+    memoDate: memo.memoDate.replace(/-/g, '.'),
+  };
+}
 
 /**
  * KindergartenListItem을 메모/북마크와 결합하고 거리를 포맷팅한 모델로 변환
@@ -32,7 +37,7 @@ function toKindergartenListItemWithMeta(
   return {
     ...rest,
     dist: formatDistance(dist, { unit: 'kilometer' }),
-    memo,
+    memo: memo ? formatMemoDate(memo) : undefined,
     isBookmarked,
   };
 }
@@ -49,7 +54,7 @@ function toKindergartenListWithMeta({
   memoData: KindergartenMemo[];
   bookmarkData: KindergartenBookmark[];
 }): KindergartenListWithMeta {
-  const memoByShopId = new Map(memoData.map((memo) => [memo.shopId, memo]));
+  const memoByShopId = new Map(memoData.map((memo) => [String(memo.shopId), memo]));
   const bookmarkedSet = new Set(
     bookmarkData.map((bookmark) => bookmark.shopId ?? bookmark.id).filter(Boolean) as string[]
   );
@@ -72,40 +77,7 @@ function toKindergartenListWithMeta({
   };
 }
 
-// FIXME: 향후 실제 API 사용 시 삭제 필요
-export function createKindergartenListWithMock(data: KindergartenSearchList): KindergartenListWithMeta {
-  return toKindergartenListWithMeta({
-    listData: data,
-    memoData: memoMockData,
-    bookmarkData: bookmarkMockData,
-  });
-}
-
-// TODO: 향후 실제 (메모, 북마크 조회) API 사용 시 사용될 함수
-export function createKindergartenListWithMeta(bookmarks: KindergartenBookmark[], memos: KindergartenMemo[] = []) {
+export function createKindergartenListWithMeta(bookmarks: KindergartenBookmark[], memos: KindergartenMemo[]) {
   return (listResponse: KindergartenSearchList): KindergartenListWithMeta =>
     toKindergartenListWithMeta({ listData: listResponse, memoData: memos, bookmarkData: bookmarks });
 }
-
-// FIXME: 향후 실제 API 사용 시 삭제 필요
-export const memoMockData: KindergartenMemo[] = [
-  {
-    id: '1',
-    shopId: '12',
-    content:
-      '시설은 진짜 좋은데 너무 비싸서 고민되는데ㅠㅠ 선생님들과 원장님과 얘기해보니 믿고 맡길 수 있을 것 같아서 돈이 아깝지 않을듯..?',
-    updatedAt: '2025-01-01',
-  },
-];
-
-// FIXME: 향후 실제 API 사용 시 삭제 필요
-export const bookmarkMockData: KindergartenBookmark[] = [
-  {
-    id: '1',
-    shopId: '12',
-  },
-  {
-    id: '2',
-    shopId: '36',
-  },
-];

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchQuery.ts
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchQuery.ts
@@ -8,6 +8,7 @@ import { useUserStore } from '@entities/user';
 import type { KindergartenListItemWithMeta } from '@entities/kindergarten';
 import { bookmarkQueries } from '@entities/bookmark';
 import { tokenUtils } from '@shared/utils';
+import { memoQueries } from '@entities/memo';
 
 export function useSearchListQuery() {
   const { committedState } = useSearchMachine();
@@ -20,10 +21,16 @@ export function useSearchListQuery() {
     enabled: isLoggedIn,
   });
 
+  const memoListQuery = useQuery({
+    ...memoQueries.list(),
+    enabled: isLoggedIn,
+  });
+
   const searchListOptions = searchQueries.searchList({
     state: committedState,
     rank,
-    bookmarks: isLoggedIn ? (bookmarksQuery.data ?? []) : [],
+    bookmarks: isLoggedIn ? bookmarksQuery.data : [],
+    memos: isLoggedIn ? memoListQuery.data?.memos : [],
   });
 
   const searchListQuery = useInfiniteQuery({

--- a/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
@@ -178,7 +178,7 @@ export function MapView(props: MapViewProps) {
             />
           ))}
 
-        {/* 업체 마커 (줌레벨 14~) */}
+        {/* 개별 마커 (줌레벨 14~) */}
         {showBusinessMarkers &&
           overlay.map((item) => (
             <Marker
@@ -186,7 +186,15 @@ export function MapView(props: MapViewProps) {
               position={item.coord}
               onClick={() => handleMarkerClick(item)}
               customIcon={{
-                content: <PlaceMarker title={item.title} distance={item.dist} selected={item.id === activeMarkerId} />,
+                content: (
+                  <PlaceMarker
+                    title={item.title}
+                    distance={item.dist}
+                    selected={item.id === activeMarkerId}
+                    isBookmarked={item.isBookmarked}
+                    hasMemo={!!item.memo}
+                  />
+                ),
                 offsetY: 12,
               }}
             />
@@ -198,7 +206,15 @@ export function MapView(props: MapViewProps) {
             position={exact.coord}
             onClick={() => handleMarkerClick(exact)}
             customIcon={{
-              content: <PlaceMarker title={exact.title} distance={exact.dist} selected={exact.id === activeMarkerId} />,
+              content: (
+                <PlaceMarker
+                  title={exact.title}
+                  distance={exact.dist}
+                  selected={exact.id === activeMarkerId}
+                  isBookmarked={exact.isBookmarked}
+                  hasMemo={!!exact.memo}
+                />
+              ),
               offsetY: 12,
             }}
           />

--- a/apps/knockdog/src/shared/ui/map/ui/PlaceMarker.tsx
+++ b/apps/knockdog/src/shared/ui/map/ui/PlaceMarker.tsx
@@ -10,9 +10,19 @@ interface PlaceMarkerProps {
   distance?: string | number;
   selected?: boolean;
   className?: string;
+  isBookmarked?: boolean;
+  hasMemo?: boolean;
 }
 
-export function PlaceMarker({ title, titleMaxLength = 7, distance, selected, className }: PlaceMarkerProps) {
+export function PlaceMarker({
+  title,
+  titleMaxLength = 7,
+  distance,
+  selected,
+  className,
+  isBookmarked,
+  hasMemo,
+}: PlaceMarkerProps) {
   return (
     <div className='relative select-none'>
       <div
@@ -29,14 +39,18 @@ export function PlaceMarker({ title, titleMaxLength = 7, distance, selected, cla
           <span className={cn('text-text-tertiary caption1-semibold', selected && 'text-text-secondary-inverse')}>
             {distance}
           </span>
-          <Icon
-            icon='BookmarkFill'
-            className={cn('text-fill-secondary-700 size-x4', selected && 'text-text-primary-inverse')}
-          />
-          <Icon
-            icon='Note'
-            className={cn('text-fill-secondary-700 size-x4', selected && 'text-text-primary-inverse')}
-          />
+          {isBookmarked && (
+            <Icon
+              icon='BookmarkFill'
+              className={cn('text-fill-secondary-700 size-x4', selected && 'text-text-primary-inverse')}
+            />
+          )}
+          {hasMemo && (
+            <Icon
+              icon='Note'
+              className={cn('text-fill-secondary-700 size-x4', selected && 'text-text-primary-inverse')}
+            />
+          )}
         </div>
       </div>
       <svg


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

  지도 검색 리스트에서 사용자가 작성한 메모 정보를 연동하여 표시하고, 검색 결과 및 개별 마커에서 메모/북마크 여부를 아이콘으로 시각화하는 작업입니다.
  https://jira-knockdog.atlassian.net/browse/KDDEV-252

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

  1. 데이터 가공 로직 수정 (`mappers.ts`)
   - 유치원 검색 결과(school.id)와 메모 정보(memo.shopId)의 ID 타입 불일치(string/number)로 인해 메모 정보가 누락되던 버그를 수정했습니다. memo.shopId를 string으로 변환하여 Map의 키로 사용함으로써
     정상적으로 데이터가 연결되도록 했습니다.
   - API 응답의 메모 날짜 형식(YYYY-MM-DD)을 화면 디자인에 맞게(YYYY.MM.DD) 변환하는 로직을 추가했습니다.

  2. 메모/북마크 아이콘 표시
   - PlaceMarker 컴포넌트에서 isBookmarked, hasMemo prop을 기반으로 북마크와 메모 아이콘을 조건부로 렌더링하도록 수정했습니다.
   - MapView에서 마커를 렌더링할 때 KindergartenListItemWithMeta의 isBookmarked, memo 데이터를 참조하여 해당 prop들을 전달합니다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

상세 페이지에서 메모 작성/수정 후, 지도 검색 리스트로 돌아왔을 때 메모 데이터가 즉시 갱신되지 않습니다.
메인 페이지와 상세 페이지는 다른 탭으로 취급되므로 쿼리캐시를 공유하지 않음 → 쿼리키로 무효화하는게 불가능함. 
다른탭에 있는건 쿼리 무효화를 어케 시켜야할까여..


## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
