### PR TITLE
fix: 집계 마커 클릭 시 검색 트리거 누락 현상 수정

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx
@@ -263,20 +263,25 @@ export function MapView(props: MapViewProps) {
    * 집계 마커 클릭 핸들러
    * @description 집계 마커 클릭 후 지도 이동/줌 반영 후 idle에서 bounds를 다시 읽어 커밋한다.
    */
+  /**
+   * 집계 마커 클릭 핸들러
+   * @description 집계 마커 클릭 후 지도 이동/줌 반영 후 idle에서 bounds를 다시 읽어 커밋한다.
+   * 이벤트 리스너 등록 순서와 플래그 관리가 중요하다.
+   */
   const handleAggregationClick = (_: string, coord: Coord, nextZoom: number) => {
     if (!map.current) return;
 
+    // handleIdle의 간섭을 막기 위해 플래그 설정
     aggNavigateRef.current = true;
 
-    const nextLatLng = new naver.maps.LatLng(coord.lat, coord.lng);
-    map.current.setCenter(nextLatLng);
-    map.current.setZoom(nextZoom);
-
+    // 동작 수행 *전*에 리스너를 등록해야 놓치지 않음
     naver.maps.Event.once(map.current, 'idle', () => {
       if (!map.current) return;
       const settledCenter = map.current.getCenter();
       const settledZoom = map.current.getZoom();
       const settledBounds = toBoundsSnapshot(map.current.getBounds());
+
+      // 처리 완료 후 플래그 해제
       aggNavigateRef.current = false;
 
       if (!settledBounds) return;
@@ -290,6 +295,10 @@ export function MapView(props: MapViewProps) {
         },
       });
     });
+
+    const nextLatLng = new naver.maps.LatLng(coord.lat, coord.lng);
+    // morph를 사용하여 이동+줌을 원자적으로 처리 (단일 idle 이벤트 보장)
+    map.current.morph(nextLatLng, nextZoom);
   };
 
   /**


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
<!-- [Fix] 집계 마커 클릭 시 검색 트리거 누락 이슈 수정 -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
버그리포트: https://jira-knockdog.atlassian.net/browse/KDDEV-285
집계 마커 클릭 시 지도 줌 레벨은 변경되나 실제 검색(API 호출)이 트리거되지 않는 버그를 수정했습니다.

<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
기존 로직에서는 지도 이동(`setCenter`/`setZoom`) 명령을 실행한 **후**에 `idle` 이벤트 리스너를 등록하고 있어, 지도 라이브러리가 이벤트를 즉시 처리하거나 타이밍 문제로 인해 `idle` 이벤트를 놓치는 Race Condition이 발생했습니다. 이로 인해 FSM 상태 갱신이 누락되어 검색이 실행되지 않는 문제를 해결했습니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

@MapView.tsx
1.  **Event Listener 등록 시점 변경**
    *   `idle` 이벤트 리스너를 지도 이동 명령 실행 **이전**에 등록하도록 순서를 변경하여 이벤트를 확실하게 잡도록 수정했습니다.
2.  **Atomic Transition 적용**
    *   `setCenter`와 `setZoom`을 개별적으로 호출하던 방식을 `map.morph()` 호출로 변경하여, 이동과 줌이 하나의 애니메이션으로 처리되도록 했습니다. 불필요한 중간 `idle` 발생을 막고 동작 원자성을 보장합니다.
3.  **Flag 관리 개선**
    *   `aggNavigateRef` 플래그를 `morph` 실행 직전 `true`로 설정하고, `idle` 콜백 내에서 처리가 완료된 후 `false`로 해제하도록 하여 [handleIdle](cci:1://file:///Users/na/dev/daeng_v2_front/apps/knockdog/src/features/kindergarten-map/ui/MapView.tsx:159:2-210:4)과의 간섭을 확실히 차단했습니다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->
## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->