### PR TITLE
Feat: 마커 -> 바텀시트 -> 상세페이지 전환 애니메이션 구현

### DIFF
--- a/apps/knockdog/app/layout.tsx
+++ b/apps/knockdog/app/layout.tsx
@@ -19,25 +19,25 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang='ko' className={cn(suit.variable)}>
-      <body className='overflow-hidden'>
-        <NuqsAdapter>
-          <ReactQueryProvider>
-            <BridgeProvider>
-              <OverlayProvider>
-                <HeaderProvider>
+      <HeaderProvider>
+        <body className='overflow-hidden'>
+          <NuqsAdapter>
+            <ReactQueryProvider>
+              <BridgeProvider>
+                <OverlayProvider>
                   <SyncWebViewQueryEffect />
                   <div className='relative mx-auto flex h-dvh w-screen max-w-screen-sm flex-col shadow-lg'>
                     {/* @TODO HeaderWrapper 추후 삭제 필요 */}
                     <HeaderWrapper />
                     {children}
                   </div>
-                </HeaderProvider>
-              </OverlayProvider>
-            </BridgeProvider>
-          </ReactQueryProvider>
-        </NuqsAdapter>
-        <Script src='//openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=s5hu0lc2kz' strategy='beforeInteractive' />
-      </body>
+                </OverlayProvider>
+              </BridgeProvider>
+            </ReactQueryProvider>
+          </NuqsAdapter>
+          <Script src='//openapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=s5hu0lc2kz' strategy='beforeInteractive' />
+        </body>
+      </HeaderProvider>
     </html>
   );
 }

--- a/apps/knockdog/src/features/kindergarten-list/model/useViewportProgress.ts
+++ b/apps/knockdog/src/features/kindergarten-list/model/useViewportProgress.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useMotionValue } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+
+interface UseSheetDragProgressProps {
+  minSnapPoint: number;
+  maxSnapPointOffset: number;
+}
+
+/**
+ * 바텀시트 드래그 진행도를 계산하는 훅.
+ *  요소의 뷰포트를 참조하여 드래그 진행도를 계산합니다.
+ *
+ * @param minSnapPoint - 최소 스냅포인트
+ * @param maxSnapPointOffset - 최대 스냅포인트 오프셋
+ * @returns
+ */
+const useSheetDragProgress = ({ minSnapPoint, maxSnapPointOffset }: UseSheetDragProgressProps) => {
+  const viewRef = useRef<HTMLDivElement>(null);
+
+  const dragProgress = useMotionValue(0);
+
+  useEffect(() => {
+    let rafId: number;
+    let lastProgress = -1;
+    const threshold = 0.005; // 0.5%
+
+    const calculateProgress = () => {
+      if (viewRef.current) {
+        const rect = viewRef.current.getBoundingClientRect();
+        const viewportHeight = window.innerHeight;
+
+        // 바텀시트의 현재 높이
+        const currentSheetHeight = viewportHeight - rect.top;
+
+        // 최소/최대 높이
+        const minHeight = minSnapPoint;
+        const maxHeight = viewportHeight - maxSnapPointOffset;
+
+        // 0-1로 정규화
+        const rawProgress = (currentSheetHeight - minHeight) / (maxHeight - minHeight);
+
+        const clamped = Math.max(0, Math.min(1, rawProgress));
+
+        if (Math.abs(clamped - lastProgress) >= threshold) {
+          dragProgress.set(clamped);
+          lastProgress = clamped;
+        }
+      }
+
+      rafId = requestAnimationFrame(calculateProgress);
+    };
+
+    rafId = requestAnimationFrame(calculateProgress);
+    return () => cancelAnimationFrame(rafId);
+  }, [dragProgress, minSnapPoint, maxSnapPointOffset]);
+
+  return { viewRef, dragProgress };
+};
+
+export { useSheetDragProgress };

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
@@ -1,20 +1,43 @@
-import type { KindergartenListItemWithMeta } from '@entities/kindergarten';
-import { BottomSheet } from '@shared/ui/bottom-sheet';
+import { Divider } from '@knockdog/ui';
+import { KindergartenTabs } from '@widgets/kindergarten-tabs';
+import { KindergartenMainBox, MainBannerSwiper, useKindergartenMainQuery } from '@features/kindergarten-main';
+import { useCurrentLocation } from '@shared/lib';
 
