### PR TITLE
[fix] PhotoUploader BottomSheet의 UI 개선

### DIFF
--- a/apps/knockdog/src/shared/ui/photo-uploader/PhotoUploader.tsx
+++ b/apps/knockdog/src/shared/ui/photo-uploader/PhotoUploader.tsx
@@ -54,24 +54,30 @@ function PhotoUploader({ maxCount = 3, quality = 0.8, defaultValue, onChange }: 
         <BottomSheet.Body className='z-modal'>
           <BottomSheet.Handle />
 
-          <BottomSheet.Header className='border-line-200 justify-between border-b'>
+          <BottomSheet.Header className='border-line-200 border-b'>
             <BottomSheet.Title>이미지 소스 선택</BottomSheet.Title>
             <BottomSheet.CloseButton />
           </BottomSheet.Header>
-          <ul className='body2-semibold mb-4 cursor-pointer px-6'>
-            <li className='border-line-200 border-b py-4' onClick={() => {
-              handlePickImages('library');
-              close();
-            }}>
-              <button>사진 보관함</button>
-            </li>
-            <li className='border-line-200 border-b py-4' onClick={() => {
-              handlePickImages('camera');
-              close();
-            }}>
-              <button>카메라로 촬영하기</button>
-            </li>
-          </ul>
+          <div className='py-x5 flex flex-col'>
+            <button
+              className='p-x4 body1-bold text-text-primary border-line-200 active:bg-fill-secondary-50 border-b text-start'
+              onClick={() => {
+                handlePickImages('library');
+                close();
+              }}
+            >
+              사진 보관함
+            </button>
+            <button
+              className='p-x4 body1-bold text-text-primary border-line-200 active:bg-fill-secondary-50 border-b text-start'
+              onClick={() => {
+                handlePickImages('camera');
+                close();
+              }}
+            >
+              카메라로 촬영하기
+            </button>
+          </div>
         </BottomSheet.Body>
       </BottomSheet.Root>
     ));


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

* PhotoUploader 컴포넌트의 BottomSheet.Header에서 CloseButton 위치 조정
* 이미지 선택 버튼을 리스트에서 버튼으로 변경하여 스타일 개선
* 버튼에 Tailwind CSS 클래스를 추가하여 일관된 디자인 유지

[JIRA 이슈](https://jira-knockdog.atlassian.net/browse/Q2-48?atlOrigin=eyJpIjoiNWUyMThmYzZmYzA4NGIyYTg0MDY2ZWM2NGIzZTJiMjMiLCJwIjoiaiJ9)