### PR TITLE
Fix: 유치원 상세 페이지 홈 버튼 동작 픽스

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
@@ -15,11 +15,6 @@ interface KindergartenCardProps extends KindergartenListItemWithMeta {
 }
 
 export function KindergartenCard(props: KindergartenCardProps) {
-  const openPhoneCallActionSheet = () =>
-    overlay.open(({ isOpen, close }) => (
-      <PhoneCallSheet isOpen={isOpen} close={close} phoneNumber={props.phoneNumber} />
-    ));
-
   const openDeparturePointSheet = () =>
     overlay.open(({ isOpen, close }) => (
       <DeparturePointSheet
@@ -117,27 +112,6 @@ export function KindergartenCard(props: KindergartenCardProps) {
           </div>
         </div>
       </div>
-
-      <BottomSheet.Footer className='pt-x6 pb-x4'>
-        <div className='gap-x2 flex items-center'>
-          <ActionButton variant='primaryLine' size='medium' onClick={openPhoneCallActionSheet}>
-            전화하기
-          </ActionButton>
-          <ActionButton variant='primaryFill' size='medium' disabled>
-            비교하기
-          </ActionButton>
-          <button
-            aria-label='보관하기'
-            className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
-            onClick={() => props.onBookmarkClick(props.id, props.isBookmarked ?? false)}
-          >
-            <Icon
-              icon={props.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
-              className='size-x6 text-fill-primary-500'
-            />
-          </button>
-        </div>
-      </BottomSheet.Footer>
     </>
   );
 }

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
@@ -38,6 +38,9 @@ export function KindergartenDetail({ kindergartenId }: KindergartenDetailProps) 
         {/* 세부 컨텐츠 영역 */}
         {/* 탭 */}
         <KindergartenTabs kindergartenId={kindergartenId} />
+
+        {/* 하단 공간 (액션 바 높이) */}
+        <div className='h-14 w-full' />
       </div>
     </>
   );

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BottomSheet, TRANSITION_DURATION_MS } from '@knockdog/ui';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ActionButton, BottomSheet, Icon } from '@knockdog/ui';
 import { KindergartenCard } from './KindergartenCard';
 import { cn } from '@knockdog/ui/lib';
 import { motion, useIsomorphicLayoutEffect, useTransform } from 'framer-motion';
 import { RemoveScroll } from 'react-remove-scroll';
 import { useBookmarkToggle } from '../model/useBookmarkToggle';
 import { useSheetDragProgress } from '../model/useViewportProgress';
+import { overlay } from 'overlay-kit';
 import { Header } from '@widgets/Header';
 import { KindergartenDetail } from '@features/kindergarten-list/ui/KindergartenDetail';
 import { useSearchListQuery } from '@features/kindergarten-map';
+import { PhoneCallSheet } from '@features/kindergarten-list/ui/PhoneCallSheet';
 import { isNativeWebView, useSafeAreaInsets, useShare } from '@shared/lib';
 import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
 
@@ -45,6 +47,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
   const [activeSnapPoint, setActiveSnapPoint] = useState<SnapPoint>(snapPoints[0] ?? null);
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLDivElement>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const { top: safeAreaTop } = useSafeAreaInsets();
   const isMaxSnap = activeSnapPoint === snapPoints[1];
@@ -71,16 +74,31 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
     share(shareData);
   };
 
+  const openPhoneCallActionSheet = () =>
+    overlay.open(({ isOpen, close }) => (
+      <PhoneCallSheet isOpen={isOpen} close={close} phoneNumber={currentItem?.phoneNumber ?? ''} />
+    ));
+
   useIsomorphicLayoutEffect(() => {
     if (containerRef.current) {
       setContainer(containerRef.current);
     }
   }, [containerRef]);
 
