### PR TITLE
fix: 필터 바텀시트 카운트 불일치 문제 수정

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/FilterBottomSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/FilterBottomSheet.tsx
@@ -4,7 +4,7 @@ import { ActionButton, Icon } from '@knockdog/ui';
 import { FilterList } from './FilterList';
 import { FilterChip } from './FilterChip';
 import { useLocalSearchFilter } from '../model/useLocalSearchFilter';
-import { isValidLatLngBounds, toBounds } from '../lib/map-adapter';
+import { type Bounds } from '@shared/types';
 import { BottomSheet } from '@shared/ui/bottom-sheet';
 import { filterQueries } from '../api/filterQueries';
 import type { FilterOption } from '@entities/kindergarten';
@@ -12,7 +12,7 @@ import type { FilterOption } from '@entities/kindergarten';
 interface FilterBottomSheetProps {
   isOpen: boolean;
   close: () => void;
-  bounds?: naver.maps.Bounds;
+  bounds: Bounds | null;
   initialFilters: FilterOption[];
   onApply: (filters: FilterOption[]) => void;
 }
@@ -36,10 +36,9 @@ export function FilterBottomSheet({ isOpen, close, bounds, initialFilters, onApp
     }
   }, [isOpen, initialFilters, setLocalFilters]);
 
-  const abstractBounds = isValidLatLngBounds(bounds) ? toBounds(bounds) : null;
   const { data: filterResultData } = useQuery({
     ...filterQueries.resultCount({
-      bounds: abstractBounds,
+      bounds,
       filters: localFilters,
     }),
   });

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -23,7 +23,7 @@ import { KindergartenList } from '@features/kindergarten-list/ui/KindergartenLis
 import { SearchStateProvider, useSearchMachine } from '@features/kindergarten-map/model/useSearchMachine';
 import { getRegionLevel } from '@features/kindergarten-map/lib/markers';
 import type { BoundsSnapshot } from '@features/kindergarten-map/lib/searchMachine';
-import { toBoundsSnapshot } from '@features/kindergarten-map/lib/bounds';
+import { boundsSnapshotToBounds, toBoundsSnapshot } from '@features/kindergarten-map/lib/bounds';
 import type { KindergartenListItemWithMeta } from '@entities/kindergarten';
 import { isEqualCoord, useBottomSheetSnapIndex, useSafeAreaInsets } from '@shared/lib';
 import { useMarkerState } from '@shared/store';
@@ -97,7 +97,7 @@ function KindergartenMainPageContent() {
       <FilterBottomSheet
         isOpen={isOpen}
         close={close}
-        bounds={mapRef.current?.getBounds()}
+        bounds={boundsSnapshotToBounds(liveState.viewportBounds)}
         initialFilters={committedState.filters}
         onApply={(newFilters) => {
           if (newFilters.length > 0) {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

필터 바텀시트에서 표시되는 유치원 개수가 실제 "결과보기"를 눌렀을 때의 검색 결과 수와 일치하지 않는 문제를 수정했습니다.
https://jira-knockdog.atlassian.net/browse/Q2-17

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- `FilterBottomSheet.tsx`:
  - `bounds` prop의 타입을 `naver.maps.Bounds`에서 표준 데이터 객체인 Bounds | null (@shared/types)로 변경했습니다.
  - 내부에서 수행하던 불필요한 영역 객체 변환 로직을 제거했습니다.
- `KindergartenMainPage.tsx`:
  - 필터 바텀시트를 열 때, 지도 객체에서 직접 영역을 가져오는 대신 검색 머신이 관리하는 liveState.viewportBounds를 Bounds 객체로 변환하여 전달하도록 수정했습니다.
  - 이를 통해 미리보기 카운트와 실제 검색 결과가 항상 동일한 데이터 소스(Search Machine State)를 바라보게 되어 데이터 불일치를 원천 차단했습니다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
