### PR TITLE
fix: 비교 결과 툴팁 우측 하단 radius 제거

### DIFF
--- a/apps/knockdog/src/entities/compare/ui/Label.tsx
+++ b/apps/knockdog/src/entities/compare/ui/Label.tsx
@@ -12,7 +12,7 @@ export function Label({
       {tooltip && (
         <Tooltip className='flex items-center' placement='top-left'>
           <TooltipTrigger />
-          <TooltipContent className='border-line-200 mr-10 ml-8 rounded-lg border p-3 text-[11px] leading-4'>
+          <TooltipContent className='border-line-200 mr-10 ml-8 rounded-lg rounded-br-none border p-3 text-[11px] leading-4'>
             {tooltip}
           </TooltipContent>
         </Tooltip>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교 결과 툴팁 우측 하단 radius 제거