### PR TITLE
[fix(knockdog)]: 사진 4장 이상 선택시 UI 틀어지는 문제 수정

### DIFF
--- a/apps/knockdog/src/features/memo/ui/FreeMemoSection.tsx
+++ b/apps/knockdog/src/features/memo/ui/FreeMemoSection.tsx
@@ -115,7 +115,9 @@ export function FreeMemoSection() {
           <TextareaInput readOnly value={memo?.content ?? ''} />
         </Textarea>
       </div>
-      <PhotoUploader maxCount={MEMO_PHOTO_MAX_COUNT} defaultValue={defaultPhotos} onChange={handlePhotosChange} />
+      <div className='overflow-y-auto'>
+        <PhotoUploader maxCount={MEMO_PHOTO_MAX_COUNT} defaultValue={defaultPhotos} onChange={handlePhotosChange} />
+      </div>
     </div>
   );
 }

--- a/apps/knockdog/src/shared/ui/full-image-slider/FullImageSlider.tsx
+++ b/apps/knockdog/src/shared/ui/full-image-slider/FullImageSlider.tsx
@@ -41,7 +41,7 @@ export function FullImageSlider({ initialIndex = 0, images, onIndexChange }: Ful
           </SwiperRoot>
         </div>
         {/* 바텀 영역 */}
-        <div className='mb-[84px] flex flex-shrink-0 items-center justify-center px-4 py-3'>
+        <div className='mb-[184px] flex shrink-0 items-center justify-center px-4 py-3'>
           <span className='text-text-accent'>{currentIndex + 1}</span>/{images.length}
         </div>
       </div>

--- a/apps/knockdog/src/shared/ui/photo-uploader/FullImageSheet.tsx
+++ b/apps/knockdog/src/shared/ui/photo-uploader/FullImageSheet.tsx
@@ -8,9 +8,11 @@ import {
   AlertDialogFooter,
   AlertDialogCancel,
   AlertDialogAction,
+  AlertDialogDescription,
 } from '@knockdog/ui';
 import { FullImageSlider } from '@shared/ui/full-image-slider';
 import { BottomSheet } from '../bottom-sheet';
+import { overlay } from 'overlay-kit';
 
 interface PriceFullImageSheetProps {
   isOpen: boolean;
@@ -21,7 +23,6 @@ interface PriceFullImageSheetProps {
 }
 
 export function FullImageSheet({ isOpen, close, images = [], initialIndex = 0, onRemove }: PriceFullImageSheetProps) {
-  const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
 
   useEffect(() => {
@@ -32,37 +33,48 @@ export function FullImageSheet({ isOpen, close, images = [], initialIndex = 0, o
 
   function handleRemove() {
     onRemove?.(currentIndex);
-    setIsAlertOpen(false);
     close();
   }
 
+  const handleRemoveImage = () => {
+    overlay.open(({ isOpen, close: closeAlert }) => (
+      <AlertDialog open={isOpen} onOpenChange={closeAlert}>
+        <AlertDialogContent className='z-9999' overlayClassName='z-[9998]'>
+          <AlertDialogHeader id='alert-dialog-title'>
+            <AlertDialogTitle>삭제하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription className='hidden'>이 작업은 되돌릴 수 없습니다.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              취소
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={handleRemove}>확인</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ));
+  };
+
   return (
-    <BottomSheet.Root open={isOpen} onOpenChange={close}>
+    // AlertDialog가 open되어, dim영역 클릭시 이벤트 버블링으로인해 BottomSheet가 닫히는 현상을 방지하기 위해 dismissible={false} 설정
+    <BottomSheet.Root open={isOpen} onOpenChange={close} dismissible={false}>
       <BottomSheet.Overlay className='z-overlay' />
       <BottomSheet.Body className='z-modal h-screen max-h-screen rounded-none' aria-describedby={'유치원 가격 정보'}>
-        <BottomSheet.Header className='justify-between'>
+        <BottomSheet.Header className='justify-between pt-[50px]'>
           <IconButton icon='Close' onClick={close} />
 
-          <BottomSheet.Title></BottomSheet.Title>
+          <BottomSheet.Title />
 
-          <IconButton icon='Trash' onClick={() => setIsAlertOpen(true)} />
+          <IconButton icon='Trash' onClick={handleRemoveImage} />
         </BottomSheet.Header>
         <BottomSheet.Content>
           <FullImageSlider initialIndex={initialIndex} images={images} onIndexChange={setCurrentIndex} />
         </BottomSheet.Content>
       </BottomSheet.Body>
-
-      <AlertDialog open={isAlertOpen} onOpenChange={setIsAlertOpen}>
-        <AlertDialogContent className='z-[9999]' overlayClassName='z-[9998]'>
-          <AlertDialogHeader>
-            <AlertDialogTitle>삭제하시겠습니까?</AlertDialogTitle>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>취소</AlertDialogCancel>
-            <AlertDialogAction onClick={handleRemove}>확인</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </BottomSheet.Root>
   );
 }

--- a/apps/knockdog/src/shared/ui/photo-uploader/PhotoUploader.tsx
+++ b/apps/knockdog/src/shared/ui/photo-uploader/PhotoUploader.tsx
@@ -76,7 +76,7 @@ function PhotoUploader({ maxCount = 3, quality = 0.8, defaultValue, onChange }: 
             <button
               onClick={handlePickImages}
               type='button'
-              className='border-line-400 body2-regular text-text-tertiary flex h-[80px] w-[80px] flex-col items-center justify-center rounded-lg border py-5'
+              className='border-line-400 body2-regular text-text-tertiary flex h-[80px] min-w-[80px] flex-col items-center justify-center rounded-lg border py-5'
             >
               <Icon icon='Plus' className='h-6 w-6' />
               {assets.length} / {maxCount}


### PR DESCRIPTION
… AlertDialog 리팩토링

<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

[QA 티켓] (https://jira-knockdog.atlassian.net/browse/Q2-4)
- 업체 상세 > 메모 > 사진 선택  사진 4장 이상 선택시 UI 틀어지는 문제 수정
- 사진 상세 보기 > 헤더 위로 겹쳐지는 문제 수정
- "삭제 하시겠습니까?" AlertDialog의 dim 영역 터치(클릭)시 BottomSheet 닫히고, 다시 안열리는 오류 수정 
