### PR TITLE
fix: FSM 전이 로직 수정으로 시군구 레벨 집계 마커 미표시 버그 해결

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
+++ b/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
@@ -212,15 +212,50 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
 
     case 'AGG_MARKER_CLICK': {
       const { bounds, center, zoom } = event.payload;
-      return {
+      const from = current.searchedLevel;
+      const to = getRegionLevel(zoom);
+
+      const nextState: SearchState = {
         ...current,
         center,
         zoom,
-        scope: 'bounds',
-        searchedLevel: 3,
-        searchBounds: bounds,
-        searchLock: 0,
       };
+
+      /**
+       * 우선순위 1)
+       * bounds + lock=1 상태는 자동 전이 금지
+       * (L3 → L2 줌아웃 포함)
+       */
+      // if (nextState.scope === 'bounds' && nextState.searchLock === 1) {
+      //   return nextState;
+      // }
+
+      /**
+       * 우선순위 2)
+       * L2 → L3 줌 진입 시 자동 bounds 확정, searchLock=0 유지
+       */
+      if (from === 2 && to === 3) {
+        return {
+          ...nextState,
+          scope: 'bounds',
+          searchedLevel: 3,
+          searchBounds: bounds,
+          searchLock: 0,
+        };
+      }
+      /**
+       * 우선순위 3)
+       * 나머지 레벨 경계 변화는 searchedLevel만 갱신
+       * → agg-only 트리거
+       */
+      if (from !== to) {
+        return {
+          ...nextState,
+          searchedLevel: to,
+        };
+      }
+
+      return nextState;
     }
 
     case 'RESEARCH_HERE': {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

키워드 검색 결과에서 특정 줌 레벨(L1 -> L2) 진입 시 집계 마커가 렌더링되지 않는 현상을 FSM전이 로직 수정을 통해 해결했습니다.
기존 로직이 L2 -> L3 전이 상황에 치중되어 있어, 하위 레벨에서 상위 레벨로의 전이(또는 그 반대) 시 상태 업데이트가 누락되는 엣지 케이스가 발생했습니다.
[버그 리포트
](https://jira-knockdog.atlassian.net/browse/KDDEV-265?atlOrigin=eyJpIjoiYWY3OTI3MmI5ZWIyNDkzMGFiMDMzMjEzOTM3M2U1MjYiLCJwIjoiaiJ9)
## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->
- FSM 전이 로직 보완
  - AGG_MARKER_CLICK 이벤트 발생 시, 현재 레벨과 타겟 레벨을 비교하는 가드 구문을 세분화했습니다.
  - 기존) L2 -> L3 케이스만 처리
  - 변경) L1(시도) -> L2(시군구) 전이 시에도 올바르게 전이되도록 로직 추가.