-interface DogSchoolDetailProps extends KindergartenListItemWithMeta {}
+interface KindergartenDetailProps {
+  kindergartenId: string;
+}
 
-export function KindergartenDetail({ ...props }: DogSchoolDetailProps) {
+export function KindergartenDetail({ kindergartenId }: KindergartenDetailProps) {
+  const { position } = useCurrentLocation();
+  const { lng, lat } = position || { lng: 126.883439, lat: 37.511281 };
+
+  const { data: kindergartenMain } = useKindergartenMainQuery({
+    id: kindergartenId,
+    lng,
+    lat,
+    enabled: Boolean(kindergartenId && lng != null && lat != null),
+  });
+
+  if (lng == null || lat == null || !kindergartenMain) return null;
+  const { banner: images, ...restKindergartenMainData } = kindergartenMain;
+
   return (
     <>
-      <BottomSheet.Title className='sr-only'>{props.title} 상세</BottomSheet.Title>
-      <div className='p-6'>
-        <h1 className='mb-4 text-2xl font-bold'>{props.title}</h1>
-        <p className='mb-2 text-gray-600'>거리: {props.dist}</p>
-        <p className='text-gray-600'>주소: {props.id}</p>
-        <div className='mt-8'>
-          <h2 className='mb-4 text-lg font-semibold'>상세 정보</h2>
-          <p>여기에 상세 정보가 표시됩니다.</p>
-        </div>
+      <div>
+        {/* 업체 메인이미지 슬라이드형 */}
+        <MainBannerSwiper images={images ?? []} />
+      </div>
+
+      {/* 컨텐츠 영역 */}
+      <div className='relative'>
+        <div className='absolute top-[-50px]' />
+        {/* 대표 컨텐츠 영역 */}
+        <KindergartenMainBox {...restKindergartenMainData} />
+        {/* Divider */}
+        <Divider size='thick' />
+        {/* 세부 컨텐츠 영역 */}
+        {/* 탭 */}
+        <KindergartenTabs kindergartenId={kindergartenId} />
       </div>
     </>
   );

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -1,10 +1,18 @@
+'use client';
+
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BottomSheet, TRANSITION_DURATION_MS } from '@knockdog/ui';
 import { KindergartenCard } from './KindergartenCard';
-import { KindergartenDetail } from './KindergartenDetail';
 import { cn } from '@knockdog/ui/lib';
+import { motion, useIsomorphicLayoutEffect, useTransform } from 'framer-motion';
+import { RemoveScroll } from 'react-remove-scroll';
 import { useBookmarkToggle } from '../model/useBookmarkToggle';
+import { useSheetDragProgress } from '../model/useViewportProgress';
+import { Header } from '@widgets/Header';
+import { KindergartenDetail } from '@features/kindergarten-list/ui/KindergartenDetail';
 import { useSearchListQuery } from '@features/kindergarten-map';
+import { isNativeWebView, useSafeAreaInsets, useShare } from '@shared/lib';
+import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
 
 interface KindergartenItemSheetProps {
   itemId: string;
@@ -12,7 +20,6 @@ interface KindergartenItemSheetProps {
   onClose: () => void;
 }
 
-const snapPoints = ['328px', 1];
 type SnapPoint = number | string | null;
 
 type SheetView = 'card' | 'detail';
@@ -33,10 +40,44 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
     return null;
   }, [exact, itemId, searchList]);
 
+  const { top } = useSafeAreaInsets();
+
+  const MIN_SNAP_POINT = isNativeWebView() ? 328 : BOTTOM_BAR_HEIGHT + 328;
+  const MAX_SNAP_POINT_OFFSET = isNativeWebView() ? 64 + top : 64;
+
+  const snapPoints = [`${MIN_SNAP_POINT}px`, 1];
+
   const [activeSnapPoint, setActiveSnapPoint] = useState<SnapPoint>(snapPoints[0] ?? null);
   const [view, setView] = useState<SheetView>('card');
   const [isTransitioning, setIsTransitioning] = useState(false);
   const transitionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const { top: safeAreaTop } = useSafeAreaInsets();
+  const isMaxSnap = activeSnapPoint === snapPoints[1];
+
+  const { viewRef, dragProgress } = useSheetDragProgress({
+    minSnapPoint: MIN_SNAP_POINT,
+    maxSnapPointOffset: MAX_SNAP_POINT_OFFSET,
+  });
+
+  const visibleOpacity = useTransform(dragProgress, [0, 1], [1, 0]);
+  const hiddenOpacity = useTransform(dragProgress, [0, 1], [0, 1]);
+  const cardY = useTransform(dragProgress, [0, 1], [0, 100]);
+  const detailY = useTransform(dragProgress, [0, 1], [100, 0]);
+  const scaleUp = useTransform(dragProgress, [0, 1], [0.8, 1]);
+  const scaleDown = useTransform(dragProgress, [0, 1], [1, 0.8]);
+
+  const share = useShare();
+  const handleShare = () => {
+    const shareData = {
+      message: `${currentItem?.title}\n https://knockdog.com/kindergarten/${currentItem?.id}`,
+      url: `https://knockdog.com/kindergarten/${currentItem?.id}`,
+    };
+
+    share(shareData);
+  };
 
   const clearTransitionTimer = useCallback(() => {
     if (transitionTimerRef.current) {
@@ -91,7 +132,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
   useEffect(() => {
     if (!isOpen) {
       clearTransitionTimer();
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+
       setActiveSnapPoint(snapPoints[0] ?? null);
       setView('card');
       setIsTransitioning(false);
@@ -99,46 +140,94 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
   }, [clearTransitionTimer, isOpen]);
 
   useEffect(() => {
-    return () => {
-      clearTransitionTimer();
-    };
+    return () => clearTransitionTimer();
   }, [clearTransitionTimer]);
 
+  useIsomorphicLayoutEffect(() => {
+    if (containerRef.current) {
+      setContainer(containerRef.current);
+    }
+  }, [containerRef]);
+
+  if (currentItem == null) return null;
   return (
-    <BottomSheet.Root
-      open={isOpen}
-      onOpenChange={(open) => {
-        if (!open) {
-          onClose();
-        }
-      }}
-      modal={false}
-      snapPoints={snapPoints}
-      activeSnapPoint={activeSnapPoint}
-      setActiveSnapPoint={handleSnapChange}
-      snapToSequentialPoint
-    >
-      <BottomSheet.Portal>
-        <BottomSheet.Body
-          onPointerDownOutside={(e: Event) => {
-            e.preventDefault();
-            onClose();
+    <>
+      <motion.div
+        className='fixed top-0 left-0 z-50 w-screen bg-white'
+        style={{ paddingTop: safeAreaTop, opacity: hiddenOpacity }}
+      >
+        <Header className='block'>
+          <Header.LeftSection>
+            <Header.BackButton />
+            <Header.HomeButton />
+          </Header.LeftSection>
+
+          <Header.Title>{currentItem.title}</Header.Title>
+
+          <Header.RightSection>
+            <Header.ShareButton onClick={handleShare} />
+          </Header.RightSection>
+        </Header>
+      </motion.div>
+
+      <div
+        ref={containerRef}
+        className='pointer-events-none absolute bottom-0 w-full'
+        style={{ height: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)` }}
+      >
+        <BottomSheet.Root
+          open={isOpen}
+          onOpenChange={(open) => {
+            if (!open) {
+              onClose();
+            }
           }}
-          className={cn(
-            'bottom-[68px] z-50 h-full',
-            activeSnapPoint === snapPoints[1] && 'h-full',
-            isTransitioning && 'pointer-events-none'
-          )}
+          modal={false}
+          snapPoints={snapPoints}
+          activeSnapPoint={activeSnapPoint}
+          setActiveSnapPoint={handleSnapChange}
+          snapToSequentialPoint
+          container={container}
         >
-          {currentItem ? (
-            view === 'card' ? (
-              <KindergartenCard {...currentItem} onBookmarkClick={onBookmarkClick} />
-            ) : (
-              <KindergartenDetail {...currentItem} />
-            )
-          ) : null}
-        </BottomSheet.Body>
-      </BottomSheet.Portal>
-    </BottomSheet.Root>
+          <RemoveScroll forwardProps noIsolation>
+            <BottomSheet.Body
+              onPointerDownOutside={(e) => {
+                e.preventDefault();
+                close();
+              }}
+              className={cn(
+                'pointer-events-auto absolute inset-x-0 z-50 h-full max-h-[calc(100vh-64px)]',
+                activeSnapPoint === snapPoints[1] && 'h-full',
+                isTransitioning && 'pointer-events-none'
+              )}
+            >
+              <div ref={viewRef} className={cn('h-full', isMaxSnap && 'overflow-y-auto')}>
+                <motion.div
+                  className='absolute inset-0'
+                  style={{
+                    opacity: visibleOpacity,
+                    y: cardY,
+                    scale: scaleDown,
+                  }}
+                >
+                  <KindergartenCard {...currentItem} onBookmarkClick={onBookmarkClick} />
+                </motion.div>
+
+                <motion.div
+                  className={cn('pointer-events-none h-full bg-white', isMaxSnap && 'pointer-events-auto')}
+                  style={{
+                    opacity: hiddenOpacity,
+                    y: detailY,
+                    scale: scaleUp,
+                  }}
+                >
+                  <KindergartenDetail kindergartenId={currentItem.id} />
+                </motion.div>
+              </div>
+            </BottomSheet.Body>
+          </RemoveScroll>
+        </BottomSheet.Root>
+      </div>
+    </>
   );
 }

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/BasicSection.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/BasicSection.tsx
@@ -1,17 +1,23 @@
 'use client';
 
-import { ExternalLinksCard } from '@features/kindergarten-basic';
-import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { LocationMap, ServiceTagBadge } from '@features/kindergarten-basic';
-import { OperationHoursCard } from '@features/kindergarten-basic';
-import { useKindergartenBasicQuery } from '@features/kindergarten-basic';
-import { useStackNavigation } from '@shared/lib/bridge';
+import {
+  ExternalLinksCard,
+  LocationMap,
+  ServiceTagBadge,
+  OperationHoursCard,
+  useKindergartenBasicQuery,
+} from '@features/kindergarten-basic';
 import { SERVICE_ICON_MAP } from '@entities/kindergarten';
+import { useStackNavigation } from '@shared/lib/bridge';
 
-function BasicSection() {
+interface BasicSectionProps {
+  kindergartenId?: string;
+}
+
+function BasicSection({ kindergartenId }: BasicSectionProps) {
   const params = useParams<{ id: string }>();
-  const id = params?.id;
+  const id = kindergartenId ?? params?.id;
   const { push } = useStackNavigation();
 
   if (!id) throw new Error('Company ID is required for basic section');

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenNearSection.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenNearSection.tsx
@@ -1,15 +1,19 @@
 'use client';
 
 import React from 'react';
-import { KindergartenNearCard, useKindergartenNearQuery } from '@features/kindergarten-near';
 import { useParams } from 'next/navigation';
+import { KindergartenNearCard, useKindergartenNearQuery } from '@features/kindergarten-near';
 import { useCurrentLocation } from '@shared/lib/geolocation';
 
-const KindergartenNearSection = () => {
-  const params = useParams<{ id: string }>();
-  const id = params?.id;
+interface KindergartenNearSectionProps {
+  kindergartenId?: string;
+}
 
-  if (!id) throw new Error('Company ID is required for kindergarten near section');
+const KindergartenNearSection = ({ kindergartenId }: KindergartenNearSectionProps) => {
+  const params = useParams<{ id: string }>();
+  const id = kindergartenId ?? params?.id;
+
+  if (!id) throw new Error('Company ID is required for near section');
 
   const { position } = useCurrentLocation();
   const { lng, lat } = position || { lng: 126.883439, lat: 37.511281 };

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -1,28 +1,28 @@
 'use client';
 
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@knockdog/ui';
+import { Tabs, TabsList, TabsTrigger, TabsContent, Divider } from '@knockdog/ui';
 import { useRef, useState, useEffect } from 'react';
 
 import { MemoSection } from './MemoSection';
 import { ReviewSection } from './ReviewSection';
 import { PricingSection } from './PricingSection';
 import { BasicSection } from './BasicSection';
-import { Divider } from '@knockdog/ui';
 import { KindergartenNearSection } from './KindergartenNearSection';
 import { useUserStore } from '@entities/user';
 import { navigateToLogin } from '@shared/lib/bridge';
 
 interface KindergartenTabsProps {
-  scrollableDivRef: React.RefObject<HTMLDivElement | null>;
+  kindergartenId?: string;
+  scrollableDivRef?: React.RefObject<HTMLDivElement | null>;
 }
 
-function KindergartenTabs({ scrollableDivRef }: KindergartenTabsProps) {
+function KindergartenTabs({ kindergartenId, scrollableDivRef }: KindergartenTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
   const [activeTab, setActiveTab] = useState('기본정보');
   const isLoggedIn = useUserStore((state) => !!state.user);
 
   const handleScrollToDivider = () => {
-    if (!tabsRef.current) return;
+    if (!tabsRef.current || !scrollableDivRef?.current) return;
 
     const headerHeight = 66;
 
@@ -61,19 +61,19 @@ function KindergartenTabs({ scrollableDivRef }: KindergartenTabsProps) {
       </TabsList>
       <TabsContent value='기본정보'>
         <>
-          <BasicSection />
+          <BasicSection kindergartenId={kindergartenId} />
           {/* Divider */}
           <Divider size='thick' className='mb-12' />
 
           {/* 이 근처 다른 유치원은 어때요? */}
-          <KindergartenNearSection />
+          <KindergartenNearSection kindergartenId={kindergartenId} />
         </>
       </TabsContent>
       <TabsContent value='요금'>
-        <PricingSection />
+        <PricingSection kindergartenId={kindergartenId} />
       </TabsContent>
       <TabsContent value='후기'>
-        <ReviewSection onScrollTop={handleScrollToDivider} />
+        <ReviewSection kindergartenId={kindergartenId} onScrollTop={handleScrollToDivider} />
       </TabsContent>
       <TabsContent value='메모'>
         <MemoSection />

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/PricingSection.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/PricingSection.tsx
@@ -1,13 +1,15 @@
-import Link from 'next/link';
 import { useParams } from 'next/navigation';
-import { ProductTypeSection, PriceImageSlider } from '@features/pricing';
-import { usePricingQuery } from '@features/pricing';
+import { ProductTypeSection, PriceImageSlider, usePricingQuery } from '@features/pricing';
 import { useCallPhone } from '@shared/lib/device';
 import { useStackNavigation } from '@shared/lib/bridge';
 
-function PricingSection() {
+interface PricingSectionProps {
+  kindergartenId?: string;
+}
+
+function PricingSection({ kindergartenId }: PricingSectionProps) {
   const params = useParams<{ id: string }>();
-  const id = params?.id;
+  const id = kindergartenId ?? params?.id;
   const { push } = useStackNavigation();
 
   if (!id) throw new Error('Company ID is required for pricing section');
@@ -17,7 +19,7 @@ function PricingSection() {
   const { data: pricing } = usePricingQuery(id);
 
   return (
-    <div className='mb-12 mt-8 flex flex-col gap-12 px-4'>
+    <div className='mt-8 mb-12 flex flex-col gap-12 px-4'>
       {/* 상품유형 */}
       <ProductTypeSection productType={pricing?.productType ?? []} />
 

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/ReviewSection.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/ReviewSection.tsx
@@ -7,10 +7,6 @@ import { ReviewCard } from '@features/review';
 import { useReviewQuery } from '@features/review/api/useReviewQuery';
 import { useInfiniteScroll } from '@shared/lib';
 
-interface ReviewSectionProps {
-  onScrollTop?: () => void;
-}
-
 const Header = () => (
   <div className='mb-3 flex'>
     <Icon icon='NaverFill' className='mr-2 h-[22px] w-[22px]' />
@@ -36,9 +32,14 @@ const EmptyState = () => (
   </div>
 );
 
-export const ReviewSection = function ReviewSection({ onScrollTop }: ReviewSectionProps) {
+interface ReviewSectionProps {
+  kindergartenId?: string;
+  onScrollTop?: () => void;
+}
+
+export const ReviewSection = function ReviewSection({ kindergartenId, onScrollTop }: ReviewSectionProps) {
   const params = useParams<{ id: string }>();
-  const id = params?.id;
+  const id = kindergartenId ?? params?.id;
 
   if (!id) throw new Error('Company ID is required for review section');
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

마커 -> 바텀시트 -> 상세페이지 전환 애니메이션 구현

## 작업 내용

- 바텀시트 컨텐츠의 뷰포트를 참조하여 드래그 진행도를 계산하는 훅 추가 `useSheetDragProgress`
- `useSheetDragProgress`로 상세페이지 전환 애니메이션 추가

## 스크린샷

https://github.com/user-attachments/assets/8d2858e1-6510-4c72-a099-aad50e0dcbd4


## 논의할 점

마커를 클릭하면 `kindergarten/main/`, `kindergarten/basic` 두 API를 호출하고 있는데, 통합 또는 구조적인 개선이 필요합니다
