### PR TITLE
feat: 필터 인터랙션 시 현재 지도 영역(bounds) 기반 검색 정책 적용

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
+++ b/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
@@ -198,7 +198,7 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
     }
 
     case 'FILTERS_CHANGED': {
-      return applyFilterTransition(current, event.filters);
+      return applyFilterTransition(current, event.filters, 'bounds');
     }
 
     case 'CLEAR_QUERY': {
@@ -206,7 +206,7 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
     }
 
     case 'CLEAR_FILTERS': {
-      return applyFilterTransition(current, []);
+      return applyFilterTransition(current, [], 'bounds');
     }
 
     case 'BASEPOINT_SYNC': {
@@ -571,14 +571,29 @@ function applyScopeTransition(current: SearchState, targetScope: SearchScope): S
  * @param nextQuery - 새로운 쿼리
  * @returns 전이된 검색 스냅샷
  */
-function applyQueryTransition(current: SearchState, nextQuery: string): SearchState {
-  const targetScope = deriveScope({
-    currentScope: current.scope,
-    query: nextQuery,
-    filters: current.filters,
-  });
+function applyQueryTransition(
+  current: SearchState,
+  nextQuery: string,
+  forcedScope: SearchScope | null = null
+): SearchState {
+  const targetScope =
+    forcedScope ??
+    deriveScope({
+      currentScope: current.scope,
+      query: nextQuery,
+      filters: current.filters,
+    });
 
   const scoped = applyScopeTransition(current, targetScope);
+
+  if (targetScope === 'bounds') {
+    return {
+      ...scoped,
+      query: nextQuery,
+      searchBounds: current.viewportBounds ?? current.searchBounds,
+      searchCenter: current.center,
+    };
+  }
 
   return {
     ...scoped,
@@ -599,14 +614,29 @@ function applyQueryTransition(current: SearchState, nextQuery: string): SearchSt
  * @param nextFilters - 새로운 필터 배열
  * @returns 전이된 검색 스냅샷
  */
-function applyFilterTransition(current: SearchState, nextFilters: FilterOption[]): SearchState {
-  const targetScope = deriveScope({
-    currentScope: current.scope,
-    query: current.query,
-    filters: nextFilters,
-  });
+function applyFilterTransition(
+  current: SearchState,
+  nextFilters: FilterOption[],
+  forcedScope: SearchScope | null = null
+): SearchState {
+  const targetScope =
+    forcedScope ??
+    deriveScope({
+      currentScope: current.scope,
+      query: current.query,
+      filters: nextFilters,
+    });
 
   const scoped = applyScopeTransition(current, targetScope);
+
+  if (targetScope === 'bounds') {
+    return {
+      ...scoped,
+      filters: nextFilters,
+      searchBounds: current.viewportBounds ?? current.searchBounds,
+      searchCenter: current.center,
+    };
+  }
 
   return {
     ...scoped,


### PR DESCRIPTION


<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/KDDEV-278
필터 칩 또는 필터 바텀시트를 통해 필터를 변경할 경우, 검색 범위를 전체(global)가 아닌 현재 지도의 영역(bounds)으로 제한하도록 정책을 변경했습니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### (FSM) 전이 로직 개선
- `applyFilterTransition` 및 `applyQueryTransition` 함수가 forcedScope 파라미터를 지원하도록 확장했습니다.
- `FILTERS_CHANGED` 및 `CLEAR_FILTERS` 이벤트 발생 시 'bounds' 스코프를 명시적으로 전달하여 인터랙티브한 필터 변경 시 현재 영역 내 검색이 수행되도록 했습니다.
- `targetScope`가 `bounds`일 경우, 줌 레벨을 초기화하지 않고 현재의 지도의 viewportBounds를 searchBounds로 캡처하는 로직을 추가했습니다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->




## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
