### PR TITLE
[fix] 강아지 이름 입력 필드에서 공백 제거 및 최대 길이 제한 추가

### DIFF
--- a/apps/knockdog/src/features/dog-profile/ui/PetProfileForm.tsx
+++ b/apps/knockdog/src/features/dog-profile/ui/PetProfileForm.tsx
@@ -143,13 +143,16 @@ function PetProfileForm({
               <Controller
                 name='name'
                 control={control}
-                rules={{
-                  required: '강아지 이름을 입력해 주세요',
-                  maxLength: { value: 8, message: '8자 이내로 입력해 주세요' },
-                }}
                 render={({ field, fieldState: { error } }) => (
                   <TextField label='강아지 이름' required errorMessage={error?.message}>
-                    <TextFieldInput {...field} placeholder='8자 이내 한글' />
+                    <TextFieldInput
+                      {...field}
+                      placeholder='8자 이내 한글'
+                      onChange={(e) => {
+                        const value = e.target.value.replace(/\s/g, '').slice(0, 8);
+                        field.onChange(value);
+                      }}
+                    />
                   </TextField>
                 )}
               />

--- a/apps/knockdog/src/views/register/pet/ui/PetProfilePage.tsx
+++ b/apps/knockdog/src/views/register/pet/ui/PetProfilePage.tsx
@@ -28,7 +28,14 @@ function PetProfilePage() {
 
         <div className='mt-7'>
           <TextField label='강아지 이름' required>
-            <TextFieldInput placeholder='8자 이내 한글' value={petName} onChange={(e) => setPetName(e.target.value)} />
+            <TextFieldInput
+              placeholder='8자 이내 한글'
+              value={petName}
+              onChange={(e) => {
+                const value = e.target.value.replace(/\s/g, '').slice(0, 8);
+                setPetName(value);
+              }}
+            />
           </TextField>
         </div>
       </div>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

- 강아지 이름 띄어쓰기 및 8자 제한 
[Q2-24](https://jira-knockdog.atlassian.net/browse/Q2-24?atlOrigin=eyJpIjoiZDMwNGZkODA3ZWI0NDk2Mjk0MDc5Nzg4MzZmN2RhYTIiLCJwIjoiaiJ9)


[Q2-24]: https://jira-knockdog.atlassian.net/browse/Q2-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