### PR TITLE
fix: 보관함에서 비교 모드 진입 시 북마크 목록을 갱신하여 해제된 유치원이 선택 상태로 표시되는 오류 수정

### DIFF
--- a/apps/knockdog/src/views/save-main-page/ui/SaveMainPage.tsx
+++ b/apps/knockdog/src/views/save-main-page/ui/SaveMainPage.tsx
@@ -37,7 +37,11 @@ export function SaveMainPage() {
     setIsLoggedIn(hasAuth);
   }, [hasAuth]);
 
-  const { data: bookmarks = [], isPending } = useQuery({
+  const {
+    data: bookmarks = [],
+    isPending,
+    refetch,
+  } = useQuery({
     ...bookmarkQueries.list(hasAuth),
     enabled: hasAuth,
   });
@@ -85,6 +89,9 @@ export function SaveMainPage() {
             isLoading={isPending}
             searchQuery={debouncedSearchQuery}
             filterState={{ refPoint, showMemoOnly, onChangeRefPoint: setRefPoint, onMemoToggle: toggleShowMemoOnly }}
+            onBookmarksRefetch={async () => {
+              await refetch();
+            }}
           />
         )}
       </div>

--- a/apps/knockdog/src/widgets/save-tabs/ui/CompareMode.tsx
+++ b/apps/knockdog/src/widgets/save-tabs/ui/CompareMode.tsx
@@ -74,11 +74,13 @@ export function CompareMode({ bookmarks, onCloseClick, filterState, searchQuery 
       />
 
       {/* 선택된 유치원 상태 바 */}
-      <SelectionBar
-        selectedKindergartens={selectedKindergartens}
-        toggleSelection={toggle}
-        onCloseClick={onCloseClick}
-      />
+      {bookmarks.length > 0 && (
+        <SelectionBar
+          selectedKindergartens={selectedKindergartens}
+          toggleSelection={toggle}
+          onCloseClick={onCloseClick}
+        />
+      )}
     </div>
   );
 }

--- a/apps/knockdog/src/widgets/save-tabs/ui/SaveTabs.tsx
+++ b/apps/knockdog/src/widgets/save-tabs/ui/SaveTabs.tsx
@@ -15,17 +15,23 @@ interface SaveTabsProps {
   isLoading: boolean;
   searchQuery?: string;
   filterState: FilterState;
+  onBookmarksRefetch: () => Promise<void>;
 }
 
-function SaveTabs({ bookmarks, isLoading, searchQuery = '', filterState }: SaveTabsProps) {
+function SaveTabs({ bookmarks, isLoading, searchQuery = '', filterState, onBookmarksRefetch }: SaveTabsProps) {
   const reset = useCompareStore((state) => state.reset);
 
   const [isCompareMode, setIsCompareMode] = useState(false);
   const [activeTab, setActiveTab] = useState('KINDERGARTEN');
 
-  const handleEnterCompareMode = () => {
-    reset();
-    setIsCompareMode(true);
+  const handleEnterCompareMode = async () => {
+    try {
+      await onBookmarksRefetch(); // 비교 모드 진입 시 북마크 목록 갱신
+      reset();
+      setIsCompareMode(true);
+    } catch {
+      // 에러 발생 시 비교 모드 진입 취소
+    }
   };
 
   const handleExitCompareMode = () => {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교 모드 진입 시 북마크 목록을 갱신하여 해제된 유치원이 선택 상태로 표시되는 오류 수정
- 비교 모드에서 북마크가 없을 때 선택 상태 바가 표시되지 않도록 수정