### PR TITLE
feat: 기준점 선택 플로우 개선 및 위치 권한 로직 리팩터링

### DIFF
--- a/apps/knockdog/src/entities/address/config/geoQueries.ts
+++ b/apps/knockdog/src/entities/address/config/geoQueries.ts
@@ -5,9 +5,8 @@ type ReverseGeocodeQueryParams = ReverseGeocodeParams & { zoomLevel?: number | n
 
 export const geoQueries = {
   keys: {
-    all: () => ['geo'] as const,
     reverseGeocode: (params: ReverseGeocodeQueryParams) =>
-      [...geoQueries.keys.all(), 'reverseGeocode', params.lat, params.lng, params.zoomLevel] as const,
+      ['reverseGeocode', params.lat, params.lng, params.zoomLevel] as const,
   },
 
   reverseGeocode: ({ lat, lng, zoomLevel }: ReverseGeocodeQueryParams) =>

--- a/apps/knockdog/src/entities/address/index.ts
+++ b/apps/knockdog/src/entities/address/index.ts
@@ -4,3 +4,6 @@ export { getReverseGeocode, type ReverseGeocodeParams } from './api/reverse';
 /** Model */
 export type { Address, LatLng, AddressSearchResult, AddressData } from './model/address';
 export type { ReverseGeocodeResponse } from './model/reverse';
+
+/** Config */
+export { geoQueries } from './config/geoQueries';

--- a/apps/knockdog/src/entities/kindergarten/ui/DeparturePointSheet.tsx
+++ b/apps/knockdog/src/entities/kindergarten/ui/DeparturePointSheet.tsx
@@ -101,7 +101,7 @@ interface DeparturePointSheetProps {
 }
 
 export function DeparturePointSheet({ isOpen, close, to }: DeparturePointSheetProps) {
-  const { data: coords, isLoading: locationLoading, error: locationError } = useGeolocationQuery(isOpen);
+  const { data: coords, isLoading: locationLoading, error: locationError } = useGeolocationQuery({ enabled: isOpen });
   const [addressLoading, setAddressLoading] = useState(false);
   const [addressError, setAddressError] = useState<string | null>(null);
   const [addressText, setAddressText] = useState<string | null>(null);
@@ -197,7 +197,7 @@ export function DeparturePointSheet({ isOpen, close, to }: DeparturePointSheetPr
             >
               <div className='gap-x2 flex items-center'>
                 <Icon icon='LocationFill' className='text-fill-secondary-500 size-x6' />
-                <div className='gap-x0_5 flex flex-col text-start'>
+                <div className='gap-x0.5 flex flex-col text-start'>
                   <p className='body1-extrabold text-text-primary'>현재 위치</p>
                   <span className='body2-regular text-text-secondary'>{label}</span>
                 </div>
@@ -218,7 +218,7 @@ export function DeparturePointSheet({ isOpen, close, to }: DeparturePointSheetPr
                   >
                     <div className='gap-x2 flex items-center'>
                       <Icon icon='LocationFill' className='text-fill-secondary-500 size-x6' />
-                      <div className='gap-x0_5 flex flex-col text-start'>
+                      <div className='gap-x0.5 flex flex-col text-start'>
                         <p className='body1-extrabold text-text-primary'>{addressLabel}</p>
                         <span className='body2-regular text-text-secondary'>{savedAddressText}</span>
                       </div>

--- a/apps/knockdog/src/entities/user/model/constant/user.ts
+++ b/apps/knockdog/src/entities/user/model/constant/user.ts
@@ -9,8 +9,8 @@ const USER_STATUS = {
 /** 주소 타입 한글 */
 const USER_ADDRESS_TYPE_KR = {
   HOME: '집',
-  WORK: '회사',
-  OTHER: '기타',
+  WORK: '직장',
+  // OTHER: '기타',
 } as const;
 
 /** 주소 타입 */
@@ -20,7 +20,7 @@ const USER_ADDRESS_TYPE = {
   /** 직장 */
   WORK: 'WORK',
   /** 기타 */
-  OTHER: 'OTHER',
+  // OTHER: 'OTHER',
 } as const;
 
 /** 탈퇴 사유 타입 */

--- a/apps/knockdog/src/entities/user/model/useBasePoint.ts
+++ b/apps/knockdog/src/entities/user/model/useBasePoint.ts
@@ -10,7 +10,7 @@ export function useBasePoint() {
   const { selectedBaseType } = useBasePointType();
   const user = useUserStore((state) => state.user);
 
-  const { data: currentLocation } = useGeolocationQuery(selectedBaseType === 'CURRENT');
+  const { data: currentLocation } = useGeolocationQuery({ enabled: selectedBaseType === 'CURRENT' });
 
   const homeAddress = useMemo(() => user?.addresses?.find((address) => address.type === 'HOME'), [user?.addresses]);
   const workAddress = useMemo(() => user?.addresses?.find((address) => address.type === 'WORK'), [user?.addresses]);

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -79,6 +79,7 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
 
     // 직장 선택 시 등록된 직장 있는지 체크
     if (newType === 'WORK') {
+      if (!user) return;
       const hasWorkAddress = user?.addresses?.some((addr) => addr.type === USER_ADDRESS_TYPE.WORK);
       if (!hasWorkAddress) {
         handleOpenAlertDialog();

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -102,7 +102,12 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel onClick={close}>나중에</AlertDialogCancel>
-            <AlertDialogAction onClick={() => push({ pathname: route.mypage.profile.location.root })}>
+            <AlertDialogAction
+              onClick={() => {
+                close();
+                push({ pathname: route.mypage.profile.location.root });
+              }}
+            >
               등록하기
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -1,5 +1,19 @@
 import { Fragment, useEffect, useRef } from 'react';
-import { Float, FloatingActionButton, Icon, SegmentedControl, SegmentedControlItem } from '@knockdog/ui';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Float,
+  FloatingActionButton,
+  Icon,
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@knockdog/ui';
 import { cn } from '@knockdog/ui/lib';
 import { useSearchFilter } from '../model/useSearchFilter';
 import { useFabExtension } from '../model/useFabExtension';
@@ -16,6 +30,11 @@ import { GetLocationPermissionError, isNativeWebView, useBottomSheetSnapIndex } 
 import { useGeolocationQuery } from '@shared/lib/geolocation/useGeolocationQuery';
 import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
 import { type BasePointType, useBasePointType } from '@shared/store';
+import { overlay } from 'overlay-kit';
+import { useStackNavigation } from '@shared/lib/bridge';
+import { route } from '@shared/constants/route';
+import { useUserStore, USER_ADDRESS_TYPE } from '@entities/user';
+import { tokenUtils } from '@shared/utils';
 
 interface KindergartenListProps {
   region?: string | null;
@@ -29,6 +48,9 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
 
   const { selectedBaseType, setBaseType } = useBasePointType();
   const { isFullExtended, setSnapIndex } = useBottomSheetSnapIndex();
+  const { push } = useStackNavigation();
+  const user = useUserStore((s) => s.user);
+  const isLoggedIn = !!user || tokenUtils.hasAccessToken();
 
   const { getSelectedFilterWithLabel, onToggleOption, isSelectedOption, isEmptyFilters } = useSearchFilter();
   const { isFabExtended, sentinelRef } = useFabExtension(containerRef);
@@ -43,6 +65,49 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
   // 위치 권한 에러 체크
   const { error: locationError } = useGeolocationQuery(selectedBaseType === 'CURRENT');
   const isPermissionDenied = selectedBaseType === 'CURRENT' && locationError instanceof GetLocationPermissionError;
+
+  const handleBasePointTypeChange = (value: string) => {
+    const newType = value as BasePointType;
+
+    // 비로그인 사용자 체크
+    if (!isLoggedIn) {
+      if (newType !== 'CURRENT') {
+        push({ pathname: route.auth.login.root });
+        return;
+      }
+    }
+
+    // 직장 선택 시 등록된 직장 있는지 체크
+    if (newType === 'WORK') {
+      const hasWorkAddress = user?.addresses?.some((addr) => addr.type === USER_ADDRESS_TYPE.WORK);
+      if (!hasWorkAddress) {
+        handleOpenAlertDialog();
+        return;
+      }
+    }
+
+    setBaseType(newType);
+  };
+
+  const handleOpenAlertDialog = () =>
+    overlay.open(({ isOpen, close }) => (
+      <AlertDialog open={isOpen} onOpenChange={close}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>등록된 직장 위치가 없어요!</AlertDialogTitle>
+            <AlertDialogDescription>
+              새로운 위치 추가는 마이 {'>'} 내 장소 관리에서 가능해요! 지금 직장 위치를 등록하러 갈까요?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={close}>나중에</AlertDialogCancel>
+            <AlertDialogAction onClick={() => push({ pathname: route.mypage.profile.location.root })}>
+              등록하기
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    ));
 
   useEffect(() => {
     const root = isFullExtended ? containerRef.current : null;
@@ -66,10 +131,6 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
     return () => observer.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasNextPage, isFetchingNextPage]);
-
-  const handleBasePointTypeChange = (value: string) => {
-    setBaseType(value as BasePointType);
-  };
 
   return (
     <>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -63,7 +63,7 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
   const selectedFilters = getSelectedFilterWithLabel();
 
   // 위치 권한 에러 체크
-  const { error: locationError } = useGeolocationQuery(selectedBaseType === 'CURRENT');
+  const { error: locationError } = useGeolocationQuery({ enabled: selectedBaseType === 'CURRENT' });
   const isPermissionDenied = selectedBaseType === 'CURRENT' && locationError instanceof GetLocationPermissionError;
 
   const handleBasePointTypeChange = (value: string) => {

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -148,7 +148,7 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
         {/* 헤더 영역  */}
         <div className='bg-bg-0 sticky top-[-.5px] z-20'>
           <div className='px-x4 pb-x4 pt-x2'>
-            <SegmentedControl defaultValue={selectedBaseType} onValueChange={handleBasePointTypeChange}>
+            <SegmentedControl value={selectedBaseType} onValueChange={handleBasePointTypeChange}>
               <SegmentedControlItem value='CURRENT'>현 위치</SegmentedControlItem>
               <SegmentedControlItem value='HOME'>집</SegmentedControlItem>
               <SegmentedControlItem value='WORK'>직장</SegmentedControlItem>

--- a/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationDisplayFAB.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationDisplayFAB.tsx
@@ -2,8 +2,8 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { CurrentLocationDisplay } from './CurrentLocationDisplay';
 import { DEFAULT_MAP_ZOOM_LEVEL } from '../config/map';
 import { getRegionLevel } from '../lib/markers';
-import { geoQueries } from '../api/geoQueries';
 import { useSearchMachine } from '../model/useSearchMachine';
+import { geoQueries } from '@entities/address';
 
 export function CurrentLocationDisplayFAB() {
   const { liveState } = useSearchMachine();

--- a/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationFAB.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationFAB.tsx
@@ -7,7 +7,7 @@ import { useBasePointType } from '@shared/store';
 
 export function CurrentLocationFAB() {
   const { dispatch } = useSearchMachine();
-  const { refetch } = useGeolocationQuery(false);
+  const { refetch } = useGeolocationQuery({ enabled: false });
   const { setBaseType } = useBasePointType();
 
   const handleClick = async () => {

--- a/apps/knockdog/src/features/location-permission/lib/useLocationPermission.ts
+++ b/apps/knockdog/src/features/location-permission/lib/useLocationPermission.ts
@@ -1,90 +1,83 @@
 import { useEffect, useState } from 'react';
 import type { PermissionStatus } from '@knockdog/bridge-core';
-import { getCurrentLocation } from '@shared/lib/geolocation';
-import { getReverseGeocode } from '@features/address-picker/api/searchAddress';
+import { getCurrentLocation, useGeolocationQuery } from '@shared/lib/geolocation';
+import { useQuery } from '@tanstack/react-query';
+import { geoQueries } from '@entities/address';
 
 function useLocationPermission() {
   const [permissionStatus, setPermissionStatus] = useState<PermissionStatus>('undetermined');
-  const [location, setLocation] = useState<{ latitude: number; longitude: number } | null>(null);
-  const [address, setAddress] = useState<{
-    primaryText: string | undefined;
-    primaryRoad: string | undefined;
-    primaryParcel: string | undefined;
-    isLoading: boolean;
-    error: string | null;
-  }>({
-    primaryText: undefined,
-    primaryRoad: undefined,
-    primaryParcel: undefined,
-    isLoading: false,
-    error: null,
+
+  // 위치 정보 가져오기 (권한이 있을 때만 실행)
+  const { data: location, ...locationQuery } = useGeolocationQuery({
+    enabled: permissionStatus === 'allowed',
+    options: {
+      enableHighAccuracy: true,
+      timeout: 10000,
+    },
   });
 
-  async function getLocation() {
-    const location = await getCurrentLocation();
-    setLocation(location.coords);
-  }
+  // 주소 정보 가져오기 (위치가 있을 때만 실행)
+  const {
+    data: addressDocument,
+    isLoading: isAddressLoading,
+    error: addressError,
+  } = useQuery({
+    ...geoQueries.reverseGeocode({
+      lat: location?.lat ?? 0,
+      lng: location?.lng ?? 0,
+    }),
+    enabled: !!location,
+    select: (data) => data.documents?.[0],
+  });
 
-  // permission이 allowed일 때 위치 가져오기
-  useEffect(() => {
-    if (permissionStatus === 'allowed') {
-      (async () => {
-        await getLocation();
-      })();
+  const address = {
+    addressName: addressDocument?.address?.address_name,
+    isLoading: isAddressLoading || (permissionStatus === 'allowed' && !location),
+    error: addressError ? '주소를 가져오는데 실패했습니다.' : null,
+  };
+
+  /**
+   * 권한 상태 확인
+   */
+  const checkPermission = async () => {
+    try {
+      const status = await getCurrentLocation.getPermission();
+      console.log('Location Permission Status:', status);
+      setPermissionStatus(status);
+    } catch (error) {
+      console.error('권한 확인 실패:', error);
+      setPermissionStatus('denied');
     }
-  }, [permissionStatus]);
+  };
 
-  // 위치가 변경되면 주소 가져오기
-  useEffect(() => {
-    if (location && permissionStatus === 'allowed' && location.latitude !== 0 && location.longitude !== 0) {
-      setAddress((prev) => ({ ...prev, isLoading: true, error: null }));
-      getReverseGeocode(location.latitude, location.longitude)
-        .then((response) => {
-          const firstDoc = response.documents[0];
-          setAddress({
-            primaryText: firstDoc?.road_address?.address_name || firstDoc?.address?.address,
-            primaryRoad: firstDoc?.address?.roadAddress,
-            primaryParcel: firstDoc?.address?.address,
-            isLoading: false,
-            error: null,
-          });
-        })
-        .catch((err) => {
-          setAddress((prev) => ({
-            ...prev,
-            isLoading: false,
-            error: err instanceof Error ? err.message : '주소를 가져오는데 실패했습니다.',
-          }));
-        });
+  /**
+   * 권한 요청 (앱 내 팝업)
+   */
+  const requestPermission = async () => {
+    try {
+      const status = await getCurrentLocation.openPermissionDialog();
+      setPermissionStatus(status);
+      return status;
+    } catch (error) {
+      console.error('권한 요청 실패:', error);
+      return 'denied';
     }
-  }, [location?.latitude, location?.longitude, permissionStatus]);
+  };
 
-  // 초기 permission 체크
+  // 초기 권한 확인
   useEffect(() => {
-    async function checkPermission() {
-      try {
-        const status = await getCurrentLocation.getPermission();
-        setPermissionStatus(status);
-      } catch (error) {
-        console.error('권한 확인 실패:', error);
-        setPermissionStatus('denied');
-      }
-    }
-
     checkPermission();
   }, []);
 
-  // 앱이 다시 foreground로 돌아올 때 permission 재확인
+  // 앱 포커스 시 권한 재확인 (설정 등에서 변경했을 수 있음)
   useEffect(() => {
     async function handleVisibilityChange() {
       if (document.visibilityState === 'visible') {
-        const status = await getCurrentLocation.getPermission();
-        setPermissionStatus(status);
+        await checkPermission();
       }
     }
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
-
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
@@ -94,6 +87,8 @@ function useLocationPermission() {
     permissionStatus,
     location,
     address,
+    requestPermission,
+    isLoading: locationQuery.isLoading || isAddressLoading,
   };
 }
 

--- a/apps/knockdog/src/features/location-permission/lib/useLocationPermission.ts
+++ b/apps/knockdog/src/features/location-permission/lib/useLocationPermission.ts
@@ -32,7 +32,7 @@ function useLocationPermission() {
 
   const address = {
     addressName: addressDocument?.address?.address_name,
-    isLoading: isAddressLoading || (permissionStatus === 'allowed' && !location),
+    isLoading: isAddressLoading || (permissionStatus === 'allowed' && !location && !locationQuery.isError),
     error: addressError ? '주소를 가져오는데 실패했습니다.' : null,
   };
 
@@ -42,7 +42,6 @@ function useLocationPermission() {
   const checkPermission = async () => {
     try {
       const status = await getCurrentLocation.getPermission();
-      console.log('Location Permission Status:', status);
       setPermissionStatus(status);
     } catch (error) {
       console.error('권한 확인 실패:', error);

--- a/apps/knockdog/src/features/location-permission/ui/LocationPermissionSection.tsx
+++ b/apps/knockdog/src/features/location-permission/ui/LocationPermissionSection.tsx
@@ -5,8 +5,7 @@ import { openSystemSetting } from '@shared/lib/bridge/openSystemSetting';
 import { useLocationPermission } from '../lib/useLocationPermission';
 
 function LocationPermissionSection() {
-  const { permissionStatus, address } = useLocationPermission();
-  const { primaryText, primaryRoad, primaryParcel } = address;
+  const { permissionStatus, address, requestPermission } = useLocationPermission();
 
   return (
     <div className='mt-6 flex flex-col gap-y-2 px-4'>
@@ -27,12 +26,28 @@ function LocationPermissionSection() {
         <div className='flex flex-col gap-y-[2px]'>
           <span className='h3-extrabold text-text-primary'>현재 위치</span>
           {permissionStatus === 'allowed' ? (
-            <span className='body2-regular text-text-secondary'>{primaryText || primaryRoad || primaryParcel}</span>
+            <span className='body2-regular text-text-secondary'>
+              {address.addressName || '위치 정보를 찾을 수 없음'}
+            </span>
           ) : (
             <span className='body2-regular text-text-secondary'>실시간 GPS가 꺼져 있습니다</span>
           )}
         </div>
-        <Switch pressed={permissionStatus === 'allowed'} onPressedChange={() => openSystemSetting()} />
+        <Switch
+          pressed={permissionStatus === 'allowed'}
+          onPressedChange={() => {
+            if (permissionStatus === 'allowed') {
+              // 1. 이미 허용 상태면 설정을 열어서 끄도록 유도
+              openSystemSetting();
+            } else if (permissionStatus === 'denied') {
+              // 2. 거절 상태면 설정을 열어서 켜도록 유도
+              openSystemSetting();
+            } else {
+              // 3. 미정 상태면 앱 내 팝업으로 권한 요청
+              requestPermission();
+            }
+          }}
+        />
       </div>
     </div>
   );

--- a/apps/knockdog/src/shared/constants/route.ts
+++ b/apps/knockdog/src/shared/constants/route.ts
@@ -63,6 +63,16 @@ const route = {
       root: '/register/welcome',
     },
   },
+  mypage: {
+    /** 마이 페이지 */
+    root: '/mypage',
+    profile: {
+      location: {
+        /** 내 장소 설정 페이지 */
+        root: '/mypage/profile/location',
+      },
+    },
+  },
 };
 
 export { route };

--- a/apps/knockdog/src/shared/lib/geolocation/useGeolocationQuery.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/useGeolocationQuery.ts
@@ -3,10 +3,25 @@
 import { useQuery } from '@tanstack/react-query';
 import { getCurrentLocation } from './getCurrentLocation';
 
-export function useGeolocationQuery(enabled = true) {
+interface UseGeolocationQueryOptions {
+  enabled?: boolean;
+  options?: {
+    enableHighAccuracy?: boolean;
+    timeout?: number;
+    maximumAge?: number;
+  };
+}
+
+export function useGeolocationQuery({ enabled = true, options }: UseGeolocationQueryOptions = {}) {
   return useQuery({
-    queryKey: ['current'],
-    queryFn: () => getCurrentLocation({ enableHighAccuracy: true, timeout: 5000, maximumAge: 30_000 }),
+    queryKey: ['current', options],
+    queryFn: () =>
+      getCurrentLocation({
+        enableHighAccuracy: true,
+        timeout: 5000,
+        maximumAge: 30_000,
+        ...options,
+      }),
     enabled,
     staleTime: 30_000,
     gcTime: 5 * 60_000,

--- a/apps/knockdog/src/views/register/location/ui/LocationAddPage.tsx
+++ b/apps/knockdog/src/views/register/location/ui/LocationAddPage.tsx
@@ -40,7 +40,7 @@ function LocationAddPage() {
               control={control}
               name='alias'
               render={({ field }) => (
-                <Field hidden={type !== USER_ADDRESS_TYPE.OTHER}>
+                <Field hidden={[USER_ADDRESS_TYPE.HOME, USER_ADDRESS_TYPE.WORK].includes(type)}>
                   <FieldLabel>장소 이름</FieldLabel>
 
                   <TextField variant='secondary'>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/Q2-64
- 기준점 선택 플로우 개선: 비로그인/등록된 직장 없음 등 사용자 상황에 따른 기준점 선택 동작을 개선했습니다.
- 위치 권한 로직 리팩터링


## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### 1. 기준점 선택(SegmentedControl) 사용성 개선
- 비로그인 사용자: '현 위치' 외의 타입(집, 직장) 선택 시 로그인 페이지로 이동하도록 설정.
- 직장 주소 미등록 사용자: '직장' 선택 시 등록 유도 Alert 노출. (등록하기 → 마이페이지 이동 / 나중에 → 선택 취소)
- Controlled Component 적용: Alert에서 '나중에' 클릭 시 선택 상태가 변경되지 않도록 SegmentedControl을 defaultValue에서 value 기반의 제어 컴포넌트로 변경.

#### 2. 위치 권한 및 데이터 훅 리팩터링
- `useGeolocationQuery` 개선: 옵션 객체({ enabled, options: { enableHighAccuracy, timeout } })를 받도록 수정하여 확장성 확보.
- `useLocationPermission` 재설계
  - 기존의 수동 상태 관리(useState+useEffect) 제거
  - React Query(`useGeolocationQuery`, useQuery) 조합으로 상태 흐름을 선언적으로 변경
  - 명시적 권한 요청: `requestPermission` 함수를 추가하여 '미정(undetermined)' 상태에서도 앱 내 권한 팝업을 띄울 수 있도록 지원.
- `LocationPermissionSection` UI 로직 수정
  - 스위치 ON/OFF 시 권한 상태(`allowed`, `denied`, `undetermined`)에 따라 시스템 설정 이동 또는 앱 내 권한 요청 분기 처리.


## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
