### PR TITLE
refactor: 검색 상태 관리 아키텍처 리팩터링 및 fitBounds 처리 로직 변경

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/model/useSearchFilter.ts
+++ b/apps/knockdog/src/features/kindergarten-list/model/useSearchFilter.ts
@@ -32,8 +32,8 @@ interface UseSearchFilterReturn {
  * 검색 필터를 관리하는 훅
  */
 export function useSearchFilter(): UseSearchFilterReturn {
-  const { liveState, dispatch } = useSearchMachine();
-  const { filters } = liveState;
+  const { searchState, dispatch } = useSearchMachine();
+  const { filters } = searchState;
   const [resultCount, setResultCount] = useState<number | null>(null);
 
   const onChangeResultCount = useCallback((count: number | null) => {

--- a/apps/knockdog/src/features/kindergarten-map/api/searchQueries.ts
+++ b/apps/knockdog/src/features/kindergarten-map/api/searchQueries.ts
@@ -23,21 +23,6 @@ interface AggregationQueryParams {
   state: SearchState;
 }
 
-/**
- * 상태가 논리적으로 일관적인지 확인
- * - 필터나 검색어가 있으면 scope는 반드시 'global' 이어야 한다.
- */
-const isStateConsistent = (state: SearchState) => {
-  const hasQuery = state.query.trim().length > 0;
-  const hasFilters = state.filters.length > 0;
-
-  if (hasQuery || hasFilters) {
-    return state.scope === 'global';
-  }
-
-  return true;
-};
-
 export const searchQueries = {
   keys: {
     all: () => ['kindergarten'] as const,
@@ -85,8 +70,7 @@ export const searchQueries = {
         isValidCoord(params.state.refPoint) &&
         Number.isFinite(params.state.zoom) &&
         params.state.zoom > 0 &&
-        (params.state.scope === 'bounds' ? isValidBoundsSnapshot(params.state.searchBounds) : true) &&
-        isStateConsistent(params.state),
+        (params.state.scope === 'bounds' ? isValidBoundsSnapshot(params.state.searchBounds) : true),
       initialPageParam: 1,
       getNextPageParam: (lastPage: { paging: { hasNext: boolean; currentPage: number } }) => {
         return lastPage.paging.hasNext ? lastPage.paging.currentPage + 1 : undefined;
@@ -117,8 +101,7 @@ export const searchQueries = {
         isValidCoord(params.state.refPoint) &&
         Number.isFinite(params.state.zoom) &&
         params.state.zoom > 0 &&
-        (params.state.scope === 'bounds' ? isValidBoundsSnapshot(params.state.searchBounds) : true) &&
-        isStateConsistent(params.state),
+        (params.state.scope === 'bounds' ? isValidBoundsSnapshot(params.state.searchBounds) : true),
       staleTime: 5 * 60 * 1000,
       gcTime: 10 * 60 * 1000,
       retryOnMount: false,

--- a/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
+++ b/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
@@ -1,7 +1,7 @@
-import type { RegionLevel, SearchScope } from '../config/map';
+import { DEFAULT_MAP_ZOOM_LEVEL, type RegionLevel, type SearchScope } from '../config/map';
 import { getRegionLevel } from './markers';
-import type { FilterOption } from '@entities/kindergarten';
-import { isEqualCoord } from '@shared/lib';
+import { isEqualFilters, type FilterOption } from '@entities/kindergarten';
+import { isEqualBounds, isEqualCoord } from '@shared/lib';
 import type { Coord } from '@shared/types';
 
 /**
@@ -37,6 +37,19 @@ export interface SearchState {
   viewportBounds: BoundsSnapshot | null;
 }
 
+export interface UrlComparableState {
+  scope: SearchScope;
+  searchedLevel: RegionLevel;
+  query: string;
+  filters: FilterOption[];
+  refPoint: Coord | null;
+  searchBounds: BoundsSnapshot | null;
+  searchLock: 0 | 1;
+  searchCenter: Coord | null;
+  center: Coord | null;
+  zoom: number;
+}
+
 /**
  * 검색 FSM 이벤트
  *
@@ -46,6 +59,7 @@ export interface SearchState {
  */
 export type SearchEvent =
   | { type: 'ENTER' }
+  | { type: 'URL_SYNC'; payload: SearchState }
   | { type: 'QUERY_CHANGED'; query: string }
   | { type: 'FILTERS_CHANGED'; filters: FilterOption[] }
   | { type: 'CLEAR_QUERY' }
@@ -86,6 +100,21 @@ export interface SearchTransitionContext {
   refPointFromBase: Coord | null;
 }
 
+const QUERY_DEFAULT_ZOOM_LEVEL = 9;
+
+export interface SearchUrlStateInput {
+  scope: SearchScope | null;
+  searchedLevel: RegionLevel | null;
+  query: string | null;
+  filters: FilterOption[] | null;
+  refPoint: Coord | null;
+  bounds: BoundsSnapshot | null;
+  searchLock: 0 | 1 | null;
+  searchCenter: Coord | null;
+  center: Coord | null;
+  zoom: number | null;
+}
+
 /**
  * 검색 FSM 전이 함수 (순수 함수)
  *
@@ -101,26 +130,21 @@ export interface SearchTransitionContext {
  */
 export function transition(current: SearchState, event: SearchEvent, ctx: SearchTransitionContext): SearchState {
   switch (event.type) {
-    case 'ENTER': {
+    case 'URL_SYNC': {
+      const baseState = event.payload;
       const targetScope = deriveScope({
-        currentScope: current.scope,
-        query: current.query,
-        filters: current.filters,
+        currentScope: baseState.scope,
+        query: baseState.query,
+        filters: baseState.filters,
       });
 
-      const scoped = applyScopeTransition(current, targetScope);
+      const scoped = applyScopeTransition(baseState, targetScope);
 
-      const nextState: SearchState = {
-        ...scoped,
-        searchedLevel: getRegionLevel(current.zoom),
-        refPoint: ctx.refPointFromBase ?? current.refPoint,
-      };
-
-      if (!nextState.searchCenter) {
-        nextState.searchCenter = nextState.center;
+      if (!scoped.searchCenter) {
+        scoped.searchCenter = scoped.center;
       }
 
-      return nextState;
+      return scoped;
     }
 
     case 'QUERY_CHANGED': {
@@ -141,14 +165,18 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
 
     case 'REFPOINT_SET': {
       if (isEqualCoord(current.refPoint, event.refPoint)) return current;
-      // RefPoint가 변경되면 scope nearby로 전환
+      const targetScope = deriveScope({
+        currentScope: current.scope,
+        query: current.query,
+        filters: current.filters,
+      });
+      const scoped = applyScopeTransition(current, targetScope);
+
+      // RefPoint가 변경되면 scope 조건을 보정
       return {
-        ...current,
+        ...scoped,
         refPoint: event.refPoint,
         center: event.refPoint,
-        scope: 'nearby',
-        searchBounds: null,
-        searchLock: 0,
         searchCenter: event.refPoint,
       };
     }
@@ -274,6 +302,87 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
     default:
       return current;
   }
+}
+
+export function normalizeQuery(query: string | null) {
+  return query?.trim() ?? '';
+}
+
+export function normalizeUrlState(urlState: SearchUrlStateInput): UrlComparableState {
+  const query = normalizeQuery(urlState.query);
+  const filters = urlState.filters ?? [];
+  const hasQueryOrFilters = query.length > 0 || filters.length > 0;
+  const zoom = urlState.zoom ?? (hasQueryOrFilters ? QUERY_DEFAULT_ZOOM_LEVEL : DEFAULT_MAP_ZOOM_LEVEL);
+  const searchedLevel = urlState.searchedLevel ?? getRegionLevel(zoom);
+  const scope = urlState.scope ?? (urlState.bounds ? 'bounds' : 'nearby');
+
+  return {
+    scope,
+    searchedLevel,
+    query,
+    filters,
+    refPoint: urlState.refPoint ?? null,
+    searchBounds: urlState.bounds ?? null,
+    searchLock: urlState.searchLock ?? 0,
+    searchCenter: urlState.searchCenter ?? null,
+    center: urlState.center ?? null,
+    zoom,
+  };
+}
+
+export function toComparableState(state: SearchState): UrlComparableState {
+  return {
+    scope: state.scope,
+    searchedLevel: state.searchedLevel,
+    query: state.query,
+    filters: state.filters,
+    refPoint: state.refPoint,
+    searchBounds: state.searchBounds,
+    searchLock: state.searchLock,
+    searchCenter: state.searchCenter,
+    center: state.center,
+    zoom: state.zoom,
+  };
+}
+
+export function areComparableStatesEqual(left: UrlComparableState, right: UrlComparableState) {
+  if (left.scope !== right.scope) return false;
+  if (left.searchedLevel !== right.searchedLevel) return false;
+  if (left.query !== right.query) return false;
+  if (!isEqualFilters(left.filters, right.filters)) return false;
+  if (!isEqualCoord(left.refPoint, right.refPoint)) return false;
+  if (!isEqualBounds(left.searchBounds, right.searchBounds)) return false;
+  if (left.searchLock !== right.searchLock) return false;
+  if (!isEqualCoord(left.searchCenter, right.searchCenter)) return false;
+  if (!isEqualCoord(left.center, right.center)) return false;
+  if (left.zoom !== right.zoom) return false;
+  return true;
+}
+
+export function buildUrlSyncState(urlState: SearchUrlStateInput, refPointFromBase: Coord | null): SearchState {
+  const query = normalizeQuery(urlState.query);
+  const filters = urlState.filters ?? [];
+  const hasQueryOrFilters = query.length > 0 || filters.length > 0;
+  const zoom = urlState.zoom ?? (hasQueryOrFilters ? QUERY_DEFAULT_ZOOM_LEVEL : DEFAULT_MAP_ZOOM_LEVEL);
+  const searchedLevel = urlState.searchedLevel ?? getRegionLevel(zoom);
+  const scope = urlState.scope ?? (urlState.bounds ? 'bounds' : 'nearby');
+  const refPoint = urlState.refPoint ?? refPointFromBase ?? null;
+  const center = urlState.center ?? refPoint ?? null;
+  const searchCenter = urlState.searchCenter ?? center ?? refPoint ?? null;
+
+  return {
+    scope,
+    searchedLevel,
+    searchLock: urlState.searchLock ?? 0,
+    query,
+    filters,
+    refPoint,
+    searchBounds: urlState.bounds ?? null,
+    searchCenter,
+    center,
+    zoom,
+    viewportBounds: null,
+  };
 }
 
 /* =============================================================================

--- a/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
+++ b/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
@@ -14,12 +14,7 @@ export interface BoundsSnapshot {
   neLng: number;
 }
 
-/**
- * 통합 검색 상태
- * - 검색 확정 상태와 지도 UI 상태를 포함
- */
-export interface SearchState {
-  // --- 검색 확정 상태 (구 SearchSnapshot) ---
+export interface SearchSnapshot {
   scope: SearchScope;
   searchedLevel: RegionLevel;
   searchLock: 0 | 1;
@@ -27,15 +22,20 @@ export interface SearchState {
   filters: FilterOption[];
   refPoint: Coord | null;
   searchBounds: BoundsSnapshot | null;
-
-  // --- 커밋된 상태 ---
   searchCenter: Coord | null;
+}
 
-  // --- 지도 UI 상태 (구 MapSnapshot) ---
+export interface MapSnapshot {
   center: Coord | null;
   zoom: number;
   viewportBounds: BoundsSnapshot | null;
 }
+
+/**
+ * 통합 검색 상태
+ * - 검색 확정 상태와 지도 UI 상태를 포함
+ */
+export type SearchState = SearchSnapshot & MapSnapshot;
 
 export interface UrlComparableState {
   scope: SearchScope;
@@ -72,6 +72,7 @@ export type SearchEvent =
         center: Coord;
         zoom: number;
         viewportBounds: BoundsSnapshot | null;
+        source: 'user' | 'auto-fit';
       };
     }
   | {
@@ -131,20 +132,44 @@ export interface SearchUrlStateInput {
 export function transition(current: SearchState, event: SearchEvent, ctx: SearchTransitionContext): SearchState {
   switch (event.type) {
     case 'URL_SYNC': {
-      const baseState = event.payload;
-      const targetScope = deriveScope({
-        currentScope: baseState.scope,
-        query: baseState.query,
-        filters: baseState.filters,
-      });
+      const mergedState: SearchState = {
+        ...current,
+        ...event.payload,
+        viewportBounds: current.viewportBounds,
+      };
 
-      const scoped = applyScopeTransition(baseState, targetScope);
+      const queryChanged = mergedState.query !== current.query;
+      const filtersChanged = !isEqualFilters(mergedState.filters, current.filters);
 
-      if (!scoped.searchCenter) {
-        scoped.searchCenter = scoped.center;
+      let nextState = mergedState;
+
+      if (queryChanged) {
+        nextState = applyQueryTransition(nextState, mergedState.query);
       }
 
-      return scoped;
+      if (filtersChanged) {
+        nextState = applyFilterTransition(nextState, mergedState.filters);
+      }
+
+      if (!queryChanged && !filtersChanged) {
+        const targetScope = deriveScope({
+          currentScope: nextState.scope,
+          query: nextState.query,
+          filters: nextState.filters,
+        });
+        nextState = applyScopeTransition(nextState, targetScope);
+      }
+
+      const resolvedState = {
+        ...nextState,
+        refPoint: ctx.refPointFromBase ?? nextState.refPoint,
+      };
+
+      if (!resolvedState.searchCenter) {
+        resolvedState.searchCenter = resolvedState.center;
+      }
+
+      return resolvedState;
     }
 
     case 'QUERY_CHANGED': {
@@ -187,7 +212,7 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
     }
 
     case 'MAP_INTERACTION_END': {
-      const { center, zoom, viewportBounds } = event.payload;
+      const { center, zoom, viewportBounds, source } = event.payload;
       const from = current.searchedLevel;
       const to = getRegionLevel(zoom);
 
@@ -197,6 +222,11 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
         zoom,
         viewportBounds,
       };
+
+      // 자동 fitBounds 결과는 검색 레벨을 변경하지 않는다.
+      if (source === 'auto-fit') {
+        return nextState;
+      }
 
       /**
        * 우선순위 1)
@@ -382,6 +412,34 @@ export function buildUrlSyncState(urlState: SearchUrlStateInput, refPointFromBas
     center,
     zoom,
     viewportBounds: null,
+  };
+}
+
+export function pickSearchSnapshot(state: SearchState): SearchSnapshot {
+  return {
+    scope: state.scope,
+    searchedLevel: state.searchedLevel,
+    searchLock: state.searchLock,
+    query: state.query,
+    filters: state.filters,
+    refPoint: state.refPoint,
+    searchBounds: state.searchBounds,
+    searchCenter: state.searchCenter,
+  };
+}
+
+export function pickMapSnapshot(state: SearchState): MapSnapshot {
+  return {
+    center: state.center,
+    zoom: state.zoom,
+    viewportBounds: state.viewportBounds,
+  };
+}
+
+export function mergeSnapshots(search: SearchSnapshot, map: MapSnapshot): SearchState {
+  return {
+    ...search,
+    ...map,
   };
 }
 

--- a/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
+++ b/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
@@ -138,17 +138,21 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
         viewportBounds: current.viewportBounds,
       };
 
-      const queryChanged = mergedState.query !== current.query;
-      const filtersChanged = !isEqualFilters(mergedState.filters, current.filters);
+      const incomingSearch = pickSearchSnapshot(mergedState);
+      const incomingMap = pickMapSnapshot(mergedState);
 
-      let nextState = mergedState;
+      const queryChanged = incomingSearch.query !== current.query;
+      const filtersChanged = !isEqualFilters(incomingSearch.filters, current.filters);
+      const boundsChanged = !isEqualBounds(incomingSearch.searchBounds, current.searchBounds);
+
+      let nextState = mergeSnapshots(incomingSearch, incomingMap);
 
       if (queryChanged) {
-        nextState = applyQueryTransition(nextState, mergedState.query);
+        nextState = applyQueryTransition(nextState, incomingSearch.query);
       }
 
       if (filtersChanged) {
-        nextState = applyFilterTransition(nextState, mergedState.filters);
+        nextState = applyFilterTransition(nextState, incomingSearch.filters);
       }
 
       if (!queryChanged && !filtersChanged) {
@@ -158,6 +162,16 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
           filters: nextState.filters,
         });
         nextState = applyScopeTransition(nextState, targetScope);
+      }
+
+      if (!queryChanged && !filtersChanged && boundsChanged && incomingSearch.searchBounds) {
+        nextState = {
+          ...nextState,
+          scope: 'bounds',
+          searchBounds: incomingSearch.searchBounds,
+          searchLock: incomingSearch.searchLock,
+          searchCenter: incomingSearch.searchCenter ?? nextState.center,
+        };
       }
 
       const resolvedState = {

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
@@ -141,7 +141,7 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
       dispatch({ type: 'REFPOINT_SET', refPoint: basePoint });
     }
     prevBaseTypeRef.current = baseType;
-  }, [basePoint, baseType, committedState.refPoint?.lat, committedState.refPoint?.lng, dispatch]);
+  }, [basePoint, baseType, committedState.refPoint, dispatch]);
 
   useEffect(() => {
     /**
@@ -163,7 +163,7 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
     };
     // URL 입력은 FSM으로 반영하되, URL 재동기화는 건너뜁니다.
     dispatch({ type: 'URL_SYNC', payload: payloadState }, { skipUrlSync: true });
-  }, [dispatch, urlState]);
+  }, [dispatch, urlState, searchUrlState, mapUrlState]);
 
   const searchState = useMemo(
     () => mergeSnapshots(committedState, committedMapState),

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
@@ -36,7 +36,7 @@ interface DispatchOptions {
 export function SearchStateProvider({ children }: { children: ReactNode }) {
   const { coord: basePoint, type: baseType } = useBasePoint();
 
-  const { urlState, setUrlState } = useSearchUrlState();
+  const { urlState, searchUrlState, mapUrlState, setUrlState } = useSearchUrlState();
   const createInitialState = () => {
     const refPointFromBase = basePoint ?? null;
     const baseState = buildUrlSyncState(urlState, refPointFromBase);
@@ -105,6 +105,7 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
       const shouldCommitMap = isSearchChanged;
 
       if (isSearchChanged) {
+        console.log('[SearchMachine] State changed:', { event, prev: prevState, next });
         setCommittedState(nextSearch);
         // URL_SYNC 직후 들어오는 이벤트가 최신 검색 상태를 사용하도록 보장한다.
         committedStateRef.current = nextSearch;
@@ -154,7 +155,8 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
     }
 
     const refPointFromBase = basePointRef.current ?? null;
-    const baseState = buildUrlSyncState(urlState, refPointFromBase);
+    // URL 파라미터를 search/map으로 분리해 FSM 입력을 구성한다.
+    const baseState = buildUrlSyncState({ ...searchUrlState, ...mapUrlState }, refPointFromBase);
     const payloadState = {
       ...baseState,
       viewportBounds: liveStateRef.current.viewportBounds,

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
@@ -84,6 +84,8 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
       const nextSearch = pickSearchSnapshot(next);
       const nextMap = pickMapSnapshot(next);
       setLiveState(nextMap);
+      // 연속 이벤트에서도 최신 map 상태를 즉시 참조하도록 업데이트한다.
+      liveStateRef.current = nextMap;
 
       const isSearchChanged =
         nextSearch.scope !== prevSearch.scope ||
@@ -103,8 +105,9 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
       const shouldCommitMap = isSearchChanged;
 
       if (isSearchChanged) {
-        console.log('[SearchMachine] State changed:', { event, prev: prevState, next });
         setCommittedState(nextSearch);
+        // URL_SYNC 직후 들어오는 이벤트가 최신 검색 상태를 사용하도록 보장한다.
+        committedStateRef.current = nextSearch;
       }
 
       if (shouldCommitMap) {
@@ -145,9 +148,7 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
      * URL_SYNC는 urlState를 다시 쓰지 않고 liveState를 재정렬한다.
      */
     const urlComparable = normalizeUrlState(urlState);
-    const committedComparable = toComparableState(
-      mergeSnapshots(committedStateRef.current, liveStateRef.current)
-    );
+    const committedComparable = toComparableState(mergeSnapshots(committedStateRef.current, liveStateRef.current));
     if (areComparableStatesEqual(urlComparable, committedComparable)) {
       return;
     }

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
@@ -1,4 +1,13 @@
-import { type SearchEvent, type SearchState, type SearchTransitionContext, transition } from '../lib/searchMachine';
+import {
+  areComparableStatesEqual,
+  buildUrlSyncState,
+  normalizeUrlState,
+  toComparableState,
+  type SearchEvent,
+  type SearchState,
+  type SearchTransitionContext,
+  transition,
+} from '../lib/searchMachine';
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useSearchUrlState } from './useSearchUrlState';
 import { isEqualFilters } from '@entities/kindergarten';
@@ -9,26 +18,38 @@ import type { Coord } from '@shared/types';
 interface SearchMachineContextValue {
   liveState: SearchState;
   committedState: SearchState;
-  dispatch: (event: SearchEvent) => void;
+  dispatch: (event: SearchEvent, options?: DispatchOptions) => void;
 }
 
 const SearchMachineContext = createContext<SearchMachineContextValue | null>(null);
 
+interface DispatchOptions {
+  skipUrlSync?: boolean;
+}
+
 export function SearchStateProvider({ children }: { children: ReactNode }) {
   const { coord: basePoint, type: baseType } = useBasePoint();
 
-  const { state: committedState, commitState } = useSearchUrlState();
-  const [liveState, setLiveState] = useState<SearchState>(committedState);
+  const { urlState, setUrlState } = useSearchUrlState();
+  const createInitialState = () => {
+    const refPointFromBase = basePoint ?? null;
+    const baseState = buildUrlSyncState(urlState, refPointFromBase);
+    return transition(baseState, { type: 'URL_SYNC', payload: baseState }, { refPointFromBase });
+  };
+  const [committedState, setCommittedState] = useState<SearchState>(createInitialState);
+  const [liveState, setLiveState] = useState<SearchState>(createInitialState);
 
   const stateRef = useRef(liveState);
-  const commitStateRef = useRef(commitState);
+  const committedStateRef = useRef(committedState);
   const basePointRef = useRef<Coord | null>(basePoint);
+  const urlStateRef = useRef(urlState);
 
   useEffect(() => {
     stateRef.current = liveState;
-    commitStateRef.current = commitState;
+    committedStateRef.current = committedState;
     basePointRef.current = basePoint;
-  }, [liveState, commitState, basePoint]);
+    urlStateRef.current = urlState;
+  }, [liveState, committedState, basePoint, urlState]);
 
   const buildTransitionContext = useCallback((): SearchTransitionContext => {
     const currentState = stateRef.current;
@@ -38,11 +59,12 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const dispatch = useCallback(
-    (event: SearchEvent) => {
+    (event: SearchEvent, options?: DispatchOptions) => {
       const prev = stateRef.current;
       const ctx = buildTransitionContext();
+      const baseState = event.type === 'URL_SYNC' ? event.payload : prev;
 
-      const next = transition(prev, event, ctx);
+      const next = transition(baseState, event, ctx);
 
       // 로컬 상태 즉시 업데이트
       setLiveState(next);
@@ -58,15 +80,19 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
         !isEqualCoord(next.searchCenter, prev.searchCenter);
 
       if (isStateChanged) {
-        commitStateRef.current(next);
+        console.log('[SearchMachine] State changed:', { event, prev, next });
+        setCommittedState(next);
+        if (!options?.skipUrlSync) {
+          const nextComparable = toComparableState(next);
+          const urlComparable = normalizeUrlState(urlStateRef.current);
+          if (!areComparableStatesEqual(nextComparable, urlComparable)) {
+            setUrlState(next);
+          }
+        }
       }
     },
-    [buildTransitionContext]
+    [buildTransitionContext, setUrlState]
   );
-
-  // useEffect(() => {
-  //   dispatch({ type: 'ENTER' });
-  // }, [dispatch]);
 
   const prevBaseTypeRef = useRef(baseType);
   useEffect(() => {
@@ -84,6 +110,19 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
     }
     prevBaseTypeRef.current = baseType;
   }, [basePoint, baseType, liveState.refPoint?.lat, liveState.refPoint?.lng, dispatch]);
+
+  useEffect(() => {
+    const urlComparable = normalizeUrlState(urlState);
+    const committedComparable = toComparableState(committedStateRef.current);
+    if (areComparableStatesEqual(urlComparable, committedComparable)) {
+      return;
+    }
+
+    const refPointFromBase = basePointRef.current ?? null;
+    const baseState = buildUrlSyncState(urlState, refPointFromBase);
+    // URL 입력은 FSM으로 반영하되, URL 재동기화는 건너뜁니다.
+    dispatch({ type: 'URL_SYNC', payload: baseState }, { skipUrlSync: true });
+  }, [dispatch, urlState]);
 
   const value = useMemo<SearchMachineContextValue>(
     () => ({

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchMachine.tsx
@@ -1,9 +1,14 @@
 import {
   areComparableStatesEqual,
   buildUrlSyncState,
+  mergeSnapshots,
   normalizeUrlState,
+  pickMapSnapshot,
+  pickSearchSnapshot,
   toComparableState,
+  type MapSnapshot,
   type SearchEvent,
+  type SearchSnapshot,
   type SearchState,
   type SearchTransitionContext,
   transition,
@@ -16,8 +21,9 @@ import { isEqualBounds, isEqualCoord } from '@shared/lib';
 import type { Coord } from '@shared/types';
 
 interface SearchMachineContextValue {
-  liveState: SearchState;
-  committedState: SearchState;
+  liveState: MapSnapshot;
+  committedState: SearchSnapshot;
+  searchState: SearchState;
   dispatch: (event: SearchEvent, options?: DispatchOptions) => void;
 }
 
@@ -36,23 +42,25 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
     const baseState = buildUrlSyncState(urlState, refPointFromBase);
     return transition(baseState, { type: 'URL_SYNC', payload: baseState }, { refPointFromBase });
   };
-  const [committedState, setCommittedState] = useState<SearchState>(createInitialState);
-  const [liveState, setLiveState] = useState<SearchState>(createInitialState);
+  const initialState = createInitialState();
+  const [committedState, setCommittedState] = useState<SearchSnapshot>(() => pickSearchSnapshot(initialState));
+  const [committedMapState, setCommittedMapState] = useState<MapSnapshot>(() => pickMapSnapshot(initialState));
+  const [liveState, setLiveState] = useState<MapSnapshot>(() => pickMapSnapshot(initialState));
 
-  const stateRef = useRef(liveState);
+  const liveStateRef = useRef(liveState);
   const committedStateRef = useRef(committedState);
   const basePointRef = useRef<Coord | null>(basePoint);
   const urlStateRef = useRef(urlState);
 
   useEffect(() => {
-    stateRef.current = liveState;
+    liveStateRef.current = liveState;
     committedStateRef.current = committedState;
     basePointRef.current = basePoint;
     urlStateRef.current = urlState;
-  }, [liveState, committedState, basePoint, urlState]);
+  }, [liveState, committedState, committedMapState, basePoint, urlState]);
 
   const buildTransitionContext = useCallback((): SearchTransitionContext => {
-    const currentState = stateRef.current;
+    const currentState = mergeSnapshots(committedStateRef.current, liveStateRef.current);
     return {
       refPointFromBase: currentState.refPoint ?? basePointRef.current ?? null,
     };
@@ -60,34 +68,54 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
 
   const dispatch = useCallback(
     (event: SearchEvent, options?: DispatchOptions) => {
-      const prev = stateRef.current;
+      /**
+       * liveState ↔ urlState 동기화 규칙
+       * - dispatch는 항상 liveState를 갱신한다.
+       * - map/search 변화가 있으면 urlState에 반영한다.
+       * - urlState 변경은 URL_SYNC로 유입되어 liveState를 다시 맞춘다.
+       */
+      const prevSearch = committedStateRef.current;
+      const prevMap = liveStateRef.current;
+      const prevState = mergeSnapshots(prevSearch, prevMap);
       const ctx = buildTransitionContext();
-      const baseState = event.type === 'URL_SYNC' ? event.payload : prev;
-
-      const next = transition(baseState, event, ctx);
+      const next = transition(prevState, event, ctx);
 
       // 로컬 상태 즉시 업데이트
-      setLiveState(next);
+      const nextSearch = pickSearchSnapshot(next);
+      const nextMap = pickMapSnapshot(next);
+      setLiveState(nextMap);
 
-      const isStateChanged =
-        next.scope !== prev.scope ||
-        next.searchedLevel !== prev.searchedLevel ||
-        next.query !== prev.query ||
-        !isEqualFilters(next.filters, prev.filters) ||
-        !isEqualCoord(next.refPoint, prev.refPoint) ||
-        !isEqualBounds(next.searchBounds, prev.searchBounds) ||
-        next.searchLock !== prev.searchLock ||
-        !isEqualCoord(next.searchCenter, prev.searchCenter);
+      const isSearchChanged =
+        nextSearch.scope !== prevSearch.scope ||
+        nextSearch.searchedLevel !== prevSearch.searchedLevel ||
+        nextSearch.query !== prevSearch.query ||
+        !isEqualFilters(nextSearch.filters, prevSearch.filters) ||
+        !isEqualCoord(nextSearch.refPoint, prevSearch.refPoint) ||
+        !isEqualBounds(nextSearch.searchBounds, prevSearch.searchBounds) ||
+        nextSearch.searchLock !== prevSearch.searchLock ||
+        !isEqualCoord(nextSearch.searchCenter, prevSearch.searchCenter);
 
-      if (isStateChanged) {
-        console.log('[SearchMachine] State changed:', { event, prev, next });
-        setCommittedState(next);
-        if (!options?.skipUrlSync) {
-          const nextComparable = toComparableState(next);
-          const urlComparable = normalizeUrlState(urlStateRef.current);
-          if (!areComparableStatesEqual(nextComparable, urlComparable)) {
-            setUrlState(next);
-          }
+      const isMapChanged =
+        nextMap.zoom !== prevMap.zoom ||
+        !isEqualCoord(nextMap.center, prevMap.center) ||
+        !isEqualBounds(nextMap.viewportBounds, prevMap.viewportBounds);
+
+      const shouldCommitMap = isSearchChanged;
+
+      if (isSearchChanged) {
+        console.log('[SearchMachine] State changed:', { event, prev: prevState, next });
+        setCommittedState(nextSearch);
+      }
+
+      if (shouldCommitMap) {
+        setCommittedMapState(nextMap);
+      }
+
+      if ((isSearchChanged || isMapChanged) && !options?.skipUrlSync) {
+        const nextComparable = toComparableState(next);
+        const urlComparable = normalizeUrlState(urlStateRef.current);
+        if (!areComparableStatesEqual(nextComparable, urlComparable)) {
+          setUrlState(next);
         }
       }
     },
@@ -98,39 +126,55 @@ export function SearchStateProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!basePoint) return;
 
-    if (!liveState.refPoint) {
+    if (!committedState.refPoint) {
       dispatch({ type: 'REFPOINT_SET', refPoint: basePoint });
       prevBaseTypeRef.current = baseType;
       return;
     }
 
     const baseTypeChanged = prevBaseTypeRef.current !== baseType;
-    if (baseTypeChanged && !isEqualCoord(liveState.refPoint, basePoint)) {
+    if (baseTypeChanged && !isEqualCoord(committedState.refPoint, basePoint)) {
       dispatch({ type: 'REFPOINT_SET', refPoint: basePoint });
     }
     prevBaseTypeRef.current = baseType;
-  }, [basePoint, baseType, liveState.refPoint?.lat, liveState.refPoint?.lng, dispatch]);
+  }, [basePoint, baseType, committedState.refPoint?.lat, committedState.refPoint?.lng, dispatch]);
 
   useEffect(() => {
+    /**
+     * URL 변경(뒤로가기/외부 진입)을 FSM으로 흡수한다.
+     * URL_SYNC는 urlState를 다시 쓰지 않고 liveState를 재정렬한다.
+     */
     const urlComparable = normalizeUrlState(urlState);
-    const committedComparable = toComparableState(committedStateRef.current);
+    const committedComparable = toComparableState(
+      mergeSnapshots(committedStateRef.current, liveStateRef.current)
+    );
     if (areComparableStatesEqual(urlComparable, committedComparable)) {
       return;
     }
 
     const refPointFromBase = basePointRef.current ?? null;
     const baseState = buildUrlSyncState(urlState, refPointFromBase);
+    const payloadState = {
+      ...baseState,
+      viewportBounds: liveStateRef.current.viewportBounds,
+    };
     // URL 입력은 FSM으로 반영하되, URL 재동기화는 건너뜁니다.
-    dispatch({ type: 'URL_SYNC', payload: baseState }, { skipUrlSync: true });
+    dispatch({ type: 'URL_SYNC', payload: payloadState }, { skipUrlSync: true });
   }, [dispatch, urlState]);
+
+  const searchState = useMemo(
+    () => mergeSnapshots(committedState, committedMapState),
+    [committedState, committedMapState]
+  );
 
   const value = useMemo<SearchMachineContextValue>(
     () => ({
       liveState,
       committedState,
+      searchState,
       dispatch,
     }),
-    [liveState, committedState, dispatch]
+    [liveState, committedState, searchState, dispatch]
   );
 
   return <SearchMachineContext.Provider value={value}>{children}</SearchMachineContext.Provider>;

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchQuery.ts
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchQuery.ts
@@ -11,7 +11,7 @@ import { tokenUtils } from '@shared/utils';
 import { memoQueries } from '@entities/memo';
 
 export function useSearchListQuery() {
-  const { committedState } = useSearchMachine();
+  const { searchState } = useSearchMachine();
   const { rank } = useListOptionsUrlState();
   const user = useUserStore((s) => s.user);
   const isLoggedIn = !!user || tokenUtils.hasAccessToken();
@@ -27,7 +27,7 @@ export function useSearchListQuery() {
   });
 
   const searchListOptions = searchQueries.searchList({
-    state: committedState,
+    state: searchState,
     rank,
     bookmarks: isLoggedIn ? bookmarksQuery.data : [],
     memos: isLoggedIn ? memoListQuery.data?.memos : [],
@@ -66,9 +66,11 @@ export function useSearchListQuery() {
 }
 
 export function useAggregationQuery() {
-  const { committedState } = useSearchMachine();
+  const { searchState } = useSearchMachine();
 
-  const { data, isLoading, isFetching } = useQuery(searchQueries.aggregation({ state: committedState }));
+  const { data, dataUpdatedAt, isLoading, isFetching } = useQuery(
+    searchQueries.aggregation({ state: searchState })
+  );
 
   const aggregation = useMemo(() => {
     if (!data?.aggregations) return [];
@@ -83,6 +85,7 @@ export function useAggregationQuery() {
   return {
     aggregation,
     geoBounds,
+    dataUpdatedAt,
     isLoading,
     isFetching,
   };

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchUrlState.ts
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchUrlState.ts
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { createParser, useQueryStates } from 'nuqs';
 import type { BoundsSnapshot, SearchState, SearchUrlStateInput } from '../lib/searchMachine';
-import type { Coord } from '@shared/types';
+import type { RegionLevel, SearchScope } from '../config/map';
 import type { FilterOption } from '@entities/kindergarten';
 import { FILTER_OPTIONS } from '@entities/kindergarten';
-import type { RegionLevel, SearchScope } from '../config/map';
+import type { Coord } from '@shared/types';
 
 type SearchLock = 0 | 1;
 
@@ -99,7 +99,7 @@ const SEARCH_LOCK_PARSER = createParser<SearchLock | null>({
     if (value === '0') return 0;
     return null;
   },
-  serialize: (value) => (value === 1 ? '1' : ''),
+  serialize: (value) => (value === 1 ? '1' : '0'),
 });
 
 const ZOOM_PARSER = createParser<number | null>({
@@ -154,8 +154,42 @@ export function useSearchUrlState() {
     [setUrlState]
   );
 
+  const searchUrlState = useMemo(
+    () => ({
+      scope: urlState.scope,
+      searchedLevel: urlState.searchedLevel,
+      query: urlState.query,
+      filters: urlState.filters,
+      refPoint: urlState.refPoint,
+      bounds: urlState.bounds,
+      searchLock: urlState.searchLock,
+      searchCenter: urlState.searchCenter,
+    }),
+    [
+      urlState.scope,
+      urlState.searchedLevel,
+      urlState.query,
+      urlState.filters,
+      urlState.refPoint,
+      urlState.bounds,
+      urlState.searchLock,
+      urlState.searchCenter,
+    ]
+  );
+
+  // 지도 UI 관련 파라미터는 map 전용으로 분리한다.
+  const mapUrlState = useMemo(
+    () => ({
+      center: urlState.center,
+      zoom: urlState.zoom,
+    }),
+    [urlState.center, urlState.zoom]
+  );
+
   return {
-    urlState: urlState as SearchUrlState,
+    urlState,
+    searchUrlState,
+    mapUrlState,
     setUrlState: setState,
   };
 }

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchUrlState.ts
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchUrlState.ts
@@ -99,7 +99,7 @@ const SEARCH_LOCK_PARSER = createParser<SearchLock | null>({
     if (value === '0') return 0;
     return null;
   },
-  serialize: (value) => (value === 1 ? '1' : '0'),
+  serialize: (value) => (value === 1 ? '1' : value === 0 ? '0' : ''),
 });
 
 const ZOOM_PARSER = createParser<number | null>({

--- a/apps/knockdog/src/features/kindergarten-map/model/useSearchUrlState.ts
+++ b/apps/knockdog/src/features/kindergarten-map/model/useSearchUrlState.ts
@@ -1,12 +1,14 @@
-import { useCallback, useMemo } from 'react';
-import { createParser, parseAsInteger, parseAsString, useQueryStates } from 'nuqs';
-import type { BoundsSnapshot, SearchState } from '../lib/searchMachine';
+import { useCallback } from 'react';
+import { createParser, useQueryStates } from 'nuqs';
+import type { BoundsSnapshot, SearchState, SearchUrlStateInput } from '../lib/searchMachine';
 import type { Coord } from '@shared/types';
 import type { FilterOption } from '@entities/kindergarten';
 import { FILTER_OPTIONS } from '@entities/kindergarten';
-import { DEFAULT_MAP_ZOOM_LEVEL, type RegionLevel, type SearchScope } from '../config/map';
+import type { RegionLevel, SearchScope } from '../config/map';
 
 type SearchLock = 0 | 1;
+
+export type SearchUrlState = SearchUrlStateInput;
 
 const isSearchScope = (value: string): value is SearchScope => {
   return value === 'nearby' || value === 'global' || value === 'bounds';
@@ -25,25 +27,34 @@ const SCOPE_PARSER = createParser<SearchScope | null>({
   },
 });
 
-const SEARCHED_LEVEL_PARSER = createParser<RegionLevel>({
+const SEARCHED_LEVEL_PARSER = createParser<RegionLevel | null>({
   parse: (value: string) => {
     const parsed = Number.parseInt(value, 10);
     if (parsed === 1 || parsed === 2 || parsed === 3) return parsed;
-    return 1;
+    return null;
   },
-  serialize: (value) => String(value),
+  serialize: (value) => (value ? String(value) : ''),
 });
 
 const isFilterOption = (value: string): value is FilterOption => {
   return Object.prototype.hasOwnProperty.call(FILTER_OPTIONS, value);
 };
 
-const FILTERS_PARSER = createParser<FilterOption[]>({
+const FILTERS_PARSER = createParser<FilterOption[] | null>({
   parse: (value: string) => {
-    if (!value) return [];
-    return value.split(',').filter(isFilterOption);
+    if (!value) return null;
+    const parsed = value.split(',').filter(isFilterOption);
+    return parsed.length > 0 ? parsed : null;
   },
-  serialize: (value) => value.join(','),
+  serialize: (value) => (value?.length ? value.join(',') : ''),
+});
+
+const QUERY_PARSER = createParser<string | null>({
+  parse: (value: string) => {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  },
+  serialize: (value) => value || '',
 });
 
 const COORD_PARSER = createParser<Coord | null>({
@@ -82,19 +93,26 @@ const BOUNDS_PARSER = createParser<BoundsSnapshot | null>({
     value ? `${value.swLat},${value.swLng},${value.neLat},${value.neLng}` : '',
 });
 
-const SEARCH_LOCK_PARSER = createParser<SearchLock>({
+const SEARCH_LOCK_PARSER = createParser<SearchLock | null>({
   parse: (value: string) => {
-    return value === '1' ? 1 : 0;
+    if (value === '1') return 1;
+    if (value === '0') return 0;
+    return null;
   },
-  serialize: (value) => (value === 1 ? '1' : '0'),
+  serialize: (value) => (value === 1 ? '1' : ''),
+});
+
+const ZOOM_PARSER = createParser<number | null>({
+  parse: (value: string) => {
+    if (!value) return null;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  },
+  serialize: (value) => (value != null ? String(value) : ''),
 });
 
 /**
  * SearchState(통합 검색상태) URL 상태를 관리하는 훅
- *
- * @description
- * ✅ useQueryStates를 사용하여 모든 검색/지도 관련 URL 파라미터를 한 번에 관리
- * - 여러 파라미터 동시 업데이트 시 배칭 처리로 URL 업데이트 1회만 발생
  *
  * 관리하는 URL 파라미터:
  * - scope, searchedLevel, query, filters, refPoint, bounds, searchLock
@@ -104,27 +122,19 @@ export function useSearchUrlState() {
   const [urlState, setUrlState] = useQueryStates({
     // 검색 상태
     scope: SCOPE_PARSER,
-    searchedLevel: SEARCHED_LEVEL_PARSER.withDefault(3),
-    query: parseAsString.withDefault(''),
-    filters: FILTERS_PARSER.withDefault([]),
+    searchedLevel: SEARCHED_LEVEL_PARSER,
+    query: QUERY_PARSER,
+    filters: FILTERS_PARSER,
     refPoint: COORD_PARSER,
     bounds: BOUNDS_PARSER,
-    searchLock: SEARCH_LOCK_PARSER.withDefault(0),
+    searchLock: SEARCH_LOCK_PARSER,
     searchCenter: COORD_PARSER,
     // 지도 상태
     center: COORD_PARSER,
-    zoom: parseAsInteger.withDefault(DEFAULT_MAP_ZOOM_LEVEL),
+    zoom: ZOOM_PARSER,
   });
 
-  /**
-   * SearchState 전체를 한 번에 커밋 (배칭)
-   *
-   * @description
-   * FSM 전이 결과를 URL에 원자적으로 반영합니다.
-   *
-   * @param nextState - 커밋할 SearchState
-   */
-  const commitState = useCallback(
+  const setState = useCallback(
     (nextState: SearchState) => {
       const updatePayload = {
         scope: nextState.scope,
@@ -139,160 +149,13 @@ export function useSearchUrlState() {
         zoom: nextState.zoom,
       };
 
-      const promise = setUrlState(updatePayload);
-
-      return promise.then((search) => {
-        // nuqs의 Promise resolve 시점의 search가 빈 경우가 있거나,
-        // 일부 값이 누락될 수 있으므로 updatePayload에서 직접 URLSearchParams를 구성
-        const expectedSearchParams = new URLSearchParams();
-
-        // updatePayload의 각 값을 직접 serialize하여 URLSearchParams 구성
-        if (updatePayload.scope !== null && updatePayload.scope !== undefined) {
-          const serialized = SCOPE_PARSER.serialize(updatePayload.scope);
-          if (serialized) expectedSearchParams.set('scope', serialized);
-        }
-        if (updatePayload.searchedLevel !== null && updatePayload.searchedLevel !== undefined) {
-          expectedSearchParams.set('searchedLevel', String(updatePayload.searchedLevel));
-        }
-        if (updatePayload.query !== null && updatePayload.query !== undefined && updatePayload.query !== '') {
-          expectedSearchParams.set('query', updatePayload.query);
-        }
-        if (
-          updatePayload.filters !== null &&
-          Array.isArray(updatePayload.filters) &&
-          updatePayload.filters.length > 0
-        ) {
-          expectedSearchParams.set('filters', updatePayload.filters.join(','));
-        }
-        if (updatePayload.refPoint !== null && updatePayload.refPoint !== undefined) {
-          const serialized = COORD_PARSER.serialize(updatePayload.refPoint);
-          if (serialized) expectedSearchParams.set('refPoint', serialized);
-        }
-        if (updatePayload.bounds !== null && updatePayload.bounds !== undefined) {
-          const serialized = BOUNDS_PARSER.serialize(updatePayload.bounds);
-          if (serialized) expectedSearchParams.set('bounds', serialized);
-        }
-        if (
-          updatePayload.searchLock !== null &&
-          updatePayload.searchLock !== undefined &&
-          updatePayload.searchLock !== 0
-        ) {
-          expectedSearchParams.set('searchLock', '1');
-        }
-        if (updatePayload.searchCenter !== null && updatePayload.searchCenter !== undefined) {
-          const serialized = COORD_PARSER.serialize(updatePayload.searchCenter);
-          if (serialized) expectedSearchParams.set('searchCenter', serialized);
-        }
-        if (updatePayload.center !== null && updatePayload.center !== undefined) {
-          const serialized = COORD_PARSER.serialize(updatePayload.center);
-          if (serialized) expectedSearchParams.set('center', serialized);
-        }
-        if (
-          updatePayload.zoom !== null &&
-          updatePayload.zoom !== undefined &&
-          updatePayload.zoom !== DEFAULT_MAP_ZOOM_LEVEL
-        ) {
-          expectedSearchParams.set('zoom', String(updatePayload.zoom));
-        }
-
-        // nuqs가 실제 URL을 업데이트하지 않는 경우를 대비하여
-        // requestAnimationFrame으로 지연 후 실제 URL을 확인하고 필요시 직접 업데이트
-        return new Promise<URLSearchParams>((resolve) => {
-          requestAnimationFrame(() => {
-            if (typeof window === 'undefined') {
-              resolve(expectedSearchParams);
-              return;
-            }
-
-            const actualSearchParams = new URLSearchParams(window.location.search);
-
-            // nuqs가 관리하는 파라미터들만 확인 (다른 시스템에서 관리하는 파라미터는 무시)
-            const nuqsParams = [
-              'scope',
-              'searchedLevel',
-              'query',
-              'filters',
-              'refPoint',
-              'bounds',
-              'searchLock',
-              'searchCenter',
-              'center',
-              'zoom',
-            ];
-            let needsUpdate = false;
-            const mismatches: string[] = [];
-
-            for (const key of nuqsParams) {
-              const expected = expectedSearchParams.get(key);
-              const actual = actualSearchParams.get(key);
-
-              // null/undefined 처리를 위해 문자열로 비교
-              const expectedStr = expected ?? '';
-              const actualStr = actual ?? '';
-
-              if (expectedStr !== actualStr) {
-                needsUpdate = true;
-                mismatches.push(`${key}: expected "${expectedStr}", actual "${actualStr}"`);
-              }
-            }
-
-            if (needsUpdate) {
-              // 현재 URL의 다른 파라미터들을 보존하면서 nuqs 파라미터만 업데이트
-              const currentUrl = new URL(window.location.href);
-              const newSearchParams = new URLSearchParams(currentUrl.search);
-
-              // nuqs 파라미터들을 expectedSearchParams로 교체
-              for (const key of nuqsParams) {
-                const expectedValue = expectedSearchParams.get(key);
-                if (expectedValue !== null) {
-                  newSearchParams.set(key, expectedValue);
-                } else {
-                  newSearchParams.delete(key);
-                }
-              }
-
-              currentUrl.search = newSearchParams.toString();
-              window.history.replaceState(null, '', currentUrl.toString());
-            }
-
-            resolve(expectedSearchParams);
-          });
-        });
-      });
+      return setUrlState(updatePayload);
     },
     [setUrlState]
   );
 
-  const state: SearchState = useMemo(
-    () => ({
-      scope: urlState.scope ?? 'nearby',
-      searchedLevel: urlState.searchedLevel,
-      query: urlState.query,
-      filters: urlState.filters,
-      refPoint: urlState.refPoint,
-      searchBounds: urlState.bounds,
-      searchLock: urlState.searchLock,
-      searchCenter: urlState.searchCenter,
-      center: urlState.center,
-      zoom: urlState.zoom,
-      viewportBounds: null,
-    }),
-    [
-      urlState.scope,
-      urlState.searchedLevel,
-      urlState.query,
-      urlState.filters,
-      urlState.refPoint,
-      urlState.bounds,
-      urlState.searchLock,
-      urlState.searchCenter,
-      urlState.center,
-      urlState.zoom,
-    ]
-  );
-
   return {
-    state,
-    commitState,
+    urlState: urlState as SearchUrlState,
+    setUrlState: setState,
   };
 }

--- a/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
@@ -8,7 +8,7 @@ import { useSearchMachine } from '../model/useSearchMachine';
 import { toBoundsSnapshot } from '../lib/bounds';
 import type { KindergartenListItemWithMeta } from '@entities/kindergarten';
 import { useBasePoint } from '@entities/user';
-import { useGeolocationQuery } from '@shared/lib';
+import { isEqualBounds, useGeolocationQuery } from '@shared/lib';
 import { AggregationMarker, CurrentLocationMarker, PlaceMarker } from '@shared/ui/map';
 import type { Coord } from '@shared/types';
 import { useMarkerState } from '@shared/store';
@@ -21,6 +21,7 @@ export function MapView(props: MapViewProps) {
   const { ref, onOpenCard } = props;
 
   const map = useRef<naver.maps.Map | null>(null);
+  const lastGeoBoundsRef = useRef<{ swLat: number; swLng: number; neLat: number; neLng: number } | null>(null);
   const lastFittedKeyRef = useRef<string | null>(null);
   const autoFitRef = useRef(false);
   const exactHandledRef = useRef<string | null>(null);
@@ -55,9 +56,11 @@ export function MapView(props: MapViewProps) {
     if (committedState.scope !== 'global') return;
     if (!geoBounds) return;
 
-    const boundsKey = `${geoBounds.swLat},${geoBounds.swLng},${geoBounds.neLat},${geoBounds.neLng}`;
+    // 이전과 동일한 bounds면 fitBounds X
+    if (isEqualBounds(lastGeoBoundsRef.current, geoBounds)) return;
+
     // 동일 검색 조건이어도 refetch 시 fitBounds를 다시 수행한다.
-    const fitKey = `global:${committedState.query}:${committedState.filters.join(',')}:${boundsKey}:${dataUpdatedAt}`;
+    const fitKey = `global:${committedState.query}:${committedState.filters.join(',')}:${dataUpdatedAt}`;
     if (lastFittedKeyRef.current === fitKey) return;
 
     const bounds = new naver.maps.LatLngBounds(
@@ -67,6 +70,7 @@ export function MapView(props: MapViewProps) {
     autoFitRef.current = true;
     map.current.fitBounds(bounds);
     lastFittedKeyRef.current = fitKey;
+    lastGeoBoundsRef.current = geoBounds;
     naver.maps.Event.once(map.current, 'idle', () => {
       if (!map.current) return;
       const coord = map.current.getCenter();

--- a/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
@@ -65,12 +65,7 @@ export function MapView(props: MapViewProps) {
       new naver.maps.LatLng(geoBounds.neLat, geoBounds.neLng)
     );
     autoFitRef.current = true;
-    map.current.fitBounds(bounds, {
-      top: 0,
-      bottom: 0,
-      left: 0,
-      right: 0,
-    });
+    map.current.fitBounds(bounds);
     lastFittedKeyRef.current = fitKey;
     naver.maps.Event.once(map.current, 'idle', () => {
       if (!map.current) return;

--- a/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
@@ -22,47 +22,83 @@ export function MapView(props: MapViewProps) {
 
   const map = useRef<naver.maps.Map | null>(null);
   const lastFittedKeyRef = useRef<string | null>(null);
+  const autoFitRef = useRef(false);
   const exactHandledRef = useRef<string | null>(null);
   useImperativeHandle(ref, () => map.current!);
 
   const { coord: basePoint } = useBasePoint();
   const { data: currentLocation } = useGeolocationQuery();
   const { activeMarkerId } = useMarkerState();
-  const { liveState: state, dispatch } = useSearchMachine();
+  const { liveState: mapState, committedState, dispatch } = useSearchMachine();
 
   const [isMapLoaded, setIsMapLoaded] = useState(false);
 
-  const mapCenter = getMapCenter({ center: state.center, basePoint });
-  const mapZoom = getMapZoom(state.zoom);
+  const mapCenter = getMapCenter({ center: mapState.center, basePoint });
+  const mapZoom = getMapZoom(mapState.zoom);
 
   // 검색 lock이 걸린 상태(scope=bounds, searchLock=1)에서는 줌과 무관하게 업체 마커만 표시한다.
-  const showAggregationMarkers = state.searchLock !== 1 && isAggregationZoom(state.zoom);
-  const showBusinessMarkers = state.searchLock === 1 || isBusinessZoom(state.zoom);
+  const showAggregationMarkers = committedState.searchLock !== 1 && isAggregationZoom(mapState.zoom);
+  const showBusinessMarkers = committedState.searchLock === 1 || isBusinessZoom(mapState.zoom);
 
   const { searchList: overlay, exact } = useSearchListQuery();
 
-  const { aggregation, geoBounds } = useAggregationQuery();
+  const { aggregation, geoBounds, dataUpdatedAt } = useAggregationQuery();
 
   /**
    * GLOBAL 스코프에서 query/filters 변동 후 agg 응답 bounds로 1회 fitBounds.
    * 동일 SearchSnapshot(스코프/레벨/쿼리/필터)에서는 중복 실행을 막는다.
    * nearby/bounds 스코프에서는 서버 bounds로 자동 이동하지 않는다.
+   * fitBounds 이후 최초 idle 이벤트에서 map 상태를 확정한다.
    */
   useEffect(() => {
     if (!isMapLoaded || !map.current) return;
-    if (state.scope !== 'global') return;
+    if (committedState.scope !== 'global') return;
     if (!geoBounds) return;
 
-    const fitKey = `global:${state.query}:${state.filters.join(',')}`;
+    const boundsKey = `${geoBounds.swLat},${geoBounds.swLng},${geoBounds.neLat},${geoBounds.neLng}`;
+    // 동일 검색 조건이어도 refetch 시 fitBounds를 다시 수행한다.
+    const fitKey = `global:${committedState.query}:${committedState.filters.join(',')}:${boundsKey}:${dataUpdatedAt}`;
     if (lastFittedKeyRef.current === fitKey) return;
 
     const bounds = new naver.maps.LatLngBounds(
       new naver.maps.LatLng(geoBounds.swLat, geoBounds.swLng),
       new naver.maps.LatLng(geoBounds.neLat, geoBounds.neLng)
     );
-    map.current.fitBounds(bounds);
+    autoFitRef.current = true;
+    map.current.fitBounds(bounds, {
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    });
     lastFittedKeyRef.current = fitKey;
-  }, [geoBounds, isMapLoaded, state.filters, state.query, state.scope]);
+    naver.maps.Event.once(map.current, 'idle', () => {
+      if (!map.current) return;
+      const coord = map.current.getCenter();
+      const centerCoord = { lat: coord.y, lng: coord.x };
+      const zoom = map.current.getZoom();
+      const viewportBounds = toBoundsSnapshot(map.current.getBounds());
+
+      autoFitRef.current = false;
+      dispatch({
+        type: 'MAP_INTERACTION_END',
+        payload: {
+          center: centerCoord,
+          zoom,
+          viewportBounds,
+          source: 'auto-fit',
+        },
+      });
+    });
+  }, [
+    dataUpdatedAt,
+    dispatch,
+    geoBounds,
+    isMapLoaded,
+    committedState.filters,
+    committedState.query,
+    committedState.scope,
+  ]);
 
   /**
    * exact 결과가 있을 때는 자동으로 선택 상태를 만들고 상세 시트를 연다.
@@ -89,9 +125,11 @@ export function MapView(props: MapViewProps) {
   };
 
   /**
-   * 지도 인터랙션(드래그, 줌) 종료 핸들러
+   * 사용자 지도 인터랙션(드래그/줌) 종료 시 liveState를 업데이트한다.
+   * 검색 레벨 변화로 인한 자동 쿼리를 트리거한다.
    */
   const handleMapInteractionEnd = () => {
+    if (autoFitRef.current) return;
     if (!map.current) return;
     const coord = map.current.getCenter();
     const centerCoord = { lat: coord.y, lng: coord.x };
@@ -105,6 +143,7 @@ export function MapView(props: MapViewProps) {
         center: centerCoord,
         zoom,
         viewportBounds,
+        source: 'user',
       },
     });
   };
@@ -223,7 +262,7 @@ export function MapView(props: MapViewProps) {
 
         {/* 개발용 BBox 디버깅 - 개발 환경에서만 표시 */}
         {process.env.NODE_ENV === 'development' && (
-          <BBoxDebug serverBounds={geoBounds} viewportBounds={state.viewportBounds} map={map.current} />
+          <BBoxDebug serverBounds={geoBounds} viewportBounds={mapState.viewportBounds} map={map.current} />
         )}
       </NaverMap>
     </>

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -22,7 +22,7 @@ import { SearchStateProvider, useSearchMachine } from '@features/kindergarten-ma
 import { getRegionLevel } from '@features/kindergarten-map/lib/markers';
 import type { BoundsSnapshot } from '@features/kindergarten-map/lib/searchMachine';
 import { toBoundsSnapshot } from '@features/kindergarten-map/lib/bounds';
-import { isEqualFilters, type KindergartenListItemWithMeta } from '@entities/kindergarten';
+import type { KindergartenListItemWithMeta } from '@entities/kindergarten';
 import { isEqualCoord, useBottomSheetSnapIndex, useSafeAreaInsets } from '@shared/lib';
 import { useMarkerState } from '@shared/store';
 
@@ -38,7 +38,6 @@ function KindergartenMainPageContent() {
   const mapRef = useRef<naver.maps.Map | null>(null);
   const searchParams = useSearchParams();
   const { liveState, committedState, dispatch } = useSearchMachine();
-  const { query, filters } = committedState;
 
   const { setActiveMarker } = useMarkerState();
   const { isFullExtended, setSnapIndex } = useBottomSheetSnapIndex();
@@ -46,9 +45,6 @@ function KindergartenMainPageContent() {
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
-
-  const prevQueryRef = useRef(query);
-  const prevFiltersRef = useRef(filters);
 
   // URL 상태(committedState)가 외부 요인(뒤로가기 등)으로 변경되면,
   // 지도 뷰를 직접 제어하여 동기화합니다.
@@ -80,31 +76,6 @@ function KindergartenMainPageContent() {
 
     return false;
   }, [liveState, committedState]);
-
-  // URL의 query 변경을 감지하고 이벤트를 발생
-  useEffect(() => {
-    if (query !== prevQueryRef.current) {
-      const trimmed = query.trim();
-      if (trimmed.length > 0) {
-        dispatch({ type: 'QUERY_CHANGED', query: trimmed });
-      } else {
-        dispatch({ type: 'CLEAR_QUERY' });
-      }
-      prevQueryRef.current = query;
-    }
-  }, [query, dispatch]);
-
-  // URL의 filters 변경을 감지하고 이벤트를 발생
-  useEffect(() => {
-    if (!isEqualFilters(filters, prevFiltersRef.current)) {
-      if (filters.length > 0) {
-        dispatch({ type: 'FILTERS_CHANGED', filters });
-      } else {
-        dispatch({ type: 'CLEAR_FILTERS' });
-      }
-      prevFiltersRef.current = filters;
-    }
-  }, [filters, dispatch]);
 
   /**
    * 재검색 핸들러

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -37,7 +37,7 @@ export default function KindergartenMainPage() {
 function KindergartenMainPageContent() {
   const mapRef = useRef<naver.maps.Map | null>(null);
   const searchParams = useSearchParams();
-  const { liveState, committedState, dispatch } = useSearchMachine();
+  const { liveState, committedState, searchState, dispatch } = useSearchMachine();
 
   const { setActiveMarker } = useMarkerState();
   const { isFullExtended, setSnapIndex } = useBottomSheetSnapIndex();
@@ -46,28 +46,28 @@ function KindergartenMainPageContent() {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
 
-  // URL 상태(committedState)가 외부 요인(뒤로가기 등)으로 변경되면,
+  // URL 상태(liveState)가 외부 요인(뒤로가기 등)으로 변경되면,
   // 지도 뷰를 직접 제어하여 동기화합니다.
   useEffect(() => {
     const map = mapRef.current;
-    if (!map || !committedState.center) return;
+    if (!map || !liveState.center) return;
 
-    const committedLatLng = new naver.maps.LatLng(committedState.center.lat, committedState.center.lng);
+    const committedLatLng = new naver.maps.LatLng(liveState.center.lat, liveState.center.lng);
 
     // 현재 지도 중심과 committed 상태의 중심이 다를 경우에만 이동
     if (!map.getCenter().equals(committedLatLng)) {
       map.setCenter(committedLatLng);
     }
     // 현재 지도 줌과 committed 상태의 줌이 다를 경우에만 변경
-    if (map.getZoom() !== committedState.zoom) {
-      map.setZoom(committedState.zoom);
+    if (map.getZoom() !== liveState.zoom) {
+      map.setZoom(liveState.zoom);
     }
-  }, [committedState.center, committedState.zoom]);
+  }, [liveState.center, liveState.zoom]);
 
   const shouldShowRefresh = useMemo(() => {
     if (!liveState.viewportBounds) return false;
 
-    const zoomChanged = liveState.zoom !== committedState.zoom;
+    const zoomChanged = liveState.zoom !== searchState.zoom;
     if (zoomChanged) return true;
 
     if (committedState.searchCenter && liveState.center) {
@@ -75,7 +75,7 @@ function KindergartenMainPageContent() {
     }
 
     return false;
-  }, [liveState, committedState]);
+  }, [liveState, committedState.searchCenter, searchState.zoom]);
 
   /**
    * 재검색 핸들러
@@ -111,7 +111,7 @@ function KindergartenMainPageContent() {
         isOpen={isOpen}
         close={close}
         bounds={mapRef.current?.getBounds()}
-        initialFilters={liveState.filters}
+        initialFilters={committedState.filters}
         onApply={(newFilters) => {
           if (newFilters.length > 0) {
             dispatch({ type: 'FILTERS_CHANGED', filters: newFilters });
@@ -127,8 +127,8 @@ function KindergartenMainPageContent() {
     <>
       <MapView ref={mapRef} onOpenCard={handleOpenCard} />
 
-      {liveState.query.trim().length > 0 ? (
-        <SearchHeader query={liveState.query} />
+      {committedState.query.trim().length > 0 ? (
+        <SearchHeader query={committedState.query} />
       ) : (
         <div
           className={cn(`absolute top-0 right-0 left-0 z-50 ${isFullExtended ? 'bg-fill-secondary-0' : ''}`)}

--- a/apps/knockdog/src/views/search-page/ui/SearchPage.tsx
+++ b/apps/knockdog/src/views/search-page/ui/SearchPage.tsx
@@ -24,8 +24,6 @@ export function SearchPage({ inputRef }: { inputRef?: React.RefObject<HTMLInputE
       const params = new URLSearchParams(searchParams.toString());
       params.set('query', suggestion.label);
       params.set('region', suggestion.code);
-      params.set('center', `${suggestion.coord.lat},${suggestion.coord.lng}`);
-      params.set('zoom', String(suggestion.zoom));
       params.set('bottomSheetSnapIndex', '1');
 
       addRecentSearchKeyword({
@@ -40,7 +38,6 @@ export function SearchPage({ inputRef }: { inputRef?: React.RefObject<HTMLInputE
     } else {
       // FILTER_ITEM 타입 검색
       const params = new URLSearchParams(searchParams.toString());
-      params.set('zoom', '9');
       params.set('filters', suggestion.code);
       params.set('bottomSheetSnapIndex', '1');
 
@@ -57,8 +54,6 @@ export function SearchPage({ inputRef }: { inputRef?: React.RefObject<HTMLInputE
   const handlePlaceClick = (place: AutocompletePlace) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('query', place.title);
-    params.set('center', `${place.coord.lat},${place.coord.lng}`);
-    params.set('zoom', '9');
     params.set('bottomSheetSnapIndex', '1');
 
     addRecentSearchKeyword({
@@ -73,7 +68,6 @@ export function SearchPage({ inputRef }: { inputRef?: React.RefObject<HTMLInputE
     if (localQuery.trim()) {
       const params = new URLSearchParams(searchParams.toString());
       params.set('query', localQuery.trim());
-      params.set('zoom', '9');
       params.set('bottomSheetSnapIndex', '1');
 
       addRecentSearchKeyword({


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
https://jira-knockdog.atlassian.net/browse/KDDEV-267?atlOrigin=eyJpIjoiYjgxYWFkYzM2NTU4NDU3NmI2ZjUxOTJjMDU5ZTZhYjYiLCJwIjoiaiJ9
  - 검색 URL 변경 시 지도 상태/쿼리 트리거가 뒤엉키는 문제를 줄이기 위해 상태 사용을 명시화하고, URL 동기화 타이밍을 보완했습니다.
  - 검색 결과에 따른 fitBounds 처리 시점과 지도 상태 업데이트를 분리해 불필요한 루프를 완화했습니다.

  ## 작업 내용

  - SearchPage에서 검색 submit 시 지도 center/zoom을 직접 조작하던 로직을 제거했습니다. 
  - 메인 페이지/검색 쿼리에서 명시적 상태(committedState, searchState) 사용으로 의도된 상태만 참조하도록 정리했습니다. 
  - fitBounds 호출 후 최초 idle 이벤트에서 MAP_INTERACTION_END를 호출하도록 하여 지도 상태 업데이트 타이밍을 명확히 했습니다. 
  - dispatch 내부에서 liveStateRef/committedStateRef를 즉시 갱신해 연속 이벤트에서 stale ref를 사용하지 않도록 했습니다. 
  - 동일 bounds 재요청 시 fitBounds를 생략해 불필요한 지도 이동을 방지했습니다. 
