### PR TITLE
feat: 위치권한 거부 시 설정창 열기 기능, 설정창 열기 메소드 추가

### DIFF
--- a/apps/knockdog/src/shared/lib/geolocation/getCurrentLocation.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/getCurrentLocation.ts
@@ -94,6 +94,8 @@ getCurrentLocation.getPermission = async (): Promise<PermissionStatus> => {
 
 /**
  * 위치 권한 요청 다이얼로그 열기
+ * - 앱 환경: 권한 요청 팝업을 띄우거나, 명시적 거부 상태일 경우 시스템 설정창으로 이동
+ * - 웹 환경: 브라우저 권한 요청 시도
  */
 getCurrentLocation.openPermissionDialog = async (): Promise<PermissionStatus> => {
   /* 앱 환경 */
@@ -104,12 +106,22 @@ getCurrentLocation.openPermissionDialog = async (): Promise<PermissionStatus> =>
       throw new Error('Bridge not initialized');
     }
 
-    const { status } = await bridge.request<{ status: PermissionStatus }>(METHODS.openLocationPermissionDialog, {});
+    const { status, canAskAgain } = await bridge.request<{ status: PermissionStatus; canAskAgain: boolean }>(
+      METHODS.openLocationPermissionDialog,
+      {}
+    );
+
+    if (status === 'denied' && !canAskAgain) {
+      await bridge.request(METHODS.openSettings, {});
+    }
+
     return status;
   }
 
   /* 웹 환경: 브라우저 권한 요청 트리거 (재시도) */
   try {
+    // 웹에서는 명시적 거부(denied) 상태일 경우, JS API로 권한 창을 다시 띄울 수 없음.
+    // 사용자가 직접 브라우저 설정에서 권한을 재설정해야 함.
     await getCurrentLocation();
     return 'allowed';
   } catch (error) {

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -115,7 +115,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     [
       'expo-location',
       {
-        locationAlwaysAndWhenInUsePermission: '$(PRODUCT_NAME) 앱을 사용하기 위해 위치 권한을 허용해주세요.',
+        locationWhenInUsePermission: '주변 유치원을 추천해드리기 위해 위치 권한이 필요합니다.',
       },
     ],
     // Kakao 로그인

--- a/apps/mobile/bridges/handlers/location.ts
+++ b/apps/mobile/bridges/handlers/location.ts
@@ -90,10 +90,11 @@ export function registerLocationHandlers(router: NativeBridgeRouter) {
 
   /** 위치 권한 요청 다이얼로그 열기 */
   router.register(METHODS.openLocationPermissionDialog, async () => {
-    const { status } = await Location.requestForegroundPermissionsAsync();
+    const { status, canAskAgain } = await Location.requestForegroundPermissionsAsync();
 
     return {
       status: mapPermissionStatus(status),
+      canAskAgain,
     };
   });
 }

--- a/apps/mobile/bridges/handlers/system.ts
+++ b/apps/mobile/bridges/handlers/system.ts
@@ -89,4 +89,15 @@ export function registerSystemHandlers(router: NativeBridgeRouter) {
       throw { code: 'EUNAVAILABLE', message: '앱 버전을 가져올 수 없습니다.' };
     }
   });
+
+  /** 설정창 열기 */
+  router.register(METHODS.openSettings, async () => {
+    try {
+      await Linking.openSettings();
+      return { opened: true };
+    } catch (error) {
+      console.error('[APP] openSettings error', error);
+      throw { code: 'EUNAVAILABLE', message: '설정창을 열 수 없습니다.' };
+    }
+  });
 }

--- a/packages/bridge-core/src/methods.ts
+++ b/packages/bridge-core/src/methods.ts
@@ -17,6 +17,7 @@ const METHODS = {
   toastDismiss: 'toast.dismiss',
   toastClear: 'toast.clear',
   openExternalLink: 'system.openExternalLink',
+  openSettings: 'system.openSettings',
   getAppVersion: 'system.getAppVersion',
   kakaoLogin: 'auth.kakaoLogin',
   googleLogin: 'auth.googleLogin',

--- a/packages/bridge-core/src/rpc-schema.ts
+++ b/packages/bridge-core/src/rpc-schema.ts
@@ -38,7 +38,11 @@ interface RPCSchema {
   };
   [METHODS.openLocationPermissionDialog]: {
     params: {};
-    result: { status: PermissionStatus };
+    result: { status: PermissionStatus; canAskAgain: boolean };
+  };
+  [METHODS.openSettings]: {
+    params: {};
+    result: { opened: boolean };
   };
   [METHODS.callPhone]: {
     params: CallPhoneParams;


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/KDDEV-299

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

1. (knockdog) 위치권한 거부시 설정창 열기 기능 추가
2. (mobile, bridge-core) 설정창 열기 메소드 추가 `openSettings`
3. iOS 위치 권한 변경 `locationAlwaysAndWhenInUsePermission` → `locationWhenInUsePermission`
: 백그라운드에서 위치를 받아올 필요 X 때문에

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
