### PR TITLE
Design: Title 컴포넌트 중앙 정렬 스타일링 변경

### DIFF
--- a/apps/knockdog/src/widgets/Header/ui/Title.tsx
+++ b/apps/knockdog/src/widgets/Header/ui/Title.tsx
@@ -6,7 +6,15 @@ function Title({ children, center = true, className, ...props }: ComponentProps<
   const { textColor } = useHeaderContext();
 
   return (
-    <span className={cn('h3-extrabold text-text-primary', textColor, center && 'mx-auto', className)} {...props}>
+    <span
+      className={cn(
+        'h3-extrabold text-text-primary',
+        textColor,
+        center && 'absolute left-1/2 -translate-x-1/2',
+        className
+      )}
+      {...props}
+    >
       {children}
     </span>
   );


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

`absolute left-1/2 -translate-x-1/2` 로 변경