### PR TITLE
refactor: 현 위치 주소 FAB 깜빡임 해결

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationDisplayFAB.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationDisplayFAB.tsx
@@ -8,13 +8,16 @@ import { useSearchMachine } from '../model/useSearchMachine';
 export function CurrentLocationDisplayFAB() {
   const { liveState } = useSearchMachine();
 
+  const hasValidCenter = !!liveState.center && liveState.center.lat !== 0 && liveState.center.lng !== 0;
+
   const { data: address } = useQuery({
     ...geoQueries.reverseGeocode({
       lat: liveState.center?.lat ?? 0,
       lng: liveState.center?.lng ?? 0,
       zoomLevel: liveState.zoom,
     }),
-    placeholderData: keepPreviousData,
+    enabled: hasValidCenter,
+    placeholderData: hasValidCenter ? keepPreviousData : undefined,
   });
 
   const resolvedZoomLevel = liveState.zoom ?? DEFAULT_MAP_ZOOM_LEVEL;

--- a/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationDisplayFAB.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationDisplayFAB.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { CurrentLocationDisplay } from './CurrentLocationDisplay';
 import { DEFAULT_MAP_ZOOM_LEVEL } from '../config/map';
 import { getRegionLevel } from '../lib/markers';
@@ -8,13 +8,14 @@ import { useSearchMachine } from '../model/useSearchMachine';
 export function CurrentLocationDisplayFAB() {
   const { liveState } = useSearchMachine();
 
-  const { data: address } = useQuery(
-    geoQueries.reverseGeocode({
+  const { data: address } = useQuery({
+    ...geoQueries.reverseGeocode({
       lat: liveState.center?.lat ?? 0,
       lng: liveState.center?.lng ?? 0,
       zoomLevel: liveState.zoom,
-    })
-  );
+    }),
+    placeholderData: keepPreviousData,
+  });
 
   const resolvedZoomLevel = liveState.zoom ?? DEFAULT_MAP_ZOOM_LEVEL;
   const regionLevel = getRegionLevel(resolvedZoomLevel);

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -155,7 +155,10 @@ function KindergartenMainPageContent() {
             <Float placement='top-start' offsetX='x4'>
               <CurrentLocationFAB />
             </Float>
-            {shouldShowRefresh ? <ResearchFAB onClick={handleRefresh} /> : <CurrentLocationDisplayFAB />}
+            {shouldShowRefresh && <ResearchFAB onClick={handleRefresh} />}
+            <div className={shouldShowRefresh ? 'hidden' : 'block'}>
+              <CurrentLocationDisplayFAB />
+            </div>
             <Float placement='top-end' offsetX='x4'>
               <ListFAB onClick={() => setSnapIndex(2)} />
             </Float>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/KDDEV-287

- CurrentLocationDisplayFAB가 지도 이동 시 언마운트되면서 주소 데이터(쿼리)가 초기화되어, 다시 나타날 때 "위치 정보 없음" 문구가 깜빡이는 문제를 해결했습니다.
- placeholderData: keepPreviousData를 적용하여 위치 이동 중에도 이전 데이터를 유지하도록 개선했습니다.


## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

1. DOM 유지 (hidden 처리):
- 기존에는 재검색 버튼(ResearchFAB)이 보이면 주소 FAB를 조건부 렌더링으로 제거(언마운트) 했습니다.
- 변경 후에는 CSS (hidden/block)를 사용하여 항상 DOM에 남겨두되 시각적으로만 숨겼습니다.
- 이로 인해 컴포넌트가 언마운트되지 않아 내부 React Query 상태가 보존됩니다.
2. 데이터 유지 (keepPreviousData):
- CurrentLocationDisplayFAB 내부 쿼리에 placeholderData: keepPreviousData 옵션을 추가했습니다.
- 지도가 이동하여 쿼리 키(좌표)가 변경되더라도 새로운 데이터를 받아오기 전까지 이전 주소를 계속 표시합니다.


## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
