### PR TITLE
fix: 헤더 레이아웃 픽스

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -158,8 +158,8 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
       >
         <Header className='block'>
           <Header.LeftSection>
-            <Header.BackButton />
-            <Header.HomeButton />
+            <Header.BackButton onClick={() => setActiveSnapPoint(snapPoints[0] ?? null)} />
+            <Header.HomeButton onClick={onClose} />
           </Header.LeftSection>
 
           <Header.Title>{currentItem.title}</Header.Title>

--- a/apps/knockdog/src/features/kindergarten-list/ui/SearchHeader.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/SearchHeader.tsx
@@ -37,10 +37,15 @@ export function SearchHeader({ query }: SearchHeaderProps) {
   };
 
   return (
-    <Header className='bg-fill-secondary-0 absolute top-0 z-50 h-fit w-full' style={{ paddingTop: top }}>
-      <Header.LeftSection className='px-4'>
+    <Header
+      className='bg-fill-secondary-0 absolute top-0 z-50 h-fit w-full'
+      innerClassName='gap-2'
+      style={{ paddingTop: top }}
+    >
+      <Header.LeftSection>
         <Header.BackButton onClick={handleGoSearch} />
       </Header.LeftSection>
+
       <TextField
         prefix={<Icon icon='Search' className='size-x6 text-fill-secondary-700' />}
         className='bg-fill-secondary-50 h-x12 border-0'
@@ -55,7 +60,8 @@ export function SearchHeader({ query }: SearchHeaderProps) {
           readOnly
         />
       </TextField>
-      <Header.RightSection className='px-4'>
+
+      <Header.RightSection>
         <Header.CloseButton onClick={handleClose} />
       </Header.RightSection>
     </Header>

--- a/apps/knockdog/src/views/save-main-page/ui/SaveMainPage.tsx
+++ b/apps/knockdog/src/views/save-main-page/ui/SaveMainPage.tsx
@@ -68,13 +68,13 @@ export function SaveMainPage() {
         </Header>
       ) : (
         <Header>
-          <Header.Title>보관함</Header.Title>
-
           {isMounted && isLoggedIn && (
             <Header.RightSection>
-              <IconButton icon='Search' onClick={handleSearch} className='absolute right-4' />
+              <IconButton icon='Search' onClick={handleSearch} />
             </Header.RightSection>
           )}
+
+          <Header.Title>보관함</Header.Title>
         </Header>
       )}
 

--- a/apps/knockdog/src/views/search-page/ui/SearchPage.tsx
+++ b/apps/knockdog/src/views/search-page/ui/SearchPage.tsx
@@ -83,11 +83,11 @@ export function SearchPage({ inputRef }: { inputRef?: React.RefObject<HTMLInputE
     <div className='flex h-full flex-col'>
       {/* 검색창 헤더 */}
       <Header>
-        <Header.LeftSection className='px-4'>
+        <Header.LeftSection>
           <Header.BackButton onClick={() => router.back()} />
         </Header.LeftSection>
 
-        <div className='relative min-w-0 flex-1'>
+        <div className='relative mx-2 min-w-0 flex-1'>
           <TextField
             prefix={<Icon icon='Search' className='size-x6 text-fill-secondary-700' />}
             className='bg-fill-secondary-50 h-x12 min-w-0 border-0'

--- a/apps/knockdog/src/widgets/Header/ui/Header.tsx
+++ b/apps/knockdog/src/widgets/Header/ui/Header.tsx
@@ -9,17 +9,19 @@ import InputField from './InputField';
 import HomeButton from './HomeButton';
 import SearchField from './SearchField';
 import { cn } from '@knockdog/ui/lib';
-import { Suspense, type ComponentProps } from 'react';
+import { type ComponentProps } from 'react';
 import type { HeaderVariant } from '../model/HeaderProvider';
 
 export function Header({
   className,
+  innerClassName,
   variant = 'solid',
   children,
   ...props
 }: ComponentProps<'header'> & {
   variant?: HeaderVariant;
   fontColor?: string;
+  innerClassName?: string;
 }) {
   const variantClass = {
     solid: 'bg-white border-b border-line-100',
@@ -36,7 +38,7 @@ export function Header({
         )}
         {...props}
       >
-        <div className={cn('flex h-16 w-full items-center')}>{children}</div>
+        <div className={cn('flex h-16 w-full items-center justify-between', innerClassName)}>{children}</div>
       </header>
     </>
   );
@@ -44,7 +46,13 @@ export function Header({
 
 function LeftSection({ children, ...props }: ComponentProps<'div'>) {
   return (
-    <div className='flex items-center gap-x-1' {...props}>
+    <div
+      className={cn(
+        'flex items-center gap-x-4',
+        '[&>button]:relative [&>button]:before:absolute [&>button]:before:-inset-2 [&>button]:before:content-[""]'
+      )}
+      {...props}
+    >
       {children}
     </div>
   );
@@ -52,7 +60,13 @@ function LeftSection({ children, ...props }: ComponentProps<'div'>) {
 
 function RightSection({ children, ...props }: ComponentProps<'div'>) {
   return (
-    <div className='flex items-center gap-x-1' {...props}>
+    <div
+      className={cn(
+        'ml-auto flex items-center gap-x-4',
+        '[&>button]:relative [&>button]:before:absolute [&>button]:before:-inset-2 [&>button]:before:content-[""]'
+      )}
+      {...props}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

- `KindergartenItemSheet` 상세페이지 뒤로가기/홈버튼 동작 추가
- `LeftSection`, `RightSection` 레이아웃 스타일링 변경
- 헤더 버튼들 터치 범위 확장