### PR TITLE
feat: 딥링크 지원 추가 (Custom Scheme + Universal/App Links)

### DIFF
--- a/apps/knockdog/next.config.js
+++ b/apps/knockdog/next.config.js
@@ -1,4 +1,16 @@
 const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/.well-known/apple-app-site-association',
+        headers: [{ key: 'Content-Type', value: 'application/json' }],
+      },
+      {
+        source: '/.well-known/assetlinks.json',
+        headers: [{ key: 'Content-Type', value: 'application/json' }],
+      },
+    ];
+  },
   // 임시 주소
   images: {
     remotePatterns: [

--- a/apps/knockdog/public/.well-known/apple-app-site-association
+++ b/apps/knockdog/public/.well-known/apple-app-site-association
@@ -1,0 +1,13 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "SN9D62F47F.net.knockdog.petcampus.v2",
+        "paths": [
+          "*"
+        ]
+      }
+    ]
+  }
+}

--- a/apps/knockdog/public/.well-known/assetlinks.json
+++ b/apps/knockdog/public/.well-known/assetlinks.json
@@ -1,0 +1,13 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "net.knockdog.petcampus.v2",
+      "sha256_cert_fingerprints": [
+        "FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C",
+        "0A:7D:A0:EF:97:81:A1:BA:BE:77:91:59:10:1B:CF:E5:06:4F:24:63:C6:0D:46:DD:99:70:22:05:CF:CF:9C:F8"
+      ]
+    }
+  }
+]

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -6,17 +6,18 @@ import * as SplashScreen from 'expo-splash-screen';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context'; // ★ SafeAreaProvider 사용
 import { PortalProvider } from '@gorhom/portal'; // ★ 포털
-import RootStackNavigator from './components/navigation/RootStackNavigator';
 import { navigationRef } from './bridges/lib/navigationRef';
 import { ToastProvider } from './components/toast'; // ★ 토스트 프로바이더 (네이티브 구현)
 import { initializeKakaoSDK } from '@react-native-kakao/core';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
+import { RootStackNavigator, useLinking } from './components/navigation';
 
 // 앱 시작 시 스플래시 자동 숨김 방지
 SplashScreen.preventAutoHideAsync().catch(() => {});
 
 export default function App() {
   const [appIsReady, setAppIsReady] = useState(false);
+  const linking = useLinking();
 
   const kakaoNativeAppKey = process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY || '';
   const iosClientId = process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID || '';
@@ -69,7 +70,7 @@ export default function App() {
           <View style={{ flex: 1 }} onLayout={onLayoutRootView}>
             {/* 토스트 프로바이더가 네비게이션 바/스크린 “밖”에 있어야 어디서든 toast() 가능 */}
             <ToastProvider>
-              <NavigationContainer ref={navigationRef}>
+              <NavigationContainer ref={navigationRef} linking={linking}>
                 <RootStackNavigator />
               </NavigationContainer>
             </ToastProvider>

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -59,6 +59,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       },
       CFBundleURLTypes: [
         {
+          CFBundleURLSchemes: ['daengv2mobile'],
+        },
+        {
           CFBundleURLSchemes: [iosUrlScheme],
         },
       ],

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -3,6 +3,10 @@ import 'dotenv/config';
 
 const kakaoNativeAppKey = process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY;
 const iosUrlScheme = process.env.EXPO_PUBLIC_IOS_URL_SCHEME;
+const WEBVIEW_URL = process.env.EXPO_PUBLIC_WEBVIEW_URL;
+
+// Universal Links / App Links용 호스트
+const WEBVIEW_HOST = WEBVIEW_URL?.replace(/^https?:\/\//, '');
 
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
@@ -28,6 +32,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     supportsTablet: true,
     usesAppleSignIn: true,
     bundleIdentifier: 'net.knockdog.petcampus.v2',
+    associatedDomains: [`applinks:${WEBVIEW_HOST}`],
     infoPlist: {
       LSApplicationQueriesSchemes: ['nmap', 'tel'],
       ITSAppUsesNonExemptEncryption: false,
@@ -88,6 +93,14 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     edgeToEdgeEnabled: true,
     package: 'net.knockdog.petcampus.v2',
     permissions: ['android.permission.ACCESS_COARSE_LOCATION', 'android.permission.ACCESS_FINE_LOCATION'],
+    intentFilters: [
+      {
+        action: 'VIEW',
+        autoVerify: true,
+        data: [{ scheme: 'https', host: WEBVIEW_HOST }],
+        category: ['BROWSABLE', 'DEFAULT'],
+      },
+    ],
   },
   web: {
     bundler: 'metro',

--- a/apps/mobile/components/navigation/RootStackNavigator.tsx
+++ b/apps/mobile/components/navigation/RootStackNavigator.tsx
@@ -6,7 +6,7 @@ import { RootStackParamList } from '@/types/navigation';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
-export default function RootStackNavigator() {
+export function RootStackNavigator() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name='Tabs' component={TabNavigator} />

--- a/apps/mobile/components/navigation/index.ts
+++ b/apps/mobile/components/navigation/index.ts
@@ -1,0 +1,2 @@
+export { RootStackNavigator } from './RootStackNavigator';
+export { useLinking } from './model/useLinking';

--- a/apps/mobile/components/navigation/model/useLinking.ts
+++ b/apps/mobile/components/navigation/model/useLinking.ts
@@ -18,7 +18,7 @@ const TAB_PATHS: Record<string, TabScreen> = {
 function useLinking(): LinkingOptions<RootStackParamList> {
   return useMemo(
     () => ({
-      prefixes: [Linking.createURL('/'), 'daengv2mobile://'],
+      prefixes: [Linking.createURL('/'), 'daengv2mobile://', WEBVIEW_URL],
       getStateFromPath: (path: string): PartialState<NavigationState<RootStackParamList>> => {
         // [Android] Expo Dev Client가 앱 시작 시 전달하는 특수 경로 필터링
         if (__DEV__ && path.startsWith('expo-development-client')) {

--- a/apps/mobile/components/navigation/model/useLinking.ts
+++ b/apps/mobile/components/navigation/model/useLinking.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import { LinkingOptions, PartialState, NavigationState } from '@react-navigation/native';
+import * as Linking from 'expo-linking';
+import { RootStackParamList } from '@/types/navigation';
+
+const WEBVIEW_URL = process.env.EXPO_PUBLIC_WEBVIEW_URL || 'https://knockdog-v2.vercel.app';
+
+// 탭 경로 매핑
+type TabScreen = NonNullable<RootStackParamList['Tabs']>['screen'];
+
+const TAB_PATHS: Record<string, TabScreen> = {
+  '': 'Explore',
+  save: 'Save',
+  compare: 'Compare',
+  mypage: 'Mypage',
+};
+
+function useLinking(): LinkingOptions<RootStackParamList> {
+  return useMemo(
+    () => ({
+      prefixes: [Linking.createURL('/'), 'daengv2mobile://'],
+      getStateFromPath: (path: string): PartialState<NavigationState<RootStackParamList>> => {
+        // [Android] Expo Dev Client가 앱 시작 시 전달하는 특수 경로 필터링
+        if (__DEV__ && path.startsWith('expo-development-client')) {
+          return {
+            routes: [{ name: 'Tabs', state: { routes: [{ name: 'Explore' }] } }],
+          };
+        }
+
+        // 탭 경로인 경우
+        const tabScreen = TAB_PATHS[path];
+        if (tabScreen) {
+          return {
+            routes: [{ name: 'Tabs', state: { routes: [{ name: tabScreen }] } }],
+          };
+        }
+
+        // 그 외 모든 경로는 Stack 스크린으로 라우팅
+        // 예) daengv2mobile://kindergarten/123
+        //     → path = "kindergarten/123"
+        //     → fullUrl = "https://knockdog-v2.vercel.app/kindergarten/123"
+        const normalizedPath = path.replace(/^\/+/, '');
+        const fullUrl = path.startsWith('http') ? path : `${WEBVIEW_URL}/${normalizedPath}`;
+
+        return {
+          routes: [{ name: 'Stack', params: { path: fullUrl } }],
+        };
+      },
+    }),
+    []
+  );
+}
+
+export { useLinking };


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- `daengv2mobile://` 커스텀 스킴 딥링크 지원
- `https://knockdog-v2.vercel.app/` 도메인 기반 딥링크 지원 (iOS Universal Links / Android App Links)

## 작업 내용
knockdog
- iOS Universal Links 검증을 위한 `.well-known/apple-app-site-association` 파일 추가
- Android App Links 검증을 위한 `.well-known/assetlinks.json` 파일 추가
- `next.config.js`에 well-known 파일의 `Content-Type: application/json` 헤더 설정

mobile
- 딥링크 URL을 파싱하여 linking 옵션을 생성하는 `useLinking` 훅 구현 및 NavigationContainer에 연결   
- `app.config.ts` 설정:
  - iOS: `associatedDomains` 에 웹 도메인 등록 (Universal Links 활성화)
  - Android: `intent-filter`에 웹 도메인 등록 (App Links 활성화)
                                                                                                                                                                           
참고 자료
- https://docs.expo.dev/linking/ios-universal-links/
- https://docs.expo.dev/linking/android-app-links/