+  useEffect(() => {
+    console.log('activeSnapPoint changed:', activeSnapPoint);
+    console.log('isOpen:', isOpen);
+  }, [activeSnapPoint, isOpen]);
+
+  useEffect(() => {
+    console.log('container changed:', container);
+  }, [container]);
+
   if (currentItem == null) return null;
   return (
     <>
       <motion.div
+        ref={headerRef}
         className='fixed top-0 left-0 z-50 w-screen bg-white'
         style={{ paddingTop: safeAreaTop, opacity: hiddenOpacity }}
       >
@@ -121,14 +139,17 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
             <BottomSheet.Body
               onPointerDownOutside={(e) => {
                 e.preventDefault();
-                onClose();
+
+                if (!headerRef.current?.contains(e.target as Node)) {
+                  onClose();
+                }
               }}
               className={cn(
                 'pointer-events-auto absolute inset-x-0 z-50 h-full max-h-[calc(100vh-64px)]',
                 activeSnapPoint === snapPoints[1] && 'h-full'
               )}
             >
-              <div ref={viewRef} className={cn('h-full', isMaxSnap && 'overflow-y-auto')}>
+              <div ref={viewRef} className={cn('relative h-full', isMaxSnap && 'overflow-y-auto')}>
                 <motion.div
                   className='absolute inset-0'
                   style={{
@@ -154,6 +175,25 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
             </BottomSheet.Body>
           </RemoveScroll>
         </BottomSheet.Root>
+
+        <div className='p-x4 gap-x2 fixed right-0 bottom-0 left-0 z-50 flex items-center bg-white'>
+          <ActionButton variant='primaryLine' size='medium' onClick={openPhoneCallActionSheet}>
+            전화하기
+          </ActionButton>
+          <ActionButton variant='primaryFill' size='medium' disabled>
+            비교하기
+          </ActionButton>
+          <button
+            aria-label='보관하기'
+            className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
+            onClick={() => onBookmarkClick(currentItem.id, currentItem.isBookmarked ?? false)}
+          >
+            <Icon
+              icon={currentItem.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
+              className='size-x6 text-fill-primary-500'
+            />
+          </button>
+        </div>
       </div>
     </>
   );

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -18,11 +18,12 @@ import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
 import { type BasePointType, useBasePointType } from '@shared/store';
 
 interface KindergartenListProps {
-  onOpenFilter: () => void;
   region?: string | null;
+  onOpenFilter: () => void;
+  onMoveHome?: () => void;
 }
 
-export function KindergartenList({ onOpenFilter, region }: KindergartenListProps) {
+export function KindergartenList({ onOpenFilter, region, onMoveHome }: KindergartenListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
@@ -164,7 +165,12 @@ export function KindergartenList({ onOpenFilter, region }: KindergartenListProps
             )}
             {searchList.map((item) => (
               <Fragment key={item.id}>
-                <KindergartenListItem {...item} banner={item.banner ?? []} onBookmarkClick={onBookmarkClick} />
+                <KindergartenListItem
+                  {...item}
+                  banner={item.banner ?? []}
+                  onBookmarkClick={onBookmarkClick}
+                  onMoveHome={onMoveHome}
+                />
                 <hr className='bg-line-100 text-line-100 h-[8px] w-full' />
               </Fragment>
             ))}

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
@@ -6,6 +6,7 @@ import { useStackNavigation } from '@shared/lib/bridge';
 
 interface KindergartenListItemProps extends KindergartenListItemWithMeta {
   onBookmarkClick?: (id: string, isBookmarked: boolean) => void;
+  onMoveHome?: () => void;
 }
 
 export function KindergartenListItem({
@@ -24,11 +25,13 @@ export function KindergartenListItem({
   memo,
   isBookmarked = false,
   onBookmarkClick,
+  onMoveHome,
 }: KindergartenListItemProps) {
-  const { push } = useStackNavigation();
+  const { pushForResult } = useStackNavigation();
 
-  const handleClick = () => {
-    push({ pathname: `/kindergarten/${id}` });
+  const handleClick = async () => {
+    const isMoveHome = await pushForResult({ pathname: `/kindergarten/${id}` });
+    if (isMoveHome) onMoveHome?.();
   };
 
   return (

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 import { cn } from '@knockdog/ui/lib';
+import { KindergartenList } from '@features/kindergarten-list/ui/KindergartenList';
 import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
 import { BottomSheet } from '@shared/ui/bottom-sheet';
 import { isNativeWebView, useBottomSheetSnapIndex, useIsomorphicLayoutEffect, useSafeAreaInsets } from '@shared/lib';
@@ -10,15 +11,14 @@ import { useMarkerState } from '@shared/store';
 // 최대 스냅포인트: 화면높이 - 64px(검색 헤더바 높이) - 16px (Handle 높이)
 
 // ✅ 구(HEAD)·신(리팩토링) 버전 병합: children을 기본으로 받되, 하위호환으로 bottomSlot도 함께 허용
-export function KindergartenListSheet({
-  fabSlot,
-  children,
-  bottomSlot,
-}: {
+interface KindergartenListSheetProps {
   fabSlot: React.ReactNode;
-  children?: React.ReactNode;
+  region?: string | null;
   bottomSlot?: React.ReactNode;
-}) {
+  onOpenFilter: () => void;
+}
+
+export function KindergartenListSheet({ fabSlot, region, bottomSlot, onOpenFilter }: KindergartenListSheetProps) {
   const { top } = useSafeAreaInsets();
 
   // 리팩토링 분기 반영
@@ -84,7 +84,7 @@ export function KindergartenListSheet({
             <BottomSheet.Title className='sr-only'>강아지 유치원 목록</BottomSheet.Title>
 
             {/* 신버전(children) 우선, 구버전(bottomSlot)도 렌더링해 하위호환 보장 */}
-            {children}
+            <KindergartenList onOpenFilter={onOpenFilter} onMoveHome={() => setSnapIndex(0)} region={region} />
             {bottomSlot}
           </BottomSheet.Body>
         </RemoveScroll>

--- a/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
@@ -2,18 +2,19 @@
 
 import { useRef } from 'react';
 import { Divider, ActionButton } from '@knockdog/ui';
+import { useParams } from 'next/navigation';
+import { overlay } from 'overlay-kit';
+import { useRecentKindergartenView } from '../model/useRecentKindergartenView';
 
 import { KindergartenTabs } from '@widgets/kindergarten-tabs';
 import { Header } from '@widgets/Header';
 import { useKindergartenMainQuery, KindergartenMainBox, MainBannerSwiper } from '@features/kindergarten-main';
-import { useCurrentLocation } from '@shared/lib/geolocation';
-import { useParams } from 'next/navigation';
-import { BookmarkToggleIcon } from '@entities/bookmark';
 import { PhoneCallSheet } from '@features/kindergarten-list';
-import { overlay } from 'overlay-kit';
+import { BookmarkToggleIcon } from '@entities/bookmark';
+import { useCurrentLocation } from '@shared/lib/geolocation';
 import { useShare } from '@shared/lib/device';
 import { SafeArea } from '@shared/ui/safe-area';
-import { useRecentKindergartenView } from '../model/useRecentKindergartenView';
+import { useNavigationResult, useStackNavigation } from '@shared/lib/bridge';
 
 function KindergartenDetailPage() {
   const scrollableDivRef = useRef<HTMLDivElement>(null);
@@ -23,6 +24,8 @@ function KindergartenDetailPage() {
   const id = Array.isArray(rawId) ? rawId[0] : rawId;
   if (!id) return null;
 
+  const { back } = useStackNavigation();
+  const navResult = useNavigationResult<boolean>();
   const { position } = useCurrentLocation();
   const { lng, lat } = position || { lng: 126.883439, lat: 37.511281 };
 
@@ -56,12 +59,17 @@ function KindergartenDetailPage() {
     share(shareData);
   };
 
+  const handleHomeClick = () => {
+    navResult.send(true);
+    back();
+  };
+
   return (
     <SafeArea edges={['bottom']}>
       <Header>
         <Header.LeftSection>
           <Header.BackButton />
-          <Header.HomeButton />
+          <Header.HomeButton onClick={handleHomeClick} />
         </Header.LeftSection>
 
         <Header.Title>{kindergartenMain?.title}</Header.Title>

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -150,6 +150,8 @@ function KindergartenMainPageContent() {
       </div>
 
       <KindergartenListSheet
+        onOpenFilter={handleOpenFilter}
+        region={searchParams?.get('region')}
         fabSlot={
           <div className='px-x4 absolute -top-[50px] flex w-full items-center justify-center'>
             <Float placement='top-start' offsetX='x4'>
@@ -164,9 +166,7 @@ function KindergartenMainPageContent() {
             </Float>
           </div>
         }
-      >
-        <KindergartenList onOpenFilter={handleOpenFilter} region={searchParams?.get('region')} />
-      </KindergartenListSheet>
+      />
 
       {isSheetOpen && selectedItemId && (
         <KindergartenItemSheet


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 티켓

- [Q2-16 [iOS/카카오/탐색] 업체 상세화면 바텀시트에서 전체화면으로 늘렸을 때 '전화하기, 비교하기, 북마크' 버튼 사라짐](https://jira-knockdog.atlassian.net/browse/Q2-16?atlOrigin=eyJpIjoiNTMyNjRmYmEwNzcwNDdhMWJhNzliN2E3YmQ2ODFkYmYiLCJwIjoiaiJ9)
- [Q2-40 [iOS/카카오/탐색] 유치원 상세페이지에서 '홈버튼' 동작되지 않음](https://jira-knockdog.atlassian.net/browse/Q2-40?atlOrigin=eyJpIjoiOWJmN2VjMmM3Yzk4NGRmZjllNmUzNThlMjkzZmE1MTgiLCJwIjoiaiJ9)


## 작업 내용

### 지도 -> 마커 클릭 -> 바텀 시트 상세 페이지
-  헤더 영역 `onPointerDownOutside` 이벤트 방지
- 전화하기, 비교하기 버튼 액션 바 레이아웃 변경

### 지도 -> 유치원 리스트 시트 -> 유치원 상세 페이지
- 홈 버튼 동작 픽스
