### PR TITLE
fix: iOS 웹뷰 바텀시트 이동 시 레이아웃 밀림 현상 수정

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
@@ -53,7 +53,7 @@ export function KindergartenListSheet({
   return (
     <div
       ref={containerRef}
-      className='pointer-events-none absolute bottom-0 w-full'
+      className='pointer-events-none absolute bottom-0 w-full overflow-hidden'
       style={{
         height: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)`,
       }}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

버그리포트: https://jira-knockdog.atlassian.net/browse/KDDEV-286

- iOS WebView 환경에서 바텀시트 조작(특히 연속으로 검색할 때) 시 화면이 위로 밀리거나 레이아웃 오프셋이 발생하는 고질적인 이슈를 해결했습니다.
- 바텀시트가 화면 하단으로 내려갈 때 문서 전체 높이가 비정상적으로 늘어나는 원인을 파악하고 이를 CSS 레벨에서 격리했습니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### ScrollHeight 팽창 방지를 위한 레이아웃 격리
- 바텀시트의 부모 컨테이너 `div`에 `overflow-hidden` 속성을 추가했습니다.
- **원인 분석**: 바텀시트가 `translate3d`를 통해 화면 아래로 내려갈 때, 부모 컨테이너에 `overflow-hidden`이 없으면 브라우저는 보이지 않는 자식 요소까지 포함하여 전체 문서의 `scrollHeight`를 계산합니다.
- **결과**: `scrollHeight`가 뷰포트 높이(`innerHeight`)보다 커지면서 iOS 브라우저가 레이아웃 재계산 시점에 자동으로 하단으로 스크롤을 시도(Scroll Adjustment)하게 되고, 이로 인해 상단 헤더 영역이 위로 밀리는 현상이 발생했습니다. `overflow-hidden` 적용으로 문서 높이를 뷰포트에 고정하여 이 현상을 근본적으로 차단했습니다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
