### PR TITLE
feat: 비교하기 페이지 주소 목록 useUserStore 적용 및 메모 필터링 활성화

### DIFF
--- a/apps/knockdog/app/compare/page.tsx
+++ b/apps/knockdog/app/compare/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Suspense, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Layout from '../(main)/layout';
 import { IconButton } from '@knockdog/ui';
 import { Header } from '@widgets/Header';
@@ -10,6 +9,7 @@ import type { CTag, ReferencePointType } from '@entities/compare';
 import { serializeCategories } from '@entities/compare';
 import type { DistanceInfo } from '@entities/bookmark';
 import { SafeArea } from '@shared/ui/safe-area';
+import { useStackNavigation } from '@shared/lib/bridge';
 
 // Helper: refPoint에 맞는 거리 정보 찾기
 function findDistanceByRefPoint(distances: DistanceInfo[], refPoint: ReferencePointType): DistanceInfo | undefined {
@@ -29,9 +29,9 @@ function parseDistanceToKm(distance: string): number {
  * 페이지
  * ========================= */
 export default function ComparePage() {
-  const router = useRouter();
   const [refPoint, setRefPoint] = useState<ReferencePointType>('HOME');
   const [showMemoOnly, setShowMemoOnly] = useState(false);
+  const { push } = useStackNavigation();
 
   const { data: bookmarks = [], isLoading, error } = useBookmarksQuery();
 
@@ -95,16 +95,17 @@ export default function ComparePage() {
     }
   };
 
-  /* =========================
-   * 비교 → compare-complete로 이동 (여기선 API 호출 안 함)
-   * ========================= */
-  const gotoCompare = () => {
+  const handleCompareButtonClick = () => {
     if (!canCompare) return;
     const ids = Object.values(selectedKindergartens)
       .map((kg) => kg!.id)
       .join(',');
-    // 스펙: GET + ids 파라미터 → compare-complete에서 실제 API 호출
-    router.push(`/compare-complete?ids=${encodeURIComponent(ids)}`);
+
+    push({ pathname: '/compare-complete', query: { ids } });
+  };
+
+  const handleListItemClick = (kindergartenId: string) => {
+    push({ pathname: `/kindergarten/${kindergartenId}` });
   };
 
   /* =========================
@@ -186,6 +187,7 @@ export default function ComparePage() {
                     distanceText={distanceText}
                     isSelected={selectedIds.left === kindergarten.id || selectedIds.right === kindergarten.id}
                     onToggle={() => toggleCheckbox(kindergarten.id)}
+                    onClick={() => handleListItemClick(kindergarten.id)}
                   />
                 );
               })}
@@ -229,7 +231,7 @@ export default function ComparePage() {
                 <button
                   type='button'
                   disabled={!canCompare}
-                  onClick={gotoCompare}
+                  onClick={handleCompareButtonClick}
                   className={`h-12 flex-1 rounded-2xl text-sm font-semibold transition-colors ${
                     canCompare ? 'bg-[#FF7A00] text-white' : 'cursor-not-allowed bg-gray-100 text-gray-400'
                   } `}

--- a/apps/knockdog/app/compare/page.tsx
+++ b/apps/knockdog/app/compare/page.tsx
@@ -67,33 +67,6 @@ export default function ComparePage() {
   const toggleShowMemoOnly = () => {
     setShowMemoOnly((prev) => !prev);
   };
-  /* =========================
-   * DEV 로그인 (토큰 갱신 → localStorage 저장)
-   * ========================= */
-  const handleDevLogin = async () => {
-    try {
-      const res = await fetch('/api/v0/auth/dev/1', {
-        method: 'GET',
-        headers: { accept: 'application/json;charset=UTF-8' },
-        cache: 'no-store',
-        credentials: 'include',
-      });
-
-      if (!res.ok) throw new Error(`로그인 실패: ${res.status}`);
-      const authHeader = res.headers.get('authorization') || res.headers.get('Authorization');
-      if (!authHeader) throw new Error('Authorization 헤더 없음');
-
-      const token = authHeader.replace(/^Bearer\s+/i, '').trim();
-      localStorage.setItem('accessToken', token);
-
-      alert('✅ DEV 로그인 성공! 토큰이 저장되었습니다.');
-      // 필요하면 새로고침
-      // window.location.reload();
-    } catch (err) {
-      console.error('DEV 로그인 중 오류:', err);
-      alert('❌ 로그인 실패. 콘솔을 확인하세요.');
-    }
-  };
 
   const handleCompareButtonClick = () => {
     if (!canCompare) return;
@@ -240,14 +213,6 @@ export default function ComparePage() {
                 </button>
               </div>
             </div>
-
-            {/* ✅ 왼쪽 하단 Dev 로그인 버튼 */}
-            <button
-              onClick={handleDevLogin}
-              className='fixed bottom-20 left-4 flex items-center gap-2 rounded-full bg-[#333] px-4 py-3 text-xs font-semibold text-white shadow-lg'
-            >
-              🔑 DEV 로그인
-            </button>
           </div>
         </Suspense>
       </SafeArea>

--- a/apps/knockdog/app/compare/page.tsx
+++ b/apps/knockdog/app/compare/page.tsx
@@ -59,12 +59,10 @@ export default function ComparePage() {
     });
   }, [bookmarks, refPoint]);
 
-  // TODO: Bookmark API 수정 후 반영하기
-  const filteredBookmarks = sortedBookmarks;
-  // const filteredBookmarks = useMemo(() => {
-  //   if (!showMemoOnly) return sortedBookmarks;
-  //   return sortedBookmarks.filter((kindergarten) => kindergarten.firstMemoAt != null);
-  // }, [sortedBookmarks, showMemoOnly]);
+  const filteredBookmarks = useMemo(() => {
+    if (!showMemoOnly) return sortedBookmarks;
+    return sortedBookmarks.filter((kindergarten) => !!kindergarten.memoAt);
+  }, [sortedBookmarks, showMemoOnly]);
 
   const toggleShowMemoOnly = () => {
     setShowMemoOnly((prev) => !prev);

--- a/apps/knockdog/src/entities/bookmark/index.ts
+++ b/apps/knockdog/src/entities/bookmark/index.ts
@@ -10,8 +10,11 @@ export {
   getBookmarksQueryOptions,
 } from './config/bookmarkQueryKeys';
 
+/** lib */
+export { formatMemoAt } from './lib/mappers';
+
 /** model */
-export type { BookmarkResponse, BookmarkItem, DistanceInfo } from './model/bookmark';
+export type { BookmarkResponse, BookmarkItem, LocalDateTime, DistanceInfo } from './model/bookmark';
 
 /** ui */
 export { BookmarkToggleIcon } from './ui/BookmarkToggleIcon';

--- a/apps/knockdog/src/entities/bookmark/lib/mappers.ts
+++ b/apps/knockdog/src/entities/bookmark/lib/mappers.ts
@@ -1,0 +1,11 @@
+import { LocalDateTime } from '../model/bookmark';
+
+/**
+ * [YYYY, MM, DD, HH, MM, SS, Nanoseconds] to YYYY.MM.DD
+ */
+function formatMemoAt(memoAt: LocalDateTime): string {
+  const [year, month, day] = memoAt;
+  return `${year}.${String(month).padStart(2, '0')}.${String(day).padStart(2, '0')}`;
+}
+
+export { formatMemoAt };

--- a/apps/knockdog/src/entities/bookmark/model/bookmark.ts
+++ b/apps/knockdog/src/entities/bookmark/model/bookmark.ts
@@ -10,8 +10,19 @@ export interface BookmarkItem {
   location: string;
   price: number;
   reviewCount: number;
+  memoAt?: LocalDateTime;
   distances: DistanceInfo[];
 }
+
+export type LocalDateTime = readonly [
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  nanosecond: number,
+];
 
 export interface DistanceInfo {
   referencePoint: 'HOME' | 'WORK' | 'OTHER';

--- a/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
@@ -5,7 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage, Icon } from '@knockdog/ui';
 import Image from 'next/image';
 import { cn } from '@knockdog/ui/lib';
 import type { BookmarkItem } from '@entities/bookmark';
-import { BookmarkToggleIcon } from '@entities/bookmark';
+import { BookmarkToggleIcon, formatMemoAt } from '@entities/bookmark';
 import type { CTag } from '@entities/compare';
 import { s3ToUrl, serializeCategories } from '@entities/compare';
 import { getShortAddress } from '@shared/lib';
@@ -26,6 +26,7 @@ function BookmarkedListItem({
   onClick,
 }: BookmarkedListItemProps) {
   const categoryText = serializeCategories(kindergarten.categories as CTag[]);
+  const memoDate = kindergarten.memoAt ? formatMemoAt(kindergarten.memoAt) : '';
 
   return (
     <div className={cn('flex min-w-0 flex-1 flex-col gap-3', className)} onClick={onClick}>
@@ -67,12 +68,13 @@ function BookmarkedListItem({
             </div>
 
             {/* 메모 배지 */}
-            {/* TODO: 북마크 API 응답에 메모 속성(e.g. memoUpdatedAt)이 추가된 후 수정 필요 */}
-            <div className='bg-fill-secondary-50 flex shrink-0 items-center gap-0.5 rounded-lg px-2 py-1'>
-              <Note className='text-fill-secondary-700 h-4 w-4' />
-              <span className='caption1-semibold text-text-primary'>2025.04.16</span>
-              <span className='caption1-semibold text-text-primary'>메모</span>
-            </div>
+            {memoDate && (
+              <div className='bg-fill-secondary-50 flex shrink-0 items-center gap-0.5 rounded-lg px-2 py-1'>
+                <Note className='text-fill-secondary-700 h-4 w-4' />
+                <span className='caption1-semibold text-text-primary'>{memoDate}</span>
+                <span className='caption1-semibold text-text-primary'>메모</span>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/apps/knockdog/src/features/bookmarked-list/ui/CompareListItem.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/CompareListItem.tsx
@@ -9,13 +9,20 @@ interface CompareListItemProps {
   isSelected: boolean;
   distanceText: string;
   onToggle: (checked: boolean) => void;
+  onClick: () => void;
 }
 
-function CompareListItem({ kindergarten, isSelected, onToggle, distanceText }: CompareListItemProps) {
+function CompareListItem({ kindergarten, isSelected, onToggle, distanceText, onClick }: CompareListItemProps) {
   return (
     <div className='flex items-start gap-3 bg-white p-5'>
       <Checkbox size='sm' checked={isSelected} onCheckedChange={onToggle} />
-      <BookmarkedListItem kindergarten={kindergarten} distanceText={distanceText} bookmarkDisabled className='p-0' />
+      <BookmarkedListItem
+        kindergarten={kindergarten}
+        distanceText={distanceText}
+        bookmarkDisabled
+        className='p-0'
+        onClick={onClick}
+      />
     </div>
   );
 }

--- a/apps/knockdog/src/features/bookmarked-list/ui/FilterBar.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/FilterBar.tsx
@@ -1,11 +1,7 @@
 import { Dropdown } from './DropDown';
-import { REFERENCE_POINT_TYPE, type ReferencePointType } from '@entities/compare';
-
-const REFERENCE_POINT_OPTIONS = Object.entries(REFERENCE_POINT_TYPE).map(([value, label]) => ({
-  value: value as ReferencePointType,
-  label,
-  displayLabel: `거리기준: ${label}`,
-}));
+import type { UserAddress } from '@entities/user';
+import { useUserStore } from '@entities/user';
+import type { ReferencePointType } from '@entities/compare';
 
 interface FilterBarProps {
   refPoint: ReferencePointType;
@@ -15,6 +11,17 @@ interface FilterBarProps {
 }
 
 export function FilterBar({ refPoint, onChangeRefPoint, showMemoOnly, onMemoToggle }: FilterBarProps) {
+  const user = useUserStore((state) => state.user);
+  const savedAddresses = user?.addresses;
+
+  const refPointOptions = (savedAddresses ?? [])
+    .filter((addr): addr is UserAddress & { alias: string } => !!addr.alias)
+    .map(({ type, alias }) => ({
+      value: type as ReferencePointType,
+      label: alias,
+      displayLabel: `거리기준: ${alias}`,
+    }));
+
   return (
     <div className='border-line-200 flex items-center justify-between border-y bg-white px-4 py-2'>
       <button
@@ -34,7 +41,7 @@ export function FilterBar({ refPoint, onChangeRefPoint, showMemoOnly, onMemoTogg
         <span className='body2-semibold text-text-primary'>메모</span>
       </button>
 
-      <Dropdown options={REFERENCE_POINT_OPTIONS} value={refPoint} onChange={onChangeRefPoint} />
+      <Dropdown options={refPointOptions} value={refPoint} onChange={onChangeRefPoint} />
     </div>
   );
 }

--- a/apps/knockdog/src/features/compare/ui/DistanceSection.tsx
+++ b/apps/knockdog/src/features/compare/ui/DistanceSection.tsx
@@ -4,15 +4,21 @@ import { DistanceSummary } from './DistanceSummary';
 import { compareDistancesByTransport } from '../lib/compareDistancesByTransport';
 import { findShortestTransport } from '../lib/findShortestTransport';
 import type { KindergartenComparison, TransportationType, ReferencePointType } from '@entities/compare';
-import { TRANSPORTATION_TYPE, Label, Badge, REFERENCE_POINT_TYPE } from '@entities/compare';
-
-const REFERENCE_POINT_OPTIONS = Object.entries(REFERENCE_POINT_TYPE).map(([value, label]) => ({
-  value: value as ReferencePointType,
-  label,
-}));
+import { TRANSPORTATION_TYPE, Label, Badge } from '@entities/compare';
+import type { UserAddress } from '@entities/user';
+import { useUserStore } from '@entities/user';
 
 export function DistanceSection({ left, right }: { left: KindergartenComparison; right: KindergartenComparison }) {
   const [referencePoint, setReferencePoint] = useState<ReferencePointType>('HOME');
+  const user = useUserStore((state) => state.user);
+  const savedAddresses = user?.addresses;
+
+  const refPointOptions = (savedAddresses ?? [])
+    .filter((addr): addr is UserAddress & { alias: string } => !!addr.alias)
+    .map(({ type, alias }) => ({
+      value: type as ReferencePointType,
+      label: alias,
+    }));
 
   const comparisonsByTransport = compareDistancesByTransport(left, right, referencePoint);
 
@@ -29,7 +35,7 @@ export function DistanceSection({ left, right }: { left: KindergartenComparison;
       <DistanceSummary
         shortestInfo={shortestInfo}
         referencePoint={referencePoint}
-        referencePointOptions={REFERENCE_POINT_OPTIONS}
+        referencePointOptions={refPointOptions}
         onReferencePointChange={setReferencePoint}
       />
       <div className='mt-7 flex flex-col gap-5'>

--- a/apps/knockdog/src/widgets/save-tabs/ui/FavoriteListSection.tsx
+++ b/apps/knockdog/src/widgets/save-tabs/ui/FavoriteListSection.tsx
@@ -39,12 +39,10 @@ function FavoriteListSection({ bookmarks }: { bookmarks: BookmarkItem[] }) {
     });
   }, [bookmarks, refPoint]);
 
-  // TODO: Bookmark API 수정 후 반영하기
-  const filteredBookmarks = sortedBookmarks;
-  // const filteredBookmarks = useMemo(() => {
-  //   if (!showMemoOnly) return sortedBookmarks;
-  //   return sortedBookmarks.filter((kindergarten) => kindergarten.firstMemoAt != null);
-  // }, [sortedBookmarks, showMemoOnly]);
+  const filteredBookmarks = useMemo(() => {
+    if (!showMemoOnly) return sortedBookmarks;
+    return sortedBookmarks.filter((kindergarten) => !!kindergarten.memoAt);
+  }, [sortedBookmarks, showMemoOnly]);
 
   const toggleShowMemoOnly = () => {
     setShowMemoOnly((prev) => !prev);


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교하기 페이지 주소 목록을 `useUserStore`에서 가져오도록 수정
- 북마크 목록 아이템에 메모 데이터 연동 및 메모 필터링 기능 활성화 
- 북마크 목록 아이템 클릭 시 유치원 상세 페이지로 이동 기능 추가 
- 비교하기 페이지 DEV 로그인 버튼 제거
