### PR TITLE
[Fix] 업체 상세 > 요금 정보 사진 상세에서 뒤로가기 버튼 안눌리는 이슈

### DIFF
--- a/apps/knockdog/src/features/pricing/ui/PriceFullImageSheet.tsx
+++ b/apps/knockdog/src/features/pricing/ui/PriceFullImageSheet.tsx
@@ -14,7 +14,7 @@ export function PriceFullImageSheet({ isOpen, close, images = [], initialIndex =
     <BottomSheet.Root open={isOpen} onOpenChange={close}>
       <BottomSheet.Overlay className='z-overlay' />
       <BottomSheet.Body className='z-modal h-screen max-h-screen rounded-none' aria-describedby={'유치원 가격 정보'}>
-        <BottomSheet.Header className='justify-between'>
+        <BottomSheet.Header className='justify-between pt-[50px]'>
           <IconButton icon='ChevronLeft' onClick={close} />
 
           <BottomSheet.Title></BottomSheet.Title>

--- a/apps/knockdog/src/features/pricing/ui/PriceFullImageSheet.tsx
+++ b/apps/knockdog/src/features/pricing/ui/PriceFullImageSheet.tsx
@@ -17,7 +17,7 @@ export function PriceFullImageSheet({ isOpen, close, images = [], initialIndex =
         <BottomSheet.Header className='justify-between pt-[50px]'>
           <IconButton icon='ChevronLeft' onClick={close} />
 
-          <BottomSheet.Title></BottomSheet.Title>
+          <BottomSheet.Title />
 
           <IconButton icon='Share' />
         </BottomSheet.Header>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

- 업체 상세 > 요금 정보 사진 상세에서 뒤로가기 버튼 안눌리는 이슈 (padding top 줘서 해결)