### PR TITLE
[feat(knockdog)] 이미지 업로더에 이미지 로딩 상태 관리 및 expo-image-manipulator 추가

### DIFF
--- a/apps/knockdog/src/features/dog-profile/ui/ProfileImageUploader.tsx
+++ b/apps/knockdog/src/features/dog-profile/ui/ProfileImageUploader.tsx
@@ -12,6 +12,7 @@ interface ProfileImageUploaderProps {
 function ProfileImageUploader({ profileImage, onImageSelect }: ProfileImageUploaderProps) {
   const { pickImage } = useImagePicker();
   const [selectedImage, setSelectedImage] = useState<string | undefined>(profileImage);
+  const [isImageLoading, setIsImageLoading] = useState(false);
 
   useEffect(() => {
     setSelectedImage(profileImage);
@@ -27,6 +28,7 @@ function ProfileImageUploader({ profileImage, onImageSelect }: ProfileImageUploa
 
       if (!result.cancelled && result.assets && result.assets.length > 0) {
         const asset = result.assets[0] as WebImageAsset;
+        setIsImageLoading(true);
         setSelectedImage(asset.uri);
         onImageSelect?.(asset.uri);
       }
@@ -35,13 +37,29 @@ function ProfileImageUploader({ profileImage, onImageSelect }: ProfileImageUploa
     }
   };
 
+  const handleImageLoad = () => {
+    setIsImageLoading(false);
+  };
+
   return (
     <div className='relative flex items-center justify-center px-4 py-7'>
-      <Avatar className='h-[120px] w-[120px]'>
-        {selectedImage && <AvatarImage src={selectedImage} className='object-cover' />}
-        <AvatarFallback className='bg-primitive-neutral-100 rounded-full p-0.5'>
-          <Icon icon='Paw' className='text-fill-secondary-400 h-[52px] w-[52px]' />
-        </AvatarFallback>
+      <Avatar className='h-[120px] w-[120px] overflow-hidden'>
+        {selectedImage && (
+          <AvatarImage
+            key={selectedImage}
+            src={selectedImage}
+            className='object-cover transition-opacity duration-300'
+            onLoad={handleImageLoad}
+            style={{
+              opacity: isImageLoading ? 0 : 1,
+            }}
+          />
+        )}
+        {!isImageLoading && (
+          <AvatarFallback className='bg-primitive-neutral-100 rounded-full p-0.5'>
+            <Icon icon='Paw' className='text-fill-secondary-400 h-[52px] w-[52px]' />
+          </AvatarFallback>
+        )}
       </Avatar>
       <button
         type='button'

--- a/apps/mobile/bridges/handlers/register-image-picker.ts
+++ b/apps/mobile/bridges/handlers/register-image-picker.ts
@@ -2,13 +2,47 @@ import type { ImagePickerOptions, ImagePickerPayload } from '@/types/image-picke
 import * as FileSystem from 'expo-file-system';
 import * as ImagePicker from 'expo-image-picker';
 import { uploadImage } from '../api/image';
+import * as ImageManipulator from 'expo-image-manipulator';
+
+function toMB(bytes: number) {
+  return (bytes / 1024 / 1024).toFixed(2);
+}
+
+// 너비 기준으로 줄이기 (세로사진/가로사진 상관 없이 비율 유지)
+async function compressForUpload(asset: ImagePicker.ImagePickerAsset) {
+  // 원본 크기 로그 (선택)
+  const originInfo = await FileSystem.getInfoAsync(asset.uri, { size: true });
+  if (originInfo.exists && typeof originInfo.size === 'number') {
+  }
+
+  // PNG/WEBP도 있을 수 있지만 "사진 업로드"는 JPEG로 통일하면 용량이 크게 줄어드는 경우가 많음
+  const targetWidth = 1600; // 보통 1280~1920 사이 추천
+  const quality = 0.75; // 0.7~0.85 사이에서 타협
+
+  const manipulated = await ImageManipulator.manipulateAsync(asset.uri, [{ resize: { width: targetWidth } }], {
+    compress: quality,
+    format: ImageManipulator.SaveFormat.JPEG,
+  });
+
+  // 압축본 크기 로그 (선택)
+  const compressedInfo = await FileSystem.getInfoAsync(manipulated.uri, { size: true });
+  if (compressedInfo.exists && typeof compressedInfo.size === 'number') {
+  }
+
+  return {
+    uri: manipulated.uri,
+    mimeType: 'image/jpeg',
+  };
+}
 
 async function uploadToS3(preSignedUrl: string, asset: ImagePicker.ImagePickerAsset) {
-  const uploadResult = await FileSystem.uploadAsync(preSignedUrl, asset.uri, {
+  const uploadAsset = await compressForUpload(asset);
+
+  const uploadResult = await FileSystem.uploadAsync(preSignedUrl, uploadAsset.uri, {
     httpMethod: 'PUT',
     uploadType: FileSystem.FileSystemUploadType.BINARY_CONTENT,
     headers: {
-      'Content-Type': asset.mimeType ?? 'application/octet-stream',
+      'Content-Type': uploadAsset.mimeType ?? 'application/octet-stream',
     },
   });
 
@@ -86,6 +120,7 @@ export function registerImagePickerHandlers(options: ImagePickerOptions) {
       for (const pickedAsset of pickedAssets) {
         const { key, preSignedUrl } = await uploadImage();
         await uploadToS3(preSignedUrl, pickedAsset);
+
         uploadedAssets.push({ key, preSignedUrl });
       }
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,6 +37,7 @@
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",
+    "expo-image-manipulator": "~13.1.7",
     "expo-image-picker": "~16.1.4",
     "expo-linking": "~8.0.8",
     "expo-location": "^18.1.6",

--- a/apps/mobile/types/expo-file-system.d.ts
+++ b/apps/mobile/types/expo-file-system.d.ts
@@ -20,5 +20,19 @@ declare module 'expo-file-system' {
     body: string;
   }
 
+  export interface FileInfo {
+    exists: boolean;
+    uri: string;
+    size?: number;
+    modificationTime?: number;
+    isDirectory?: boolean;
+  }
+
+  export interface GetInfoOptions {
+    size?: boolean;
+    md5?: boolean;
+  }
+
   export function uploadAsync(url: string, fileUri: string, options?: UploadOptions): Promise<UploadResult>;
+  export function getInfoAsync(fileUri: string, options?: GetInfoOptions): Promise<FileInfo>;
 }

--- a/apps/mobile/types/expo-image-manipulator.d.ts
+++ b/apps/mobile/types/expo-image-manipulator.d.ts
@@ -1,0 +1,29 @@
+declare module 'expo-image-manipulator' {
+  export enum SaveFormat {
+    JPEG = 'jpeg',
+    PNG = 'png',
+    WEBP = 'webp',
+  }
+
+  export interface Action {
+    resize?: { width?: number; height?: number };
+    rotate?: number;
+    flip?: 'vertical' | 'horizontal';
+    crop?: { originX: number; originY: number; width: number; height: number };
+  }
+
+  export interface SaveOptions {
+    compress?: number;
+    format?: SaveFormat;
+    base64?: boolean;
+  }
+
+  export interface ImageResult {
+    uri: string;
+    width: number;
+    height: number;
+    base64?: string;
+  }
+
+  export function manipulateAsync(uri: string, actions?: Action[], saveOptions?: SaveOptions): Promise<ImageResult>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       expo-image:
         specifier: ~2.4.0
         version: 2.4.1(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native-web@0.20.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0)
+      expo-image-manipulator:
+        specifier: ~13.1.7
+        version: 13.1.7(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))
       expo-image-picker:
         specifier: ~16.1.4
         version: 16.1.4(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))
@@ -6281,6 +6284,11 @@ packages:
 
   expo-image-loader@5.1.0:
     resolution: {integrity: sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-manipulator@13.1.7:
+    resolution: {integrity: sha512-DBy/Xdd0E/yFind14x36XmwfWuUxOHI/oH97/giKjjPaRc2dlyjQ3tuW3x699hX6gAs9Sixj5WEJ1qNf3c8sag==}
     peerDependencies:
       expo: '*'
 
@@ -17763,6 +17771,11 @@ snapshots:
   expo-image-loader@5.1.0(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0)):
     dependencies:
       expo: 53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0)
+
+  expo-image-manipulator@13.1.7(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0)):
+    dependencies:
+      expo: 53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0)
+      expo-image-loader: 5.1.0(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))
 
   expo-image-picker@16.1.4(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0))(react-native@0.79.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.2(typescript@5.8.3))(@types/react@19.2.7)(react@19.0.0))(react@19.0.0)):
     dependencies:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

* feat: ProfileImageUploader에서 이미지 로딩 상태를 관리하는 isImageLoading 추가  
* feat: 이미지 선택 후 압축을 위한 compressForUpload 함수 구현  
* feat: expo-image-manipulator 패키지 추가 및 관련 타입 정의  
* fix: 이미지 업로드 시 압축된 이미지 사용하도록 uploadToS3 수정  
* chore: pnpm-lock.yaml에 expo-image-manipulator 의존성 추가