### PR TITLE
fix: 비교결과 페이지 디자인 QA 수정

### DIFF
--- a/apps/knockdog/src/entities/compare/ui/Label.tsx
+++ b/apps/knockdog/src/entities/compare/ui/Label.tsx
@@ -12,7 +12,9 @@ export function Label({
       {tooltip && (
         <Tooltip className='flex items-center' placement='top-left'>
           <TooltipTrigger />
-          <TooltipContent>{tooltip}</TooltipContent>
+          <TooltipContent className='border-line-200 mr-10 ml-8 rounded-lg border p-3 text-[11px] leading-4'>
+            {tooltip}
+          </TooltipContent>
         </Tooltip>
       )}
     </div>

--- a/apps/knockdog/src/features/compare/ui/ComparisonDaysItem.tsx
+++ b/apps/knockdog/src/features/compare/ui/ComparisonDaysItem.tsx
@@ -20,7 +20,7 @@ export function ComparisonDaysItem({ kindergarten }: { kindergarten: Kindergarte
     ) as DayOfWeekShort[];
 
     DaysContent = (
-      <div className='mt-4 flex gap-1.5'>
+      <div className='mt-4 flex w-full justify-center gap-1.5'>
         {Object.entries(DAY_OF_WEEK_SHORT).map(([day, label]) => {
           const isOpen = openDays.includes(day as DayOfWeekShort);
           return <DayChip key={day} isOn={isOpen} label={label} />;
@@ -45,7 +45,7 @@ export function ComparisonDaysItem({ kindergarten }: { kindergarten: Kindergarte
 function DayChip({ isOn, label }: { isOn: boolean; label: string }) {
   return (
     <span
-      className={`${isOn ? 'bg-fill-secondary-800 text-white' : 'text-text-primary bg-gray-100'} label-extrabold flex h-10 w-10 items-center justify-center rounded-lg text-sm`}
+      className={`${isOn ? 'bg-fill-secondary-800 text-white' : 'text-text-primary bg-gray-100'} label-extrabold flex aspect-square w-10 items-center justify-center rounded-lg text-sm`}
     >
       {label}
     </span>

--- a/apps/knockdog/src/features/compare/ui/ComparisonTable.tsx
+++ b/apps/knockdog/src/features/compare/ui/ComparisonTable.tsx
@@ -13,7 +13,7 @@ function ComparisonTable({ title, cols }: ComparisonTableProps) {
       </div>
 
       <div
-        className={`grid ${cols.length === 1 ? 'grid grid-cols-1' : 'grid grid-cols-2'} items-start border border-t-0 border-neutral-100`}
+        className={`grid ${cols.length === 1 ? 'grid grid-cols-1' : 'grid grid-cols-2'} border border-t-0 border-neutral-100`}
       >
         {cols.map((services, index) => (
           <div

--- a/apps/knockdog/src/widgets/compare-complete-tabs/ui/Row.tsx
+++ b/apps/knockdog/src/widgets/compare-complete-tabs/ui/Row.tsx
@@ -1,8 +1,18 @@
 import type { CellData } from '@entities/compare';
 
-function Row({ label, left, right }: { label: string; left: CellData; right: CellData }) {
+interface RowProps {
+  label: string;
+  left: CellData;
+  right: CellData;
+  index: number;
+  startWithWhite?: boolean;
+}
+
+function Row({ label, left, right, index, startWithWhite = false }: RowProps) {
+  const isGray = startWithWhite ? index % 2 === 1 : index % 2 === 0;
+
   return (
-    <div className='grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] odd:bg-gray-50'>
+    <div className={`grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] ${isGray ? 'bg-gray-50' : ''}`}>
       <div className='flex min-w-0 flex-col items-center justify-center p-4'>
         <div className='font-semibold'>{left.value}</div>
         {left.detail && <div className='mt-0.5 w-full truncate text-center text-sm'>{left.detail}</div>}

--- a/apps/knockdog/src/widgets/compare-complete-tabs/ui/RowList.tsx
+++ b/apps/knockdog/src/widgets/compare-complete-tabs/ui/RowList.tsx
@@ -1,11 +1,17 @@
 import { Row } from './Row';
 import type { RowData } from '@entities/compare';
 
-function RowList({ rows, className }: { rows: RowData[]; className?: string }) {
+interface RowListProps {
+  rows: RowData[];
+  className?: string;
+  startWithWhite?: boolean;
+}
+
+function RowList({ rows, className, startWithWhite = false }: RowListProps) {
   return (
     <div className={`min-w-full overflow-hidden rounded-lg bg-white ${className}`}>
       {rows.map((row, i) => (
-        <Row key={i} label={row.label} left={row.left} right={row.right} />
+        <Row key={i} label={row.label} left={row.left} right={row.right} index={i} startWithWhite={startWithWhite} />
       ))}
     </div>
   );

--- a/apps/knockdog/src/widgets/compare-complete-tabs/ui/Slide.tsx
+++ b/apps/knockdog/src/widgets/compare-complete-tabs/ui/Slide.tsx
@@ -7,7 +7,7 @@ function Slide({ type, rows }: SlideProps) {
       <div className='flex items-center justify-center bg-gray-50 px-2 py-3'>
         <span className='text-sm font-semibold text-neutral-700'>{type}</span>
       </div>
-      <RowList rows={rows} />
+      <RowList rows={rows} startWithWhite />
     </div>
   );
 }

--- a/apps/knockdog/src/widgets/compare-complete-tabs/ui/SwipeCarousel.tsx
+++ b/apps/knockdog/src/widgets/compare-complete-tabs/ui/SwipeCarousel.tsx
@@ -51,7 +51,7 @@ function SwipeCarousel({ title, slides }: SwipeCarouselProps) {
     <div className='w-full'>
       {title && <Title>{title}</Title>}
       <div
-        className='relative overflow-hidden rounded-lg bg-white select-none'
+        className='relative overflow-hidden bg-white select-none'
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교결과 ComparisonTable 구분선이 전체 높이를 채우도록 수정
- 비교결과 캐러셀 라운드값 삭제 &  행 배경색 수정
- 비교결과 툴팁 디자인 수정
- 비교결과 요일 칩 반응형 크기 개선