### PR TITLE
fix: WebView localStorage null 에러 해결

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -193,7 +193,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
             <BottomSheet.Body
               onPointerDownOutside={(e) => {
                 e.preventDefault();
-                close();
+                onClose();
               }}
               className={cn(
                 'pointer-events-auto absolute inset-x-0 z-50 h-full max-h-[calc(100vh-64px)]',

--- a/apps/mobile/bridges/ui/BridgeWebView.tsx
+++ b/apps/mobile/bridges/ui/BridgeWebView.tsx
@@ -93,7 +93,7 @@ export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
       originWhitelist={['*']}
       cacheEnabled
       geolocationEnabled
-      webviewDebuggingEnabled
+      webviewDebuggingEnabled={__DEV__}
       injectedJavaScriptBeforeContentLoaded={INJECT_BEFORE}
     />
   );

--- a/apps/mobile/bridges/ui/BridgeWebView.tsx
+++ b/apps/mobile/bridges/ui/BridgeWebView.tsx
@@ -89,11 +89,12 @@ export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
       onMessage={handleOnMessage}
       onLoadEnd={notifyReady}
       javaScriptEnabled
+      domStorageEnabled
       originWhitelist={['*']}
-      cacheEnabled={false}
-      injectedJavaScriptBeforeContentLoaded={INJECT_BEFORE}
+      cacheEnabled
       geolocationEnabled
-      webviewDebuggingEnabled={true}
+      webviewDebuggingEnabled
+      injectedJavaScriptBeforeContentLoaded={INJECT_BEFORE}
     />
   );
 }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

버그 리포트:
https://jira-knockdog.atlassian.net/browse/KDDEV-264

- iOS Expo RN 앱의 WebView 내에서 localStorage가 간헐적으로 null로 평가되어 발생하는 런타임 에러(TypeError: null is not an object)를 해결했습니다.
- WebView의 자원 관리 및 저장소 연결 안정성을 높이기 위한 캐시 옵션을 조정했습니다.

<img width="1135" height="182" alt="스크린샷 2026-01-05 22 59 24" src="https://github.com/user-attachments/assets/1ff126ba-c46a-4898-ac8f-b95cca627d2d" />
메인 페이지에서 업체 마커를 활성화 한 후 아이템 시트가 열린상태에서 "외부"클릭으로 바텀시트를 닫으려 시도할 때 window.localStorage가 null로 평가됨.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### 1. 전역 close() 호출로 인한 WebKit 상태 유실 수정
- 문제: `KindergartenItemSheet`에서 시트 외부 클릭 시 부모의 `onClose` 대신 전역 함수인 `window.close()`가 호출되고 있었습니다.
- 원인: 브라우저 환경에서 `window.close()`가 호출되면 WebKit 프로세스가 페이지 종료 준비(Cleanup) 단계에 진입합니다. 이 과정에서 `localStorage` 등의 객체가 먼저 해제되면서, 이후 실행되는 코드에서 localStorage 접근 시 null 에러가 발생했던 것으로 확인되었습니다.
- 수정: 실수로 호출된 `close()`를 주입받은 `onClose()` 핸들러로 올바르게 교체했습니다.

#### 2. WebView 캐시 옵션 활성화 (`domStorageEnabled`, `cacheEnabled`)
- `domStorageEnabled`: 저장소 기능을 명시적으로 활성화. (안드로이드 전용)
- `cacheEnabled`: 자원 재사용을 통해 Web Content 프로세스의 부하를 줄였습니다. 

