### PR TITLE
fix: 동적 스냅 안정화 및 리스트/시트 구조 정리

### DIFF
--- a/apps/knockdog/app/globals.css
+++ b/apps/knockdog/app/globals.css
@@ -5,6 +5,9 @@
 
 @theme {
   --breakpoint-sm: 30rem;
+
+  --top-bar-height: 64px;
+  --bottom-bar-height: 68px;
 }
 
 html body[data-scroll-locked] {

--- a/apps/knockdog/src/features/kindergarten-list/model/useViewportProgress.ts
+++ b/apps/knockdog/src/features/kindergarten-list/model/useViewportProgress.ts
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react';
 interface UseSheetDragProgressProps {
   minSnapPoint: number;
   maxSnapPointOffset: number;
+  enabled?: boolean;
 }
 
 /**
@@ -16,12 +17,13 @@ interface UseSheetDragProgressProps {
  * @param maxSnapPointOffset - 최대 스냅포인트 오프셋
  * @returns
  */
-const useSheetDragProgress = ({ minSnapPoint, maxSnapPointOffset }: UseSheetDragProgressProps) => {
+const useSheetDragProgress = ({ minSnapPoint, maxSnapPointOffset, enabled = true }: UseSheetDragProgressProps) => {
   const viewRef = useRef<HTMLDivElement>(null);
 
   const dragProgress = useMotionValue(0);
 
   useEffect(() => {
+    if (!enabled) return;
     let rafId: number;
     let lastProgress = -1;
     const threshold = 0.005; // 0.5%
@@ -39,7 +41,13 @@ const useSheetDragProgress = ({ minSnapPoint, maxSnapPointOffset }: UseSheetDrag
         const maxHeight = viewportHeight - maxSnapPointOffset;
 
         // 0-1로 정규화
-        const rawProgress = (currentSheetHeight - minHeight) / (maxHeight - minHeight);
+        const range = maxHeight - minHeight;
+        if (range <= 0) {
+          rafId = requestAnimationFrame(calculateProgress);
+          return;
+        }
+
+        const rawProgress = (currentSheetHeight - minHeight) / range;
 
         const clamped = Math.max(0, Math.min(1, rawProgress));
 
@@ -54,7 +62,7 @@ const useSheetDragProgress = ({ minSnapPoint, maxSnapPointOffset }: UseSheetDrag
 
     rafId = requestAnimationFrame(calculateProgress);
     return () => cancelAnimationFrame(rafId);
-  }, [dragProgress, minSnapPoint, maxSnapPointOffset]);
+  }, [dragProgress, minSnapPoint, maxSnapPointOffset, enabled]);
 
   return { viewRef, dragProgress };
 };

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
@@ -26,9 +26,6 @@ export function KindergartenCard(props: KindergartenCardProps) {
 
   return (
     <>
-      <BottomSheet.Handle />
-      <BottomSheet.Title className='sr-only'>강아지 유치원 상세 정보</BottomSheet.Title>
-
       {/* 컨텐츠 영역 */}
       <div className='pt-x3_5 gap-x3 px-x4 flex w-full flex-col'>
         <div className='gap-x2 flex'>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
@@ -1,6 +1,5 @@
 import { ActionButton, Icon } from '@knockdog/ui';
 import Image from 'next/image';
-import { PhoneCallSheet } from './PhoneCallSheet';
 import { overlay } from 'overlay-kit';
 import {
   DeparturePointSheet,
@@ -8,10 +7,10 @@ import {
   SERVICE_TAGS,
   ServiceBadgesTruncated,
 } from '@entities/kindergarten';
-import { BottomSheet } from '@shared/ui/bottom-sheet';
 
 interface KindergartenCardProps extends KindergartenListItemWithMeta {
   onBookmarkClick: (id: string, isBookmarked: boolean) => void;
+  onPhoneCall: () => void;
 }
 
 export function KindergartenCard(props: KindergartenCardProps) {
@@ -108,6 +107,22 @@ export function KindergartenCard(props: KindergartenCardProps) {
             <span className='h3-extrabold text-text-primary'>{props.price.toLocaleString()}~</span>
           </div>
         </div>
+      </div>
+
+      <div className='p-x4 gap-x2 flex items-center bg-white pb-[calc(env(safe-area-inset-bottom)+16px)]'>
+        <ActionButton variant='primaryLine' size='medium' onClick={props.onPhoneCall}>
+          전화하기
+        </ActionButton>
+        <ActionButton variant='primaryFill' size='medium' disabled>
+          비교하기
+        </ActionButton>
+        <button
+          aria-label='보관하기'
+          className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
+          onClick={() => props.onBookmarkClick(props.id, props.isBookmarked ?? false)}
+        >
+          <Icon icon={props.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'} className='size-x6 text-fill-primary-500' />
+        </button>
       </div>
     </>
   );

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
@@ -1,13 +1,15 @@
-import { Divider } from '@knockdog/ui';
+import { ActionButton, Divider, Icon } from '@knockdog/ui';
 import { KindergartenTabs } from '@widgets/kindergarten-tabs';
 import { KindergartenMainBox, MainBannerSwiper, useKindergartenMainQuery } from '@features/kindergarten-main';
 import { useCurrentLocation } from '@shared/lib';
 
 interface KindergartenDetailProps {
   kindergartenId: string;
+  onPhoneCall?: () => void;
+  onBookmarkClick?: (id: string, isBookmarked: boolean) => void;
 }
 
-export function KindergartenDetail({ kindergartenId }: KindergartenDetailProps) {
+export function KindergartenDetail({ kindergartenId, onPhoneCall, onBookmarkClick }: KindergartenDetailProps) {
   const { position } = useCurrentLocation();
   const { lng, lat } = position || { lng: 126.883439, lat: 37.511281 };
 
@@ -42,6 +44,22 @@ export function KindergartenDetail({ kindergartenId }: KindergartenDetailProps) 
         {/* 하단 공간 (액션 바 높이) */}
         <div className='h-14 w-full' />
       </div>
+
+      {/* <div className='p-x4 gap-x2 flex items-center bg-white pb-[calc(env(safe-area-inset-bottom)+16px)]'>
+        <ActionButton variant='primaryLine' size='medium' onClick={onPhoneCall}>
+          전화하기
+        </ActionButton>
+        <ActionButton variant='primaryFill' size='medium' disabled>
+          비교하기
+        </ActionButton>
+        <button
+          aria-label='보관하기'
+          className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
+          onClick={() => onBookmarkClick(kindergartenId, isBookmarked ?? false)}
+        >
+          <Icon icon={props.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'} className='size-x6 text-fill-primary-500' />
+        </button>
+        </div> */}
     </>
   );
 }

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type ComponentProps, useMemo, useRef, useState } from 'react';
-import { ActionButton, BottomSheet, Icon } from '@knockdog/ui';
+import { BottomSheet } from '@knockdog/ui';
 import { KindergartenCard } from './KindergartenCard';
 import { cn } from '@knockdog/ui/lib';
 import { motion, useIsomorphicLayoutEffect, useTransform } from 'framer-motion';
@@ -70,7 +70,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
     share(shareData);
   };
 
-  const openPhoneCallActionSheet = () =>
+  const openPhoneCallSheet = () =>
     overlay.open(({ isOpen, close }) => (
       <PhoneCallSheet isOpen={isOpen} close={close} phoneNumber={currentItem?.phoneNumber ?? ''} />
     ));
@@ -123,7 +123,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
             snapToSequentialPoint
             container={container}
           >
-            <BottomSheet.Portal>
+            <RemoveScroll forwardProps noIsolation>
               <BottomSheet.Body
                 onPointerDownOutside={(e) => {
                   e.preventDefault();
@@ -141,63 +141,47 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
                   ['--initial-transform' as never]: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)`,
                 }}
               >
-                <RemoveScroll noIsolation>
-                  {/* Visual Apron: 바텀시트 하단 gap을 가려주는 역할 */}
-                  <div aria-hidden='true' className='absolute top-[99%] left-0 h-screen w-full bg-white' />
-                  <div ref={viewRef} className={cn('relative h-full', activeSnapPoint === 1 && 'overflow-y-auto')}>
-                    {/* 카드 뷰 */}
-                    <motion.div
-                      className={cn(
-                        'top-0 left-0 h-fit w-full pb-[88px]',
-                        activeSnapPoint === 1 ? 'pointer-events-none absolute opacity-0' : 'relative'
-                      )}
-                      style={{
-                        opacity: visibleOpacity,
-                        y: cardY,
-                        scale: scaleDown,
-                      }}
-                    >
-                      <BottomSheet.Handle />
-                      <BottomSheet.Title className='sr-only'>강아지 유치원 상세 정보</BottomSheet.Title>
-                      <KindergartenCard {...currentItem} onBookmarkClick={onBookmarkClick} />
-                    </motion.div>
-
-                    {/* 상세 뷰 */}
-                    <motion.div
-                      className={cn(
-                        'pointer-events-none h-full bg-white',
-                        activeSnapPoint === 1 ? 'pointer-events-auto relative w-full pb-[88px]' : 'absolute inset-0'
-                      )}
-                      style={{
-                        opacity: hiddenOpacity,
-                        y: detailY,
-                        scale: scaleUp,
-                      }}
-                    >
-                      <KindergartenDetail kindergartenId={currentItem.id} />
-                    </motion.div>
-                  </div>
-                </RemoveScroll>
-                <div className='p-x4 gap-x2 fixed right-0 bottom-0 left-0 flex items-center bg-white pb-[calc(env(safe-area-inset-bottom)+16px)]'>
-                  <ActionButton variant='primaryLine' size='medium' onClick={openPhoneCallActionSheet}>
-                    전화하기
-                  </ActionButton>
-                  <ActionButton variant='primaryFill' size='medium' disabled>
-                    비교하기
-                  </ActionButton>
-                  <button
-                    aria-label='보관하기'
-                    className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
-                    onClick={() => onBookmarkClick(currentItem.id, currentItem.isBookmarked ?? false)}
+                {/* Visual Apron: 바텀시트 하단 gap을 가려주는 역할 */}
+                <div aria-hidden='true' className='absolute top-[99%] left-0 h-screen w-full bg-white' />
+                <div ref={viewRef} className={cn('relative', activeSnapPoint === 1 && 'h-full overflow-y-auto')}>
+                  {/* 카드 뷰 */}
+                  <motion.div
+                    className={cn(
+                      'top-0 left-0 h-fit w-full',
+                      activeSnapPoint === 1 ? 'pointer-events-none absolute opacity-0' : 'relative'
+                    )}
+                    style={{
+                      opacity: visibleOpacity,
+                      y: cardY,
+                      scale: scaleDown,
+                    }}
                   >
-                    <Icon
-                      icon={currentItem.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
-                      className='size-x6 text-fill-primary-500'
+                    <BottomSheet.Handle />
+                    <BottomSheet.Title className='sr-only'>강아지 유치원 상세 정보</BottomSheet.Title>
+                    <KindergartenCard
+                      {...currentItem}
+                      onBookmarkClick={onBookmarkClick}
+                      onPhoneCall={openPhoneCallSheet}
                     />
-                  </button>
+                  </motion.div>
+
+                  {/* 상세 뷰 */}
+                  <motion.div
+                    className={cn(
+                      'pointer-events-none h-full bg-white',
+                      activeSnapPoint === 1 ? 'pointer-events-auto relative w-full pb-[88px]' : 'absolute inset-0'
+                    )}
+                    style={{
+                      opacity: hiddenOpacity,
+                      y: detailY,
+                      scale: scaleUp,
+                    }}
+                  >
+                    <KindergartenDetail kindergartenId={currentItem.id} />
+                  </motion.div>
                 </div>
               </BottomSheet.Body>
-            </BottomSheet.Portal>
+            </RemoveScroll>
           </BottomSheet.Root>
         )}
       </div>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { type ComponentProps, useMemo, useRef, useState } from 'react';
 import { ActionButton, BottomSheet, Icon } from '@knockdog/ui';
 import { KindergartenCard } from './KindergartenCard';
 import { cn } from '@knockdog/ui/lib';
@@ -14,18 +14,14 @@ import { KindergartenDetail } from '@features/kindergarten-list/ui/KindergartenD
 import { useSearchListQuery } from '@features/kindergarten-map';
 import { PhoneCallSheet } from '@features/kindergarten-list/ui/PhoneCallSheet';
 import { isNativeWebView, useSafeAreaInsets, useShare } from '@shared/lib';
-import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
+import { TOP_BAR_HEIGHT } from '@shared/constants';
 
+type BottomSheetSnapPoint = ComponentProps<typeof BottomSheet.Root>['activeSnapPoint'];
 interface KindergartenItemSheetProps {
   itemId: string;
   isOpen: boolean;
   onClose: () => void;
 }
-
-type SnapPoint = number | string | null;
-
-const MIN_SNAP_POINT = isNativeWebView() ? 328 : BOTTOM_BAR_HEIGHT + 328;
-const snapPoints = [`${MIN_SNAP_POINT}px`, 1];
 
 export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenItemSheetProps) {
   const { searchListQueryKey, searchList, exact } = useSearchListQuery();
@@ -42,18 +38,19 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
   }, [exact, itemId, searchList]);
 
   const { top } = useSafeAreaInsets();
-  const MAX_SNAP_POINT_OFFSET = isNativeWebView() ? 64 + top : 64;
+  const MAX_SNAP_POINT_OFFSET = isNativeWebView() ? TOP_BAR_HEIGHT + top : TOP_BAR_HEIGHT;
 
-  const [activeSnapPoint, setActiveSnapPoint] = useState<SnapPoint>(snapPoints[0] ?? null);
+  const dynamicSnapPoints = useMemo(() => [{ type: 'content' as const, min: 328 }, 1], []);
+  const [activeSnapPoint, setActiveSnapPoint] = useState<BottomSheetSnapPoint>(dynamicSnapPoints[0] ?? null);
 
-  const containerRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
-  const isMaxSnap = activeSnapPoint === snapPoints[1];
 
   const { viewRef, dragProgress } = useSheetDragProgress({
-    minSnapPoint: MIN_SNAP_POINT,
+    minSnapPoint: 328,
     maxSnapPointOffset: MAX_SNAP_POINT_OFFSET,
+    enabled: isOpen,
   });
 
   const visibleOpacity = useTransform(dragProgress, [0, 1], [1, 0]);
@@ -85,6 +82,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
   }, [containerRef]);
 
   if (currentItem == null) return null;
+
   return (
     <>
       <motion.div
@@ -94,7 +92,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
       >
         <Header className='block'>
           <Header.LeftSection>
-            <Header.BackButton onClick={() => setActiveSnapPoint(snapPoints[0] ?? null)} />
+            <Header.BackButton onClick={() => setActiveSnapPoint(dynamicSnapPoints[0] ?? null)} />
             <Header.HomeButton onClick={onClose} />
           </Header.LeftSection>
 
@@ -108,8 +106,7 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
 
       <div
         ref={containerRef}
-        className='pointer-events-none absolute bottom-0 w-full'
-        style={{ height: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)` }}
+        className='pointer-events-none absolute bottom-0 h-[calc(100vh-calc(var(--top-bar-height)+var(--safe-area-inset-top,0px)))] w-full'
       >
         <BottomSheet.Root
           open={isOpen}
@@ -119,71 +116,88 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
             }
           }}
           modal={false}
-          snapPoints={snapPoints}
+          snapPoints={dynamicSnapPoints}
           activeSnapPoint={activeSnapPoint}
-          setActiveSnapPoint={(snapPoint) => setActiveSnapPoint(snapPoint)}
+          setActiveSnapPoint={(snap) => setActiveSnapPoint(snap)}
           snapToSequentialPoint
           container={container}
         >
-          <RemoveScroll forwardProps noIsolation>
+          <BottomSheet.Portal>
             <BottomSheet.Body
               onPointerDownOutside={(e) => {
                 e.preventDefault();
-
                 if (!headerRef.current?.contains(e.target as Node)) {
                   onClose();
                 }
               }}
               className={cn(
-                'pointer-events-auto absolute inset-x-0 z-50 h-full max-h-[calc(100vh-64px)]',
-                activeSnapPoint === snapPoints[1] && 'h-full'
+                'pointer-events-auto absolute inset-x-0 top-0 z-50',
+                activeSnapPoint === 1
+                  ? 'h-[calc(100vh-calc(var(--top-bar-height)+var(--safe-area-inset-top,0px)))]'
+                  : 'h-fit'
               )}
+              style={{
+                ['--initial-transform' as never]: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)`,
+              }}
             >
-              <div ref={viewRef} className={cn('relative h-full', isMaxSnap && 'overflow-y-auto')}>
-                <motion.div
-                  className='absolute inset-0'
-                  style={{
-                    opacity: visibleOpacity,
-                    y: cardY,
-                    scale: scaleDown,
-                  }}
-                >
-                  <KindergartenCard {...currentItem} onBookmarkClick={onBookmarkClick} />
-                </motion.div>
+              <RemoveScroll noIsolation>
+                {/* Visual Apron: 바텀시트 하단 gap을 가려주는 역할 */}
+                <div aria-hidden='true' className='absolute top-[99%] left-0 h-screen w-full bg-white' />
+                <div ref={viewRef} className={cn('relative h-full', activeSnapPoint === 1 && 'overflow-y-auto')}>
+                  {/* 카드 뷰 */}
+                  <motion.div
+                    className={cn(
+                      'top-0 left-0 h-fit w-full pb-[88px]',
+                      activeSnapPoint === 1 ? 'pointer-events-none absolute opacity-0' : 'relative'
+                    )}
+                    style={{
+                      opacity: visibleOpacity,
+                      y: cardY,
+                      scale: scaleDown,
+                    }}
+                  >
+                    <BottomSheet.Handle />
+                    <BottomSheet.Title className='sr-only'>강아지 유치원 상세 정보</BottomSheet.Title>
+                    <KindergartenCard {...currentItem} onBookmarkClick={onBookmarkClick} />
+                  </motion.div>
 
-                <motion.div
-                  className={cn('pointer-events-none h-full bg-white', isMaxSnap && 'pointer-events-auto')}
-                  style={{
-                    opacity: hiddenOpacity,
-                    y: detailY,
-                    scale: scaleUp,
-                  }}
+                  {/* 상세 뷰 */}
+                  <motion.div
+                    className={cn(
+                      'pointer-events-none h-full bg-white',
+                      activeSnapPoint === 1 ? 'pointer-events-auto relative w-full pb-[88px]' : 'absolute inset-0'
+                    )}
+                    style={{
+                      opacity: hiddenOpacity,
+                      y: detailY,
+                      scale: scaleUp,
+                    }}
+                  >
+                    <KindergartenDetail kindergartenId={currentItem.id} />
+                  </motion.div>
+                </div>
+              </RemoveScroll>
+              <div className='p-x4 gap-x2 fixed right-0 bottom-0 left-0 flex items-center bg-white pb-[calc(env(safe-area-inset-bottom)+16px)]'>
+                <ActionButton variant='primaryLine' size='medium' onClick={openPhoneCallActionSheet}>
+                  전화하기
+                </ActionButton>
+                <ActionButton variant='primaryFill' size='medium' disabled>
+                  비교하기
+                </ActionButton>
+                <button
+                  aria-label='보관하기'
+                  className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
+                  onClick={() => onBookmarkClick(currentItem.id, currentItem.isBookmarked ?? false)}
                 >
-                  <KindergartenDetail kindergartenId={currentItem.id} />
-                </motion.div>
+                  <Icon
+                    icon={currentItem.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
+                    className='size-x6 text-fill-primary-500'
+                  />
+                </button>
               </div>
             </BottomSheet.Body>
-          </RemoveScroll>
+          </BottomSheet.Portal>
         </BottomSheet.Root>
-
-        <div className='p-x4 gap-x2 fixed right-0 bottom-0 left-0 z-50 flex items-center bg-white'>
-          <ActionButton variant='primaryLine' size='medium' onClick={openPhoneCallActionSheet}>
-            전화하기
-          </ActionButton>
-          <ActionButton variant='primaryFill' size='medium' disabled>
-            비교하기
-          </ActionButton>
-          <button
-            aria-label='보관하기'
-            className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
-            onClick={() => onBookmarkClick(currentItem.id, currentItem.isBookmarked ?? false)}
-          >
-            <Icon
-              icon={currentItem.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
-              className='size-x6 text-fill-primary-500'
-            />
-          </button>
-        </div>
       </div>
     </>
   );

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -108,96 +108,98 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
         ref={containerRef}
         className='pointer-events-none absolute bottom-0 h-[calc(100vh-calc(var(--top-bar-height)+var(--safe-area-inset-top,0px)))] w-full'
       >
-        <BottomSheet.Root
-          open={isOpen}
-          onOpenChange={(open) => {
-            if (!open) {
-              onClose();
-            }
-          }}
-          modal={false}
-          snapPoints={dynamicSnapPoints}
-          activeSnapPoint={activeSnapPoint}
-          setActiveSnapPoint={(snap) => setActiveSnapPoint(snap)}
-          snapToSequentialPoint
-          container={container}
-        >
-          <BottomSheet.Portal>
-            <BottomSheet.Body
-              onPointerDownOutside={(e) => {
-                e.preventDefault();
-                if (!headerRef.current?.contains(e.target as Node)) {
-                  onClose();
-                }
-              }}
-              className={cn(
-                'pointer-events-auto absolute inset-x-0 top-0 z-50',
-                activeSnapPoint === 1
-                  ? 'h-[calc(100vh-calc(var(--top-bar-height)+var(--safe-area-inset-top,0px)))]'
-                  : 'h-fit'
-              )}
-              style={{
-                ['--initial-transform' as never]: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)`,
-              }}
-            >
-              <RemoveScroll noIsolation>
-                {/* Visual Apron: 바텀시트 하단 gap을 가려주는 역할 */}
-                <div aria-hidden='true' className='absolute top-[99%] left-0 h-screen w-full bg-white' />
-                <div ref={viewRef} className={cn('relative h-full', activeSnapPoint === 1 && 'overflow-y-auto')}>
-                  {/* 카드 뷰 */}
-                  <motion.div
-                    className={cn(
-                      'top-0 left-0 h-fit w-full pb-[88px]',
-                      activeSnapPoint === 1 ? 'pointer-events-none absolute opacity-0' : 'relative'
-                    )}
-                    style={{
-                      opacity: visibleOpacity,
-                      y: cardY,
-                      scale: scaleDown,
-                    }}
-                  >
-                    <BottomSheet.Handle />
-                    <BottomSheet.Title className='sr-only'>강아지 유치원 상세 정보</BottomSheet.Title>
-                    <KindergartenCard {...currentItem} onBookmarkClick={onBookmarkClick} />
-                  </motion.div>
+        {container && (
+          <BottomSheet.Root
+            open={isOpen}
+            onOpenChange={(open) => {
+              if (!open) {
+                onClose();
+              }
+            }}
+            modal={false}
+            snapPoints={dynamicSnapPoints}
+            activeSnapPoint={activeSnapPoint}
+            setActiveSnapPoint={(snap) => setActiveSnapPoint(snap)}
+            snapToSequentialPoint
+            container={container}
+          >
+            <BottomSheet.Portal>
+              <BottomSheet.Body
+                onPointerDownOutside={(e) => {
+                  e.preventDefault();
+                  if (!headerRef.current?.contains(e.target as Node)) {
+                    onClose();
+                  }
+                }}
+                className={cn(
+                  'pointer-events-auto absolute inset-x-0 top-0 z-50',
+                  activeSnapPoint === 1
+                    ? 'h-[calc(100vh-calc(var(--top-bar-height)+var(--safe-area-inset-top,0px)))]'
+                    : 'h-fit'
+                )}
+                style={{
+                  ['--initial-transform' as never]: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)`,
+                }}
+              >
+                <RemoveScroll noIsolation>
+                  {/* Visual Apron: 바텀시트 하단 gap을 가려주는 역할 */}
+                  <div aria-hidden='true' className='absolute top-[99%] left-0 h-screen w-full bg-white' />
+                  <div ref={viewRef} className={cn('relative h-full', activeSnapPoint === 1 && 'overflow-y-auto')}>
+                    {/* 카드 뷰 */}
+                    <motion.div
+                      className={cn(
+                        'top-0 left-0 h-fit w-full pb-[88px]',
+                        activeSnapPoint === 1 ? 'pointer-events-none absolute opacity-0' : 'relative'
+                      )}
+                      style={{
+                        opacity: visibleOpacity,
+                        y: cardY,
+                        scale: scaleDown,
+                      }}
+                    >
+                      <BottomSheet.Handle />
+                      <BottomSheet.Title className='sr-only'>강아지 유치원 상세 정보</BottomSheet.Title>
+                      <KindergartenCard {...currentItem} onBookmarkClick={onBookmarkClick} />
+                    </motion.div>
 
-                  {/* 상세 뷰 */}
-                  <motion.div
-                    className={cn(
-                      'pointer-events-none h-full bg-white',
-                      activeSnapPoint === 1 ? 'pointer-events-auto relative w-full pb-[88px]' : 'absolute inset-0'
-                    )}
-                    style={{
-                      opacity: hiddenOpacity,
-                      y: detailY,
-                      scale: scaleUp,
-                    }}
+                    {/* 상세 뷰 */}
+                    <motion.div
+                      className={cn(
+                        'pointer-events-none h-full bg-white',
+                        activeSnapPoint === 1 ? 'pointer-events-auto relative w-full pb-[88px]' : 'absolute inset-0'
+                      )}
+                      style={{
+                        opacity: hiddenOpacity,
+                        y: detailY,
+                        scale: scaleUp,
+                      }}
+                    >
+                      <KindergartenDetail kindergartenId={currentItem.id} />
+                    </motion.div>
+                  </div>
+                </RemoveScroll>
+                <div className='p-x4 gap-x2 fixed right-0 bottom-0 left-0 flex items-center bg-white pb-[calc(env(safe-area-inset-bottom)+16px)]'>
+                  <ActionButton variant='primaryLine' size='medium' onClick={openPhoneCallActionSheet}>
+                    전화하기
+                  </ActionButton>
+                  <ActionButton variant='primaryFill' size='medium' disabled>
+                    비교하기
+                  </ActionButton>
+                  <button
+                    aria-label='보관하기'
+                    className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
+                    onClick={() => onBookmarkClick(currentItem.id, currentItem.isBookmarked ?? false)}
                   >
-                    <KindergartenDetail kindergartenId={currentItem.id} />
-                  </motion.div>
+                    <Icon
+                      icon={currentItem.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
+                      className='size-x6 text-fill-primary-500'
+                    />
+                  </button>
                 </div>
-              </RemoveScroll>
-              <div className='p-x4 gap-x2 fixed right-0 bottom-0 left-0 flex items-center bg-white pb-[calc(env(safe-area-inset-bottom)+16px)]'>
-                <ActionButton variant='primaryLine' size='medium' onClick={openPhoneCallActionSheet}>
-                  전화하기
-                </ActionButton>
-                <ActionButton variant='primaryFill' size='medium' disabled>
-                  비교하기
-                </ActionButton>
-                <button
-                  aria-label='보관하기'
-                  className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
-                  onClick={() => onBookmarkClick(currentItem.id, currentItem.isBookmarked ?? false)}
-                >
-                  <Icon
-                    icon={currentItem.isBookmarked ? 'BookmarkFill' : 'BookmarkLine'}
-                    className='size-x6 text-fill-primary-500'
-                  />
-                </button>
-              </div>
-            </BottomSheet.Body>
-          </BottomSheet.Portal>
-        </BottomSheet.Root>
+              </BottomSheet.Body>
+            </BottomSheet.Portal>
+          </BottomSheet.Root>
+        )}
       </div>
     </>
   );

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -49,7 +49,6 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
   const containerRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
-  const { top: safeAreaTop } = useSafeAreaInsets();
   const isMaxSnap = activeSnapPoint === snapPoints[1];
 
   const { viewRef, dragProgress } = useSheetDragProgress({
@@ -85,22 +84,13 @@ export function KindergartenItemSheet({ itemId, isOpen, onClose }: KindergartenI
     }
   }, [containerRef]);
 
-  useEffect(() => {
-    console.log('activeSnapPoint changed:', activeSnapPoint);
-    console.log('isOpen:', isOpen);
-  }, [activeSnapPoint, isOpen]);
-
-  useEffect(() => {
-    console.log('container changed:', container);
-  }, [container]);
-
   if (currentItem == null) return null;
   return (
     <>
       <motion.div
         ref={headerRef}
-        className='fixed top-0 left-0 z-50 w-screen bg-white'
-        style={{ paddingTop: safeAreaTop, opacity: hiddenOpacity }}
+        className='fixed top-0 left-0 z-50 w-screen bg-white pt-(--safe-area-inset-top,0px)'
+        style={{ opacity: hiddenOpacity }}
       >
         <Header className='block'>
           <Header.LeftSection>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -39,10 +39,9 @@ import { tokenUtils } from '@shared/utils';
 interface KindergartenListProps {
   region?: string | null;
   onOpenFilter: () => void;
-  onMoveHome?: () => void;
 }
 
-export function KindergartenList({ onOpenFilter, region, onMoveHome }: KindergartenListProps) {
+export function KindergartenList({ onOpenFilter, region }: KindergartenListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
 
@@ -232,12 +231,7 @@ export function KindergartenList({ onOpenFilter, region, onMoveHome }: Kindergar
             )}
             {searchList.map((item) => (
               <Fragment key={item.id}>
-                <KindergartenListItem
-                  {...item}
-                  banner={item.banner ?? []}
-                  onBookmarkClick={onBookmarkClick}
-                  onMoveHome={onMoveHome}
-                />
+                <KindergartenListItem {...item} banner={item.banner ?? []} onBookmarkClick={onBookmarkClick} />
                 <hr className='bg-line-100 text-line-100 h-[8px] w-full' />
               </Fragment>
             ))}

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
@@ -3,10 +3,10 @@ import { CardBtnClipDefs } from './CardBtnClipDefs';
 import { BannerImageSlider } from './BannerImageSlider';
 import { SERVICE_TAGS, ServiceBadgesTruncated, type KindergartenListItemWithMeta } from '@entities/kindergarten';
 import { useStackNavigation } from '@shared/lib/bridge';
+import { useBottomSheetSnapIndex } from '@shared/lib';
 
 interface KindergartenListItemProps extends KindergartenListItemWithMeta {
   onBookmarkClick?: (id: string, isBookmarked: boolean) => void;
-  onMoveHome?: () => void;
 }
 
 export function KindergartenListItem({
@@ -25,13 +25,13 @@ export function KindergartenListItem({
   memo,
   isBookmarked = false,
   onBookmarkClick,
-  onMoveHome,
 }: KindergartenListItemProps) {
   const { pushForResult } = useStackNavigation();
+  const { setSnapIndex } = useBottomSheetSnapIndex();
 
   const handleClick = async () => {
     const isMoveHome = await pushForResult({ pathname: `/kindergarten/${id}` });
-    if (isMoveHome) onMoveHome?.();
+    if (isMoveHome) setSnapIndex(0);
   };
 
   return (

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
@@ -1,28 +1,21 @@
-import React, { useRef, useState } from 'react';
+import React, { type ComponentProps, useMemo, useRef, useState } from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 import { cn } from '@knockdog/ui/lib';
-import { KindergartenList } from '@features/kindergarten-list/ui/KindergartenList';
 import { BOTTOM_BAR_HEIGHT } from '@shared/constants';
 import { BottomSheet } from '@shared/ui/bottom-sheet';
-import { isNativeWebView, useBottomSheetSnapIndex, useIsomorphicLayoutEffect, useSafeAreaInsets } from '@shared/lib';
+import { isNativeWebView, useBottomSheetSnapIndex, useIsomorphicLayoutEffect } from '@shared/lib';
 import { useMarkerState } from '@shared/store';
 
 // 최소 스냅포인트: 149px(바텀시트 최소 높이) + 68px(바텀바 높이)
 // 최대 스냅포인트: 화면높이 - 64px(검색 헤더바 높이) - 16px (Handle 높이)
 interface KindergartenListSheetProps {
   fabSlot: React.ReactNode;
-  region?: string | null;
-  onOpenFilter: () => void;
+  children: React.ReactNode;
 }
 
-export function KindergartenListSheet({ fabSlot, region, onOpenFilter }: KindergartenListSheetProps) {
-  const { top } = useSafeAreaInsets();
-
+export function KindergartenListSheet({ fabSlot, children }: KindergartenListSheetProps) {
   const MIN_SNAP_POINT = isNativeWebView() ? 141 : BOTTOM_BAR_HEIGHT + 141;
-  const MAX_SNAP_POINT_OFFSET = isNativeWebView() ? 64 + top : 64;
-
-  const snapPoints = [`${MIN_SNAP_POINT}px`, 0.5, 1];
-
+  const snapPoints = useMemo(() => [MIN_SNAP_POINT, 0.5, 1], [MIN_SNAP_POINT]);
   const { snapIndex, setSnapIndex, isFullExtended } = useBottomSheetSnapIndex();
 
   const activeMarkerId = useMarkerState((state) => state.activeMarkerId);
@@ -31,12 +24,11 @@ export function KindergartenListSheet({ fabSlot, region, onOpenFilter }: Kinderg
   const containerRef = useRef<HTMLDivElement>(null);
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
 
-  const activeSnapPoint = snapPoints[snapIndex] ?? snapPoints[0];
-
-  const handleSnapChange = (newSnap: number | string | null) => {
+  const handleSnapChange = (newSnap: ComponentProps<typeof BottomSheet.Root>['activeSnapPoint']) => {
+    if (newSnap == null) return;
     const index = snapPoints.findIndex((point) => point === newSnap);
     if (index !== -1) {
-      setSnapIndex(index as 0 | 1 | 2);
+      setSnapIndex(index);
     }
   };
 
@@ -49,17 +41,14 @@ export function KindergartenListSheet({ fabSlot, region, onOpenFilter }: Kinderg
   return (
     <div
       ref={containerRef}
-      className='pointer-events-none absolute bottom-0 w-full overflow-hidden'
-      style={{
-        height: `calc(100vh - ${MAX_SNAP_POINT_OFFSET}px)`,
-      }}
+      className='pointer-events-none absolute bottom-0 h-[calc(100vh-var(--top-bar-height)-var(--safe-area-inset-top,0px))] w-full overflow-hidden'
     >
       <BottomSheet.Root
         defaultOpen
         dismissible={false}
         modal={false}
         snapPoints={snapPoints}
-        activeSnapPoint={activeSnapPoint}
+        activeSnapPoint={snapPoints[snapIndex] ?? snapPoints[0]}
         setActiveSnapPoint={handleSnapChange}
         container={container}
       >
@@ -78,8 +67,7 @@ export function KindergartenListSheet({ fabSlot, region, onOpenFilter }: Kinderg
               </>
             )}
             <BottomSheet.Title className='sr-only'>강아지 유치원 목록</BottomSheet.Title>
-
-            <KindergartenList onOpenFilter={onOpenFilter} onMoveHome={() => setSnapIndex(0)} region={region} />
+            {children}
           </BottomSheet.Body>
         </RemoveScroll>
       </BottomSheet.Root>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListSheet.tsx
@@ -9,19 +9,15 @@ import { useMarkerState } from '@shared/store';
 
 // 최소 스냅포인트: 149px(바텀시트 최소 높이) + 68px(바텀바 높이)
 // 최대 스냅포인트: 화면높이 - 64px(검색 헤더바 높이) - 16px (Handle 높이)
-
-// ✅ 구(HEAD)·신(리팩토링) 버전 병합: children을 기본으로 받되, 하위호환으로 bottomSlot도 함께 허용
 interface KindergartenListSheetProps {
   fabSlot: React.ReactNode;
   region?: string | null;
-  bottomSlot?: React.ReactNode;
   onOpenFilter: () => void;
 }
 
-export function KindergartenListSheet({ fabSlot, region, bottomSlot, onOpenFilter }: KindergartenListSheetProps) {
+export function KindergartenListSheet({ fabSlot, region, onOpenFilter }: KindergartenListSheetProps) {
   const { top } = useSafeAreaInsets();
 
-  // 리팩토링 분기 반영
   const MIN_SNAP_POINT = isNativeWebView() ? 141 : BOTTOM_BAR_HEIGHT + 141;
   const MAX_SNAP_POINT_OFFSET = isNativeWebView() ? 64 + top : 64;
 
@@ -83,9 +79,7 @@ export function KindergartenListSheet({ fabSlot, region, bottomSlot, onOpenFilte
             )}
             <BottomSheet.Title className='sr-only'>강아지 유치원 목록</BottomSheet.Title>
 
-            {/* 신버전(children) 우선, 구버전(bottomSlot)도 렌더링해 하위호환 보장 */}
             <KindergartenList onOpenFilter={onOpenFilter} onMoveHome={() => setSnapIndex(0)} region={region} />
-            {bottomSlot}
           </BottomSheet.Body>
         </RemoveScroll>
       </BottomSheet.Root>

--- a/apps/knockdog/src/features/kindergarten-list/ui/SearchHeader.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/SearchHeader.tsx
@@ -1,7 +1,6 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Icon, TextField, TextFieldInput } from '@knockdog/ui';
 import { Header } from '@widgets/Header';
-import { useSafeAreaInsets } from '@shared/lib';
 
 interface SearchHeaderProps {
   query: string;
@@ -10,7 +9,6 @@ interface SearchHeaderProps {
 export function SearchHeader({ query }: SearchHeaderProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { top } = useSafeAreaInsets();
 
   /**
    * 검색창 재활성화 (검색 페이지로 이동)
@@ -38,9 +36,8 @@ export function SearchHeader({ query }: SearchHeaderProps) {
 
   return (
     <Header
-      className='bg-fill-secondary-0 absolute top-0 z-50 h-fit w-full'
+      className='bg-fill-secondary-0 absolute top-0 z-50 h-fit w-full pt-(--safe-area-inset-top,0px)'
       innerClassName='gap-2'
-      style={{ paddingTop: top }}
     >
       <Header.LeftSection>
         <Header.BackButton onClick={handleGoSearch} />

--- a/apps/knockdog/src/shared/constants/ui.ts
+++ b/apps/knockdog/src/shared/constants/ui.ts
@@ -1,1 +1,2 @@
+export const TOP_BAR_HEIGHT = 64;
 export const BOTTOM_BAR_HEIGHT = 68;

--- a/apps/knockdog/src/shared/lib/device/useSafeAreaInsets.ts
+++ b/apps/knockdog/src/shared/lib/device/useSafeAreaInsets.ts
@@ -6,6 +6,21 @@ import type { SafeAreaInsets } from '@knockdog/bridge-core';
 
 const DEFAULT_INSETS: SafeAreaInsets = { top: 0, bottom: 0, left: 0, right: 0 };
 
+declare global {
+  interface Window {
+    __SAFE_AREA_INSETS__?: SafeAreaInsets;
+  }
+}
+
+/**
+ * Safe Area Insets Hook
+ *
+ * @deprecated 레이아웃(style) 용도로는 사용을 권장하지 않습니다.
+ * 대신 CSS 변수(`var(--safe-area-inset-top)` 등)를 사용하세요.
+ *
+ * CSS 변수는 Hydration 이슈 없이 즉시 적용되므로 레이아웃 깜빡임이 없습니다.
+ * 이 Hook은 로직 계산이 필요할 때만 제한적으로 사용하세요.
+ */
 export function useSafeAreaInsets() {
   const { data } = useQuery({
     queryKey: ['safeAreaInsets'],
@@ -16,6 +31,12 @@ export function useSafeAreaInsets() {
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     refetchOnReconnect: false,
+    initialData: () => {
+      if (typeof window !== 'undefined' && window.__SAFE_AREA_INSETS__) {
+        return window.__SAFE_AREA_INSETS__;
+      }
+      return undefined;
+    },
   });
   return data ?? DEFAULT_INSETS;
 }

--- a/apps/knockdog/src/shared/ui/safe-area/SafeArea.tsx
+++ b/apps/knockdog/src/shared/ui/safe-area/SafeArea.tsx
@@ -1,5 +1,4 @@
-import { useSafeAreaInsets } from '@shared/lib';
-import { CSSProperties, useState, useEffect } from 'react';
+import { CSSProperties } from 'react';
 
 type EdgeMode = 'off' | 'additive' | 'maximum';
 type Edge = 'top' | 'right' | 'bottom' | 'left';
@@ -9,8 +8,6 @@ type EdgesObject = Partial<Record<Edge, EdgeMode>>;
 interface SafeAreaProps extends React.HTMLAttributes<HTMLDivElement> {
   edges?: EdgesArray | EdgesObject;
 }
-
-const DEFAULT_INSETS = { top: 0, bottom: 0, left: 0, right: 0 };
 
 /**
  * 안전 영역
@@ -26,56 +23,38 @@ const DEFAULT_INSETS = { top: 0, bottom: 0, left: 0, right: 0 };
  *   - 'maximum': finalPadding = max(safeArea, padding)
  */
 export function SafeArea({ edges, style, children, ...props }: SafeAreaProps) {
-  const insets = useSafeAreaInsets();
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  // 서버 사이드 렌더링이나 하이드레이션 전에는 기본값 사용하여 mismatch 방지
-  const safeInsets = isMounted ? insets : DEFAULT_INSETS;
-
   const normalizedEdges: EdgesObject = Array.isArray(edges)
     ? edges.reduce((acc, edge) => ({ ...acc, [edge]: 'additive' as EdgeMode }), {})
     : (edges ?? { top: 'additive', right: 'additive', bottom: 'additive', left: 'additive' });
 
   const existingStyle = style ?? {};
-  const parsePadding = (value: string | number | undefined): number => {
-    if (typeof value === 'number') return value;
-    if (typeof value === 'string') return parseFloat(value) || 0;
-    return 0;
-  };
 
-  const existingPadding = {
-    top: parsePadding(existingStyle.paddingTop),
-    right: parsePadding(existingStyle.paddingRight),
-    bottom: parsePadding(existingStyle.paddingBottom),
-    left: parsePadding(existingStyle.paddingLeft),
-  };
-
-  const calculatePadding = (edge: Edge, safeAreaValue: number): number => {
+  const getEdgeValue = (edge: Edge, existingValue: string | number | undefined): string | number | undefined => {
     const mode = normalizedEdges[edge] ?? 'off';
-    const existingValue = existingPadding[edge];
+
+    const valueStr =
+      existingValue === undefined ? '0px' : typeof existingValue === 'number' ? `${existingValue}px` : existingValue;
 
     if (mode === 'off') {
       return existingValue;
     }
 
+    const cssVar = `var(--safe-area-inset-${edge})`;
+
     if (mode === 'maximum') {
-      return Math.max(safeAreaValue, existingValue);
+      return `max(${cssVar}, ${valueStr})`;
     }
 
-    // 'additive'
-    return safeAreaValue + existingValue;
+    // additive
+    return `calc(${cssVar} + ${valueStr})`;
   };
 
   const finalStyle: CSSProperties = {
     ...existingStyle,
-    paddingTop: calculatePadding('top', safeInsets.top),
-    paddingRight: calculatePadding('right', safeInsets.right),
-    paddingBottom: calculatePadding('bottom', safeInsets.bottom),
-    paddingLeft: calculatePadding('left', safeInsets.left),
+    paddingTop: getEdgeValue('top', existingStyle.paddingTop),
+    paddingRight: getEdgeValue('right', existingStyle.paddingRight),
+    paddingBottom: getEdgeValue('bottom', existingStyle.paddingBottom),
+    paddingLeft: getEdgeValue('left', existingStyle.paddingLeft),
   };
 
   return (

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -152,8 +152,6 @@ function KindergartenMainPageContent() {
       </div>
 
       <KindergartenListSheet
-        onOpenFilter={handleOpenFilter}
-        region={searchParams?.get('region')}
         fabSlot={
           <div className='px-x4 absolute -top-[50px] flex w-full items-center justify-center'>
             <Float placement='top-start' offsetX='x4'>
@@ -168,7 +166,9 @@ function KindergartenMainPageContent() {
             </Float>
           </div>
         }
-      />
+      >
+        <KindergartenList onOpenFilter={handleOpenFilter} region={searchParams?.get('region')} />
+      </KindergartenListSheet>
 
       {isSheetOpen && selectedItemId && (
         <KindergartenItemSheet

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -46,7 +46,6 @@ function KindergartenMainPageContent() {
 
   const { setActiveMarker } = useMarkerState();
   const { isFullExtended, setSnapIndex } = useBottomSheetSnapIndex();
-  // const { top } = useSafeAreaInsets(); // CSS 변수 사용으로 변경
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
@@ -137,7 +136,7 @@ function KindergartenMainPageContent() {
         </div>
       )}
 
-      <div className='px-x4 gap-x2 absolute top-[calc(64px+var(--safe-area-inset-top,0px))] flex w-full items-center'>
+      <div className='px-x4 gap-x2 absolute top-[calc(var(--top-bar-height)+var(--safe-area-inset-top,0px))] flex w-full items-center'>
         <Chip.Toggle variant='outline' checked={isOnlyMemoed} onChange={toggleMemoed}>
           <Chip.PrefixIcon>
             <Icon icon='Note' className='size-x4' />

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -25,7 +25,7 @@ import { getRegionLevel } from '@features/kindergarten-map/lib/markers';
 import type { BoundsSnapshot } from '@features/kindergarten-map/lib/searchMachine';
 import { boundsSnapshotToBounds, toBoundsSnapshot } from '@features/kindergarten-map/lib/bounds';
 import type { KindergartenListItemWithMeta } from '@entities/kindergarten';
-import { isEqualCoord, useBottomSheetSnapIndex, useSafeAreaInsets } from '@shared/lib';
+import { isEqualCoord, useBottomSheetSnapIndex } from '@shared/lib';
 import { useMarkerState } from '@shared/store';
 
 export default function KindergartenMainPage() {
@@ -46,7 +46,7 @@ function KindergartenMainPageContent() {
 
   const { setActiveMarker } = useMarkerState();
   const { isFullExtended, setSnapIndex } = useBottomSheetSnapIndex();
-  const { top } = useSafeAreaInsets();
+  // const { top } = useSafeAreaInsets(); // CSS 변수 사용으로 변경
 
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
@@ -118,8 +118,11 @@ function KindergartenMainPageContent() {
         <SearchHeader query={committedState.query} />
       ) : (
         <div
-          className={cn(`absolute top-0 right-0 left-0 z-50 ${isFullExtended ? 'bg-fill-secondary-0' : ''}`)}
-          style={{ paddingTop: top }}
+          className={cn(
+            `absolute top-0 right-0 left-0 z-50 pt-(--safe-area-inset-top,0px) ${
+              isFullExtended ? 'bg-fill-secondary-0' : ''
+            }`
+          )}
         >
           <div className='px-x4 flex h-16 w-full items-center transition-colors ease-out'>
             <Link href={`/search${searchParams?.toString() ? `?${searchParams.toString()}` : ''}`} className='w-full'>
@@ -134,7 +137,7 @@ function KindergartenMainPageContent() {
         </div>
       )}
 
-      <div className='px-x4 gap-x2 absolute flex w-full items-center' style={{ top: `${64 + top}px` }}>
+      <div className='px-x4 gap-x2 absolute top-[calc(64px+var(--safe-area-inset-top,0px))] flex w-full items-center'>
         <Chip.Toggle variant='outline' checked={isOnlyMemoed} onChange={toggleMemoed}>
           <Chip.PrefixIcon>
             <Icon icon='Note' className='size-x4' />

--- a/apps/mobile/bridges/ui/BridgeWebView.tsx
+++ b/apps/mobile/bridges/ui/BridgeWebView.tsx
@@ -71,6 +71,7 @@ function buildSafeAreaInjector(insets: { top: number; bottom: number; left: numb
 
 export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
   const insets = useSafeAreaInsets();
+  const lastInjectedInsetsRef = useRef<string | null>(null);
 
   const CONSOLE_PATCH = useMemo(
     () => buildConsolePatch({ tag: 'WEBVIEW', levels: ['log', 'warn', 'error'], maxLen: 1_000 }),
@@ -97,6 +98,15 @@ export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
     scripts.push(INJECT_STATE);
     return scripts.join('\n');
   }, [CONSOLE_PATCH, INJECT_STATE, INJECT_SAFE_AREA]);
+
+  useEffect(() => {
+    const ref = refToUse.current;
+    if (!ref) return;
+    const key = `${insets.top}-${insets.bottom}-${insets.left}-${insets.right}`;
+    if (lastInjectedInsetsRef.current === key) return;
+    lastInjectedInsetsRef.current = key;
+    ref.injectJavaScript(buildSafeAreaInjector(insets));
+  }, [insets, refToUse]);
 
   // unmount 시 이 WebView가 기다리던 모든 txId 정리
   useEffect(() => {

--- a/apps/mobile/bridges/ui/BridgeWebView.tsx
+++ b/apps/mobile/bridges/ui/BridgeWebView.tsx
@@ -1,4 +1,5 @@
 import WebView from 'react-native-webview';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type RefObject, useRef, useMemo, useEffect } from 'react';
 import { makeOnMessage } from '../lib/onMessage';
 import { createBridgeForWebView } from '../wiring/createBridge';
@@ -52,7 +53,25 @@ function buildHistoryStateInjector(state?: InitialState) {
   `;
 }
 
+/** Safe Area Insets 주입 스크립트 */
+function buildSafeAreaInjector(insets: { top: number; bottom: number; left: number; right: number }) {
+  const { top, bottom, left, right } = insets;
+  return `
+    (function(){
+      var insets = { top: ${top}, bottom: ${bottom}, left: ${left}, right: ${right} };
+      window.__SAFE_AREA_INSETS__ = insets;
+      var style = document.documentElement.style;
+      style.setProperty('--safe-area-inset-top', '${top}px');
+      style.setProperty('--safe-area-inset-bottom', '${bottom}px');
+      style.setProperty('--safe-area-inset-left', '${left}px');
+      style.setProperty('--safe-area-inset-right', '${right}px');
+    })();
+  `;
+}
+
 export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
+  const insets = useSafeAreaInsets();
+
   const CONSOLE_PATCH = useMemo(
     () => buildConsolePatch({ tag: 'WEBVIEW', levels: ['log', 'warn', 'error'], maxLen: 1_000 }),
     []
@@ -67,13 +86,17 @@ export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
   // 초기 state/history 주입 스크립트
   const INJECT_STATE = useMemo(() => buildHistoryStateInjector(initialState), [initialState]);
 
+  // Safe Area 주입 스크립트
+  const INJECT_SAFE_AREA = useMemo(() => buildSafeAreaInjector(insets), [insets]);
+
   // 개발 모드에서는 콘솔 패치 + state 주입을 함께, 프로덕션에서도 state 주입은 항상 수행
   const INJECT_BEFORE = useMemo(() => {
     const scripts = [];
     if (__DEV__) scripts.push(CONSOLE_PATCH);
+    scripts.push(INJECT_SAFE_AREA);
     scripts.push(INJECT_STATE);
     return scripts.join('\n');
-  }, [CONSOLE_PATCH, INJECT_STATE]);
+  }, [CONSOLE_PATCH, INJECT_STATE, INJECT_SAFE_AREA]);
 
   // unmount 시 이 WebView가 기다리던 모든 txId 정리
   useEffect(() => {

--- a/packages/headless-ui/vaul/src/context.ts
+++ b/packages/headless-ui/vaul/src/context.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DrawerDirection } from './types';
+import { DrawerDirection, SnapPoint } from './types';
 
 interface DrawerContextValue {
   drawerRef: React.RefObject<HTMLDivElement>;
@@ -15,12 +15,12 @@ interface DrawerContextValue {
   isDragging: boolean;
   keyboardIsOpen: React.MutableRefObject<boolean>;
   snapPointsOffset: number[] | null;
-  snapPoints?: (number | string)[] | null;
+  snapPoints?: SnapPoint[] | null;
   activeSnapPointIndex?: number | null;
   modal: boolean;
   shouldFade: boolean;
-  activeSnapPoint?: number | string | null;
-  setActiveSnapPoint: (o: number | string | null) => void;
+  activeSnapPoint?: SnapPoint | null;
+  setActiveSnapPoint: (o: SnapPoint | null) => void;
   closeDrawer: () => void;
   openProp?: boolean;
   onOpenChange?: (o: boolean) => void;

--- a/packages/headless-ui/vaul/src/index.tsx
+++ b/packages/headless-ui/vaul/src/index.tsx
@@ -18,7 +18,7 @@ import {
   WINDOW_TOP_OFFSET,
   DRAG_CLASS,
 } from './constants';
-import { DrawerDirection } from './types';
+import { DrawerDirection, SnapPoint } from './types';
 import { useControllableState } from './use-controllable-state';
 import { useScaleBackground } from './use-scale-background';
 import { usePositionFixed } from './use-position-fixed';
@@ -30,7 +30,7 @@ export interface WithFadeFromProps {
    * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
    * You can also use px values, which doesn't take screen height into account.
    */
-  snapPoints: (number | string)[];
+  snapPoints: SnapPoint[];
   /**
    * Index of a `snapPoint` from which the overlay fade should be applied. Defaults to the last snap point.
    */
@@ -43,13 +43,13 @@ export interface WithoutFadeFromProps {
    * Should go from least visible. Example `[0.2, 0.5, 0.8]`.
    * You can also use px values, which doesn't take screen height into account.
    */
-  snapPoints?: (number | string)[];
+  snapPoints?: SnapPoint[];
   fadeFromIndex?: never;
 }
 
 export type DialogProps = {
-  activeSnapPoint?: number | string | null;
-  setActiveSnapPoint?: (snapPoint: number | string | null) => void;
+  activeSnapPoint?: SnapPoint | null;
+  setActiveSnapPoint?: (snapPoint: SnapPoint | null) => void;
   children?: React.ReactNode;
   open?: boolean;
   /**
@@ -144,6 +144,7 @@ export type DialogProps = {
   shouldAnimate?: boolean;
   preventScrollRestoration?: boolean;
   autoFocus?: boolean;
+  onSnapPointsResolved?: (resolved: number[]) => void;
 } & (WithFadeFromProps | WithoutFadeFromProps);
 
 export function Root({
@@ -178,6 +179,7 @@ export function Root({
   shouldAnimate: shouldAnimateProp,
   container,
   autoFocus = false,
+  onSnapPointsResolved,
 }: DialogProps) {
   const [isOpen = false, setIsOpen] = useControllableState({
     defaultProp: defaultOpen,
@@ -251,6 +253,7 @@ export function Root({
     direction,
     container,
     snapToSequentialPoint,
+    onSnapPointsResolved,
   });
   usePreventScroll({
     isDisabled:
@@ -873,6 +876,8 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
   const lastKnownPointerEventRef = React.useRef<React.PointerEvent<HTMLDivElement> | null>(null);
   const wasBeyondThePointRef = React.useRef(false);
   const hasSnapPoints = snapPoints && snapPoints.length > 0;
+  const snapPointOffset =
+    typeof activeSnapPointIndex === 'number' ? snapPointsOffset?.[activeSnapPointIndex] : undefined;
   useScaleBackground();
 
   const isDeltaInDirection = (delta: { x: number; y: number }, direction: DrawerDirection, threshold = 0) => {
@@ -924,9 +929,9 @@ export const Content = React.forwardRef<HTMLDivElement, ContentProps>(function (
       {...rest}
       ref={composedRef}
       style={
-        snapPointsOffset && snapPointsOffset.length > 0
+        typeof snapPointOffset === 'number' && Number.isFinite(snapPointOffset)
           ? ({
-              '--snap-point-height': `${snapPointsOffset[activeSnapPointIndex ?? 0]!}px`,
+              '--snap-point-height': `${snapPointOffset}px`,
               ...style,
             } as React.CSSProperties)
           : style

--- a/packages/headless-ui/vaul/src/types.ts
+++ b/packages/headless-ui/vaul/src/types.ts
@@ -1,7 +1,16 @@
 export type DrawerDirection = 'top' | 'bottom' | 'left' | 'right';
-export interface SnapPoint {
-  fraction: number;
-  height: number;
-}
+
+export type SnapContext = {
+  viewportHeight: number;
+  measuredDrawerHeight: number;
+};
+
+export type ContentSnap = {
+  type: 'content';
+  min: number | string;
+  max?: number | string;
+};
+
+export type SnapPoint = number | `${number}%` | ContentSnap | ((ctx: SnapContext) => number);
 
 export type AnyFunction = (...args: any) => any;

--- a/packages/headless-ui/vaul/src/use-snap-points.ts
+++ b/packages/headless-ui/vaul/src/use-snap-points.ts
@@ -180,17 +180,18 @@ export function useSnapPoints({
       }
 
       if (typeof snapPoint === 'object' && snapPoint !== null && snapPoint.type === 'content') {
-        let height = measuredDrawerHeight;
-        if (height <= 0 && snapPoint.min !== undefined) {
-          height = resolve(snapPoint.min as SnapPoint, 'y');
+        const axis: 'x' | 'y' = isVertical(direction) ? 'y' : 'x';
+        let size = isVertical(direction) ? measuredDrawerHeight : containerSize.width;
+        if (size <= 0 && snapPoint.min !== undefined) {
+          size = resolve(snapPoint.min as SnapPoint, axis);
         }
         if (snapPoint.min !== undefined) {
-          height = Math.max(height, resolve(snapPoint.min as SnapPoint, 'y'));
+          size = Math.max(size, resolve(snapPoint.min as SnapPoint, axis));
         }
         if (snapPoint.max !== undefined) {
-          height = Math.min(height, resolve(snapPoint.max as SnapPoint, 'y'));
+          size = Math.min(size, resolve(snapPoint.max as SnapPoint, axis));
         }
-        return height;
+        return size;
       }
 
       return 0;
@@ -214,9 +215,13 @@ export function useSnapPoints({
         return heightOrWidth;
       }) ?? [];
 
-    onSnapPointsResolved?.(offsets);
     return offsets;
-  }, [snapPoints, windowDimensions, container, measuredDrawerHeight, onSnapPointsResolved, hasContentSnap]);
+  }, [snapPoints, windowDimensions, container, measuredDrawerHeight, hasContentSnap, direction]);
+
+  React.useEffect(() => {
+    if (!onSnapPointsResolved) return;
+    onSnapPointsResolved(snapPointsOffset);
+  }, [snapPointsOffset, onSnapPointsResolved]);
 
   const activeSnapPointOffset = React.useMemo(
     () => (activeSnapPointIndex !== null ? snapPointsOffset?.[activeSnapPointIndex] : null),

--- a/packages/headless-ui/vaul/src/use-snap-points.ts
+++ b/packages/headless-ui/vaul/src/use-snap-points.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { set, isVertical } from './helpers';
 import { TRANSITIONS, VELOCITY_THRESHOLD } from './constants';
 import { useControllableState } from './use-controllable-state';
-import { DrawerDirection } from './types';
+import { DrawerDirection, SnapPoint, SnapContext } from './types';
 
 export function useSnapPoints({
   activeSnapPointProp,
@@ -15,10 +15,11 @@ export function useSnapPoints({
   direction = 'bottom',
   container,
   snapToSequentialPoint,
+  onSnapPointsResolved,
 }: {
-  activeSnapPointProp?: number | string | null;
-  setActiveSnapPointProp?(snapPoint: number | null | string): void;
-  snapPoints?: (number | string)[];
+  activeSnapPointProp?: SnapPoint | null;
+  setActiveSnapPointProp?(snapPoint: SnapPoint | null): void;
+  snapPoints?: SnapPoint[];
   fadeFromIndex?: number;
   drawerRef: React.RefObject<HTMLDivElement>;
   overlayRef: React.RefObject<HTMLDivElement>;
@@ -26,12 +27,39 @@ export function useSnapPoints({
   direction?: DrawerDirection;
   container?: HTMLElement | null | undefined;
   snapToSequentialPoint?: boolean;
+  onSnapPointsResolved?: (resolved: number[]) => void;
 }) {
-  const [activeSnapPoint, setActiveSnapPoint] = useControllableState<string | number | null>({
+  const [activeSnapPoint, setActiveSnapPoint] = useControllableState<SnapPoint | null>({
     prop: activeSnapPointProp,
     defaultProp: snapPoints?.[0],
     onChange: setActiveSnapPointProp,
   });
+
+  const [measuredDrawerHeight, setMeasuredDrawerHeight] = React.useState(0);
+
+  const activeSnapPointRef = React.useRef(activeSnapPoint);
+
+  React.useEffect(() => {
+    activeSnapPointRef.current = activeSnapPoint;
+  }, [activeSnapPoint]);
+
+  React.useEffect(() => {
+    const hasContentSnap = snapPoints?.some((s) => typeof s === 'object' && s !== null && s.type === 'content');
+    if (!drawerRef.current || !hasContentSnap) return;
+
+    // Measure drawer content height so content-based snap points can resolve reliably.
+    // We always keep the latest measurement to avoid stale values when switching snap points.
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const item = entry.borderBoxSize?.[0];
+        const height = item ? item.blockSize : entry.contentRect.height;
+        setMeasuredDrawerHeight(height);
+      }
+    });
+
+    observer.observe(drawerRef.current);
+    return () => observer.disconnect();
+  }, [drawerRef, snapPoints]);
 
   const [windowDimensions, setWindowDimensions] = React.useState(
     typeof window !== 'undefined'
@@ -59,10 +87,26 @@ export function useSnapPoints({
     [snapPoints, activeSnapPoint],
   );
 
-  const activeSnapPointIndex = React.useMemo(
-    () => snapPoints?.findIndex((snapPoint) => snapPoint === activeSnapPoint) ?? null,
-    [snapPoints, activeSnapPoint],
-  );
+  const activeSnapPointIndex = React.useMemo(() => {
+    if (!snapPoints || snapPoints.length === 0) return null;
+    const index = snapPoints.findIndex((snapPoint) => snapPoint === activeSnapPoint);
+    return index >= 0 ? index : null;
+  }, [snapPoints, activeSnapPoint]);
+
+  React.useEffect(() => {
+    if (!snapPoints || snapPoints.length === 0) return;
+    if (activeSnapPointIndex !== null) return;
+    if (activeSnapPoint == null) return;
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[Vaul:Snap] activeSnapPoint is not in snapPoints. Resetting to first snap point.', {
+        activeSnapPoint,
+        snapPoints,
+      });
+    }
+
+    setActiveSnapPoint(snapPoints[0] ?? null);
+  }, [activeSnapPointIndex, activeSnapPoint, setActiveSnapPoint, snapPoints]);
 
   const shouldFade =
     (snapPoints &&
@@ -79,34 +123,67 @@ export function useSnapPoints({
       ? { width: window.innerWidth, height: window.innerHeight }
       : { width: 0, height: 0 };
 
-    return (
-      snapPoints?.map((snapPoint) => {
-        const isPx = typeof snapPoint === 'string';
-        let snapPointAsNumber = 0;
+    const ctx: SnapContext = {
+      viewportHeight: containerSize.height,
+      measuredDrawerHeight,
+    };
 
-        if (isPx) {
-          snapPointAsNumber = parseInt(snapPoint, 10);
+    const resolve = (snapPoint: SnapPoint, axis: 'x' | 'y'): number => {
+      const size = axis === 'y' ? containerSize.height : containerSize.width;
+      if (typeof snapPoint === 'number') {
+        // 0 to 1 is fraction, > 1 is pixels
+        return snapPoint <= 1 ? snapPoint * size : snapPoint;
+      }
+
+      if (typeof snapPoint === 'string') {
+        if (snapPoint.endsWith('%')) {
+          return (parseFloat(snapPoint) / 100) * size;
         }
+        return parseInt(snapPoint, 10);
+      }
+
+      if (typeof snapPoint === 'function') {
+        return snapPoint(ctx);
+      }
+
+      if (typeof snapPoint === 'object' && snapPoint !== null && snapPoint.type === 'content') {
+        let height = measuredDrawerHeight;
+        if (height <= 0 && snapPoint.min !== undefined) {
+          height = resolve(snapPoint.min as SnapPoint, 'y');
+        }
+        if (snapPoint.min !== undefined) {
+          height = Math.max(height, resolve(snapPoint.min as SnapPoint, 'y'));
+        }
+        if (snapPoint.max !== undefined) {
+          height = Math.min(height, resolve(snapPoint.max as SnapPoint, 'y'));
+        }
+        return height;
+      }
+
+      return 0;
+    };
+
+    const offsets =
+      snapPoints?.map((snapPoint) => {
+        const heightOrWidth = resolve(snapPoint, isVertical(direction) ? 'y' : 'x');
 
         if (isVertical(direction)) {
-          const height = isPx ? snapPointAsNumber : windowDimensions ? snapPoint * containerSize.height : 0;
-
           if (windowDimensions) {
-            return direction === 'bottom' ? containerSize.height - height : -containerSize.height + height;
+            return direction === 'bottom'
+              ? containerSize.height - heightOrWidth
+              : -containerSize.height + heightOrWidth;
           }
-
-          return height;
+          return heightOrWidth;
         }
-        const width = isPx ? snapPointAsNumber : windowDimensions ? snapPoint * containerSize.width : 0;
-
         if (windowDimensions) {
-          return direction === 'right' ? containerSize.width - width : -containerSize.width + width;
+          return direction === 'right' ? containerSize.width - heightOrWidth : -containerSize.width + heightOrWidth;
         }
+        return heightOrWidth;
+      }) ?? [];
 
-        return width;
-      }) ?? []
-    );
-  }, [snapPoints, windowDimensions, container]);
+    onSnapPointsResolved?.(offsets);
+    return offsets;
+  }, [snapPoints, windowDimensions, container, measuredDrawerHeight, onSnapPointsResolved]);
 
   const activeSnapPointOffset = React.useMemo(
     () => (activeSnapPointIndex !== null ? snapPointsOffset?.[activeSnapPointIndex] : null),
@@ -147,14 +224,12 @@ export function useSnapPoints({
   );
 
   React.useEffect(() => {
-    if (activeSnapPoint || activeSnapPointProp) {
-      const newIndex =
-        snapPoints?.findIndex((snapPoint) => snapPoint === activeSnapPointProp || snapPoint === activeSnapPoint) ?? -1;
-      if (snapPointsOffset && newIndex !== -1 && typeof snapPointsOffset[newIndex] === 'number') {
-        snapToPoint(snapPointsOffset[newIndex] as number);
-      }
+    if (activeSnapPointIndex === null) return;
+    const offset = snapPointsOffset?.[activeSnapPointIndex];
+    if (typeof offset === 'number') {
+      snapToPoint(offset);
     }
-  }, [activeSnapPoint, activeSnapPointProp, snapPoints, snapPointsOffset, snapToPoint]);
+  }, [activeSnapPointIndex, snapPointsOffset, snapToPoint]);
 
   function onRelease({
     draggedDistance,

--- a/packages/headless-ui/vaul/src/use-snap-points.ts
+++ b/packages/headless-ui/vaul/src/use-snap-points.ts
@@ -43,23 +43,56 @@ export function useSnapPoints({
     activeSnapPointRef.current = activeSnapPoint;
   }, [activeSnapPoint]);
 
+  const hasContentSnap = React.useMemo(
+    () => snapPoints?.some((s) => typeof s === 'object' && s !== null && s.type === 'content') ?? false,
+    [snapPoints],
+  );
+  const isActiveContentSnap = React.useMemo(
+    () => typeof activeSnapPoint === 'object' && activeSnapPoint !== null && activeSnapPoint.type === 'content',
+    [activeSnapPoint],
+  );
+
   React.useEffect(() => {
-    const hasContentSnap = snapPoints?.some((s) => typeof s === 'object' && s !== null && s.type === 'content');
-    if (!drawerRef.current || !hasContentSnap) return;
+    if (!hasContentSnap) return;
 
-    // Measure drawer content height so content-based snap points can resolve reliably.
-    // We always keep the latest measurement to avoid stale values when switching snap points.
-    const observer = new ResizeObserver((entries) => {
-      for (const entry of entries) {
-        const item = entry.borderBoxSize?.[0];
-        const height = item ? item.blockSize : entry.contentRect.height;
-        setMeasuredDrawerHeight(height);
+    let rafId: number | null = null;
+    let observer: ResizeObserver | null = null;
+
+    const startObserving = () => {
+      if (!drawerRef.current) {
+        rafId = window.requestAnimationFrame(startObserving);
+        return;
       }
-    });
 
-    observer.observe(drawerRef.current);
-    return () => observer.disconnect();
-  }, [drawerRef, snapPoints]);
+      // Measure drawer content height so content-based snap points can resolve reliably.
+      // We always keep the latest measurement to avoid stale values when switching snap points.
+      observer = new ResizeObserver((entries) => {
+        if (!isActiveContentSnap) return;
+        for (const entry of entries) {
+          const item = entry.borderBoxSize?.[0];
+          const height = item ? item.blockSize : entry.contentRect.height;
+          setMeasuredDrawerHeight(height);
+        }
+      });
+
+      observer.observe(drawerRef.current);
+    };
+
+    startObserving();
+
+    return () => {
+      if (rafId !== null) window.cancelAnimationFrame(rafId);
+      observer?.disconnect();
+    };
+  }, [drawerRef, hasContentSnap, isActiveContentSnap, snapPoints]);
+
+  React.useEffect(() => {
+    if (!isActiveContentSnap || !drawerRef.current) return;
+    const rect = drawerRef.current.getBoundingClientRect();
+    if (rect.height > 0) {
+      setMeasuredDrawerHeight(rect.height);
+    }
+  }, [isActiveContentSnap]);
 
   const [windowDimensions, setWindowDimensions] = React.useState(
     typeof window !== 'undefined'
@@ -183,7 +216,7 @@ export function useSnapPoints({
 
     onSnapPointsResolved?.(offsets);
     return offsets;
-  }, [snapPoints, windowDimensions, container, measuredDrawerHeight, onSnapPointsResolved]);
+  }, [snapPoints, windowDimensions, container, measuredDrawerHeight, onSnapPointsResolved, hasContentSnap]);
 
   const activeSnapPointOffset = React.useMemo(
     () => (activeSnapPointIndex !== null ? snapPointsOffset?.[activeSnapPointIndex] : null),

--- a/packages/headless-ui/vaul/test/package.json
+++ b/packages/headless-ui/vaul/test/package.json
@@ -24,6 +24,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.3",
-    "vaul": "workspace:^"
+    "@daeng-design/vaul": "workspace:^"
   }
 }

--- a/packages/ui/src/components/bottom-sheet/BottomSheet.tsx
+++ b/packages/ui/src/components/bottom-sheet/BottomSheet.tsx
@@ -25,7 +25,7 @@ function BottomSheetOverlay({ className, ...props }: React.ComponentProps<typeof
   return (
     <DrawerPrimitive.Overlay
       data-slot='bottom-sheet-overlay'
-      className={cn('z-(--z-index-overlay) fixed inset-0 bg-black/40', className)}
+      className={cn('z-overlay fixed inset-0 bg-black/40', className)}
       {...props}
     />
   );
@@ -36,7 +36,7 @@ function BottomSheetBody({ className, children, ...props }: React.ComponentProps
     <DrawerPrimitive.Content
       data-slot='bottom-sheet-body'
       className={cn(
-        'bg-primitive-neutral-0 z-(--z-index-modal) fixed inset-x-0 bottom-0 max-h-[calc(100vh-72px)] w-full rounded-t-[16px] shadow-[0px_-16px_20px] shadow-black/5',
+        'bg-primitive-neutral-0 z-modal fixed inset-x-0 bottom-0 max-h-[calc(100vh-72px)] w-full rounded-t-[16px] shadow-[0px_-16px_20px] shadow-black/5',
         className
       )}
       {...props}
@@ -54,7 +54,7 @@ function BottomSheetHandle({ className, ...props }: React.ComponentProps<typeof 
   return (
     <DrawerPrimitive.Handle
       data-slot='bottom-sheet-handle'
-      className={cn('bg-fill-secondary-200 mx-auto mb-[8px] mt-[12px] h-[5px] w-[36px] rounded-full', className)}
+      className={cn('bg-fill-secondary-200 mx-auto mt-[12px] mb-[8px] h-[5px] w-[36px] rounded-full', className)}
       {...props}
     />
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: ^15.5.9
-        version: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nuqs:
         specifier: ^2.7.3
         version: 2.8.1(next@15.5.9(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -397,7 +397,7 @@ importers:
         version: 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/nextjs':
         specifier: 9.1.10
-        version: 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
+        version: 9.1.10(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
@@ -976,13 +976,13 @@ importers:
         version: link:../config-typescript
       '@storybook/nextjs':
         specifier: 9.1.10
-        version: 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
+        version: 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       '@svgr/cli':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
       '@turbo/gen':
         specifier: ^2.6.3
-        version: 2.6.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@24.10.4)(typescript@5.9.3)
+        version: 2.6.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@25.0.2)(typescript@5.9.3)
       '@types/react':
         specifier: ^19.2.3
         version: 19.2.7
@@ -4152,9 +4152,6 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
-  '@types/node@24.10.3':
-    resolution: {integrity: sha512-gqkrWUsS8hcm0r44yn7/xZeV1ERva/nLgrLxFRUGb7aoNMIJfZJ3AC261zDQuOAKC7MiXai1WCpYc48jAHoShQ==}
-
   '@types/node@24.10.4':
     resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
 
@@ -5460,9 +5457,6 @@ packages:
   cssstyle@5.3.4:
     resolution: {integrity: sha512-KyOS/kJMEq5O9GdPnaf82noigg5X5DYn0kZPJTaAsCUaBizp6Xa1y9D4Qoqf/JazEXWuruErHgVXwjN5391ZJw==}
     engines: {node: '>=20'}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -12843,12 +12837,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.10.4)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.0.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.1
     optionalDependencies:
-      '@types/node': 24.10.4
+      '@types/node': 25.0.2
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -12889,14 +12883,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.10.3
+      '@types/node': 24.10.4
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.10.3
+      '@types/node': 24.10.4
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -12930,7 +12924,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.10.3
+      '@types/node': 24.10.4
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -13033,21 +13027,6 @@ snapshots:
     dependencies:
       playwright: 1.57.0
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))':
-    dependencies:
-      ansi-html: 0.0.9
-      core-js-pure: 3.46.0
-      error-stack-parser: 2.1.4
-      html-entities: 2.6.0
-      loader-utils: 2.0.4
-      react-refresh: 0.14.2
-      schema-utils: 4.3.3
-      source-map: 0.7.6
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-    optionalDependencies:
-      type-fest: 2.19.0
-      webpack-hot-middleware: 2.26.1
-
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))':
     dependencies:
       ansi-html: 0.0.9
@@ -13059,6 +13038,21 @@ snapshots:
       schema-utils: 4.3.3
       source-map: 0.7.6
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+    optionalDependencies:
+      type-fest: 2.19.0
+      webpack-hot-middleware: 2.26.1
+
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))':
+    dependencies:
+      ansi-html: 0.0.9
+      core-js-pure: 3.46.0
+      error-stack-parser: 2.1.4
+      html-entities: 2.6.0
+      loader-utils: 2.0.4
+      react-refresh: 0.14.2
+      schema-utils: 4.3.3
+      source-map: 0.7.6
+      webpack: 5.102.1(esbuild@0.25.11)
     optionalDependencies:
       type-fest: 2.19.0
       webpack-hot-middleware: 2.26.1
@@ -14084,36 +14078,9 @@ snapshots:
     dependencies:
       storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@storybook/builder-webpack5@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/builder-webpack5@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
       '@storybook/core-webpack': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
-      case-sensitive-paths-webpack-plugin: 2.4.0
-      cjs-module-lexer: 1.4.3
-      css-loader: 6.11.0(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      html-webpack-plugin: 5.6.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      magic-string: 0.30.19
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      style-loader: 3.3.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      terser-webpack-plugin: 5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      ts-dedent: 2.2.0
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-      webpack-dev-middleware: 6.1.3(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      webpack-hot-middleware: 2.26.1
-      webpack-virtual-modules: 0.6.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-      - webpack-cli
-
-  '@storybook/builder-webpack5@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
-    dependencies:
-      '@storybook/core-webpack': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
       css-loader: 6.11.0(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
@@ -14121,7 +14088,7 @@ snapshots:
       fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       html-webpack-plugin: 5.6.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       magic-string: 0.30.19
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       style-loader: 3.3.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       terser-webpack-plugin: 5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       ts-dedent: 2.2.0
@@ -14138,10 +14105,32 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/core-webpack@9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/builder-webpack5@9.1.10(esbuild@0.25.11)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/core-webpack': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
+      case-sensitive-paths-webpack-plugin: 2.4.0
+      cjs-module-lexer: 1.4.3
+      css-loader: 6.11.0(webpack@5.102.1(esbuild@0.25.11))
+      es-module-lexer: 1.7.0
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.3)(webpack@5.102.1(esbuild@0.25.11))
+      html-webpack-plugin: 5.6.4(webpack@5.102.1(esbuild@0.25.11))
+      magic-string: 0.30.19
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      style-loader: 3.3.4(webpack@5.102.1(esbuild@0.25.11))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.11)(webpack@5.102.1(esbuild@0.25.11))
       ts-dedent: 2.2.0
+      webpack: 5.102.1(esbuild@0.25.11)
+      webpack-dev-middleware: 6.1.3(webpack@5.102.1(esbuild@0.25.11))
+      webpack-hot-middleware: 2.26.1
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+      - webpack-cli
 
   '@storybook/core-webpack@9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
@@ -14160,67 +14149,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/nextjs@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.4)
-      '@babel/plugin-transform-runtime': 7.28.3(@babel/core@7.28.4)
-      '@babel/preset-env': 7.28.3(@babel/core@7.28.4)
-      '@babel/preset-react': 7.27.1(@babel/core@7.28.4)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
-      '@babel/runtime': 7.28.4
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      '@storybook/builder-webpack5': 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@storybook/react': 9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@types/semver': 7.7.1
-      babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      css-loader: 6.11.0(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      image-size: 2.0.2
-      loader-utils: 3.3.1
-      next: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      postcss: 8.5.6
-      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      react-refresh: 0.14.2
-      resolve-url-loader: 5.0.0
-      sass-loader: 16.0.5(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      semver: 7.7.3
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      style-loader: 3.3.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
-      styled-jsx: 5.1.7(@babel/core@7.28.4)(react@19.2.3)
-      tsconfig-paths: 4.2.0
-      tsconfig-paths-webpack-plugin: 4.2.0
-    optionalDependencies:
-      typescript: 5.9.3
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/webpack'
-      - babel-plugin-macros
-      - esbuild
-      - node-sass
-      - sass
-      - sass-embedded
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - webpack-cli
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-
-  '@storybook/nextjs@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))':
+  '@storybook/nextjs@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
@@ -14236,15 +14165,15 @@ snapshots:
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
       '@babel/runtime': 7.28.4
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
-      '@storybook/builder-webpack5': 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@storybook/preset-react-webpack': 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
-      '@storybook/react': 9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/builder-webpack5': 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/react': 9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
       '@types/semver': 7.7.1
       babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       css-loader: 6.11.0(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       postcss: 8.5.6
       postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
@@ -14254,7 +14183,7 @@ snapshots:
       resolve-url-loader: 5.0.0
       sass-loader: 16.0.5(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       semver: 7.7.3
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       style-loader: 3.3.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       styled-jsx: 5.1.7(@babel/core@7.28.4)(react@19.2.3)
       tsconfig-paths: 4.2.0
@@ -14280,33 +14209,69 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/nextjs@9.1.10(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))':
     dependencies:
-      '@storybook/core-webpack': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
+      '@babel/core': 7.28.4
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.4)
+      '@babel/plugin-syntax-import-assertions': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-class-properties': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-numeric-separator': 7.27.1(@babel/core@7.28.4)
+      '@babel/plugin-transform-object-rest-spread': 7.28.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-runtime': 7.28.3(@babel/core@7.28.4)
+      '@babel/preset-env': 7.28.3(@babel/core@7.28.4)
+      '@babel/preset-react': 7.27.1(@babel/core@7.28.4)
+      '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
+      '@babel/runtime': 7.28.4
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))
+      '@storybook/builder-webpack5': 9.1.10(esbuild@0.25.11)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/preset-react-webpack': 9.1.10(esbuild@0.25.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
+      '@storybook/react': 9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)
       '@types/semver': 7.7.1
-      find-up: 7.0.0
-      magic-string: 0.30.19
+      babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.102.1(esbuild@0.25.11))
+      css-loader: 6.11.0(webpack@5.102.1(esbuild@0.25.11))
+      image-size: 2.0.2
+      loader-utils: 3.3.1
+      next: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.102.1(esbuild@0.25.11))
+      postcss: 8.5.6
+      postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(esbuild@0.25.11))
       react: 19.2.3
-      react-docgen: 7.1.1
       react-dom: 19.2.3(react@19.2.3)
-      resolve: 1.22.10
+      react-refresh: 0.14.2
+      resolve-url-loader: 5.0.0
+      sass-loader: 16.0.5(webpack@5.102.1(esbuild@0.25.11))
       semver: 7.7.3
       storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      style-loader: 3.3.4(webpack@5.102.1(esbuild@0.25.11))
+      styled-jsx: 5.1.7(@babel/core@7.28.4)(react@19.2.3)
       tsconfig-paths: 4.2.0
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
+      tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
+      webpack: 5.102.1(esbuild@0.25.11)
     transitivePeerDependencies:
+      - '@rspack/core'
       - '@swc/core'
+      - '@types/webpack'
+      - babel-plugin-macros
       - esbuild
+      - node-sass
+      - sass
+      - sass-embedded
+      - sockjs-client
       - supports-color
+      - type-fest
       - uglify-js
       - webpack-cli
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
 
-  '@storybook/preset-react-webpack@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
+  '@storybook/preset-react-webpack@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
-      '@storybook/core-webpack': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/core-webpack': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       '@types/semver': 7.7.1
       find-up: 7.0.0
@@ -14316,7 +14281,7 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       resolve: 1.22.10
       semver: 7.7.3
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       tsconfig-paths: 4.2.0
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
     optionalDependencies:
@@ -14328,19 +14293,29 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))':
+  '@storybook/preset-react-webpack@9.1.10(esbuild@0.25.11)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
-      debug: 4.4.3
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.2.0
-      micromatch: 4.0.8
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      tslib: 2.8.1
+      '@storybook/core-webpack': 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.102.1(esbuild@0.25.11))
+      '@types/semver': 7.7.1
+      find-up: 7.0.0
+      magic-string: 0.30.19
+      react: 19.2.3
+      react-docgen: 7.1.1
+      react-dom: 19.2.3(react@19.2.3)
+      resolve: 1.22.10
+      semver: 7.7.3
+      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      tsconfig-paths: 4.2.0
+      webpack: 5.102.1(esbuild@0.25.11)
+    optionalDependencies:
       typescript: 5.9.3
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
     transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
       - supports-color
+      - uglify-js
+      - webpack-cli
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))':
     dependencies:
@@ -14356,27 +14331,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.3)(webpack@5.102.1(esbuild@0.25.11))':
     dependencies:
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      debug: 4.4.3
+      endent: 2.1.0
+      find-cache-dir: 3.3.2
+      flat-cache: 3.2.0
+      micromatch: 4.0.8
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      tslib: 2.8.1
+      typescript: 5.9.3
+      webpack: 5.102.1(esbuild@0.25.11)
+    transitivePeerDependencies:
+      - supports-color
 
   '@storybook/react-dom-shim@9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-
-  '@storybook/react@9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      storybook: 9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-    optionalDependencies:
-      typescript: 5.9.3
 
   '@storybook/react@9.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(typescript@5.9.3)':
     dependencies:
@@ -14722,17 +14695,17 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/gen@2.6.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@24.10.4)(typescript@5.9.3)':
+  '@turbo/gen@2.6.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@25.0.2)(typescript@5.9.3)':
     dependencies:
-      '@turbo/workspaces': 2.6.3(@types/node@24.10.4)
+      '@turbo/workspaces': 2.6.3(@types/node@25.0.2)
       commander: 10.0.1
       fs-extra: 10.1.0
-      inquirer: 8.2.7(@types/node@24.10.4)
+      inquirer: 8.2.7(@types/node@25.0.2)
       minimatch: 9.0.5
       node-plop: 0.26.3
       picocolors: 1.0.1
       proxy-agent: 6.5.0
-      ts-node: 10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@24.10.4)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@25.0.2)(typescript@5.9.3)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -14742,14 +14715,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@turbo/workspaces@2.6.3(@types/node@24.10.4)':
+  '@turbo/workspaces@2.6.3(@types/node@25.0.2)':
     dependencies:
       commander: 10.0.1
       execa: 5.1.1
       fast-glob: 3.3.3
       fs-extra: 10.1.0
       gradient-string: 2.0.2
-      inquirer: 8.2.7(@types/node@24.10.4)
+      inquirer: 8.2.7(@types/node@25.0.2)
       js-yaml: 4.1.1
       ora: 4.1.1
       picocolors: 1.0.1
@@ -14792,7 +14765,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 24.10.4
 
   '@types/deep-eql@4.0.2': {}
 
@@ -14819,7 +14792,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.0.2
+      '@types/node': 24.10.4
 
   '@types/hammerjs@2.0.46': {}
 
@@ -14827,7 +14800,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 24.10.1
+      '@types/node': 24.10.4
 
   '@types/inquirer@6.5.0':
     dependencies:
@@ -14864,10 +14837,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@24.10.3':
-    dependencies:
-      undici-types: 7.16.0
-
   '@types/node@24.10.4':
     dependencies:
       undici-types: 7.16.0
@@ -14892,7 +14861,7 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       '@types/scheduler': 0.26.0
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/react@19.2.7':
     dependencies:
@@ -15274,14 +15243,6 @@ snapshots:
       magic-string: 0.30.19
     optionalDependencies:
       vite: 7.1.10(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@3.2.4(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.19
-    optionalDependencies:
-      vite: 7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@3.2.4(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -15694,19 +15655,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      '@babel/core': 7.28.4
-      find-cache-dir: 4.0.0
-      schema-utils: 4.3.3
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@babel/core': 7.28.4
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+  babel-loader@9.2.1(@babel/core@7.28.4)(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      '@babel/core': 7.28.4
+      find-cache-dir: 4.0.0
+      schema-utils: 4.3.3
+      webpack: 5.102.1(esbuild@0.25.11)
 
   babel-plugin-inline-dotenv@1.7.0(dotenv-expand@11.0.7):
     dependencies:
@@ -16185,7 +16146,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.0.2
+      '@types/node': 24.10.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -16196,7 +16157,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.0.2
+      '@types/node': 24.10.4
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -16537,19 +16498,6 @@ snapshots:
     dependencies:
       hyphenate-style-name: 1.1.0
 
-  css-loader@6.11.0(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.6)
-      postcss: 8.5.6
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
-      postcss-modules-scope: 3.2.1(postcss@8.5.6)
-      postcss-modules-values: 4.0.0(postcss@8.5.6)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.3
-    optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   css-loader@6.11.0(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
@@ -16562,6 +16510,19 @@ snapshots:
       semver: 7.7.3
     optionalDependencies:
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+  css-loader@6.11.0(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.6)
+      postcss: 8.5.6
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.6)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.6)
+      postcss-modules-scope: 3.2.1(postcss@8.5.6)
+      postcss-modules-values: 4.0.0(postcss@8.5.6)
+      postcss-value-parser: 4.2.0
+      semver: 7.7.3
+    optionalDependencies:
+      webpack: 5.102.1(esbuild@0.25.11)
 
   css-select@4.3.0:
     dependencies:
@@ -16616,8 +16577,6 @@ snapshots:
       css-tree: 3.1.0
     transitivePeerDependencies:
       - postcss
-
-  csstype@3.1.3: {}
 
   csstype@3.2.3: {}
 
@@ -18143,23 +18102,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.7.3
-      tapable: 2.3.0
-      typescript: 5.9.3
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -18176,6 +18118,23 @@ snapshots:
       tapable: 2.3.0
       typescript: 5.9.3
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.3)(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      cosmiconfig: 7.1.0
+      deepmerge: 4.3.1
+      fs-extra: 10.1.0
+      memfs: 3.5.3
+      minimatch: 3.1.2
+      node-abort-controller: 3.1.1
+      schema-utils: 3.3.0
+      semver: 7.7.3
+      tapable: 2.3.0
+      typescript: 5.9.3
+      webpack: 5.102.1(esbuild@0.25.11)
 
   forwarded@0.2.0: {}
 
@@ -18505,16 +18464,6 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.44.0
 
-  html-webpack-plugin@5.6.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.3.0
-    optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   html-webpack-plugin@5.6.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -18524,6 +18473,16 @@ snapshots:
       tapable: 2.3.0
     optionalDependencies:
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+  html-webpack-plugin@5.6.4(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.3.0
+    optionalDependencies:
+      webpack: 5.102.1(esbuild@0.25.11)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -18688,9 +18647,9 @@ snapshots:
       through: 2.3.8
       wrap-ansi: 7.0.0
 
-  inquirer@8.2.7(@types/node@24.10.4):
+  inquirer@8.2.7(@types/node@25.0.2):
     dependencies:
-      '@inquirer/external-editor': 1.0.3(@types/node@24.10.4)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.0.2)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -18958,7 +18917,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.10.3
+      '@types/node': 24.10.4
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -18968,7 +18927,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.0.2
+      '@types/node': 24.10.4
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -18995,7 +18954,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.10.3
+      '@types/node': 24.10.4
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -19003,7 +18962,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.10.3
+      '@types/node': 24.10.4
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -19020,13 +18979,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.0.2
+      '@types/node': 24.10.4
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.0.2
+      '@types/node': 24.10.4
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -19780,7 +19739,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
@@ -19788,7 +19747,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.7
       '@next/swc-darwin-x64': 15.5.7
@@ -19840,35 +19799,6 @@ snapshots:
       mkdirp: 0.5.6
       resolve: 1.22.11
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      assert: 2.1.0
-      browserify-zlib: 0.2.0
-      buffer: 6.0.3
-      console-browserify: 1.2.0
-      constants-browserify: 1.0.0
-      crypto-browserify: 3.12.1
-      domain-browser: 4.23.0
-      events: 3.3.0
-      filter-obj: 2.0.2
-      https-browserify: 1.0.0
-      os-browserify: 0.3.0
-      path-browserify: 1.0.1
-      process: 0.11.10
-      punycode: 2.3.1
-      querystring-es3: 0.2.1
-      readable-stream: 4.7.0
-      stream-browserify: 3.0.0
-      stream-http: 3.2.0
-      string_decoder: 1.3.0
-      timers-browserify: 2.0.12
-      tty-browserify: 0.0.1
-      type-fest: 2.19.0
-      url: 0.11.4
-      util: 0.12.5
-      vm-browserify: 1.1.2
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   node-polyfill-webpack-plugin@2.0.1(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       assert: 2.1.0
@@ -19897,6 +19827,35 @@ snapshots:
       util: 0.12.5
       vm-browserify: 1.1.2
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      assert: 2.1.0
+      browserify-zlib: 0.2.0
+      buffer: 6.0.3
+      console-browserify: 1.2.0
+      constants-browserify: 1.0.0
+      crypto-browserify: 3.12.1
+      domain-browser: 4.23.0
+      events: 3.3.0
+      filter-obj: 2.0.2
+      https-browserify: 1.0.0
+      os-browserify: 0.3.0
+      path-browserify: 1.0.1
+      process: 0.11.10
+      punycode: 2.3.1
+      querystring-es3: 0.2.1
+      readable-stream: 4.7.0
+      stream-browserify: 3.0.0
+      stream-http: 3.2.0
+      string_decoder: 1.3.0
+      timers-browserify: 2.0.12
+      tty-browserify: 0.0.1
+      type-fest: 2.19.0
+      url: 0.11.4
+      util: 0.12.5
+      vm-browserify: 1.1.2
+      webpack: 5.102.1(esbuild@0.25.11)
 
   node-releases@2.0.23: {}
 
@@ -19927,7 +19886,7 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       react: 19.2.3
     optionalDependencies:
-      next: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   ob1@0.82.5:
     dependencies:
@@ -20299,17 +20258,6 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      cosmiconfig: 9.0.0(typescript@5.9.3)
-      jiti: 2.6.1
-      postcss: 8.5.6
-      semver: 7.7.3
-    optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-    transitivePeerDependencies:
-      - typescript
-
   postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.3)
@@ -20318,6 +20266,17 @@ snapshots:
       semver: 7.7.3
     optionalDependencies:
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+    transitivePeerDependencies:
+      - typescript
+
+  postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      cosmiconfig: 9.0.0(typescript@5.9.3)
+      jiti: 2.6.1
+      postcss: 8.5.6
+      semver: 7.7.3
+    optionalDependencies:
+      webpack: 5.102.1(esbuild@0.25.11)
     transitivePeerDependencies:
       - typescript
 
@@ -21161,17 +21120,17 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.5(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      neo-async: 2.6.2
-    optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   sass-loader@16.0.5(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+  sass-loader@16.0.5(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      neo-async: 2.6.2
+    optionalDependencies:
+      webpack: 5.102.1(esbuild@0.25.11)
 
   sax@1.4.1: {}
 
@@ -21514,30 +21473,6 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@testing-library/jest-dom': 6.9.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/spy': 3.2.4
-      better-opn: 3.0.2
-      esbuild: 0.25.11
-      esbuild-register: 3.6.0(esbuild@0.25.11)
-      recast: 0.23.11
-      semver: 7.7.3
-      ws: 8.18.3
-    optionalDependencies:
-      prettier: 3.7.4
-    transitivePeerDependencies:
-      - '@testing-library/dom'
-      - bufferutil
-      - msw
-      - supports-color
-      - utf-8-validate
-      - vite
-
   storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@storybook/global': 5.0.0
@@ -21698,20 +21633,20 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  style-loader@3.3.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   style-loader@3.3.4(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
+  style-loader@3.3.4(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      webpack: 5.102.1(esbuild@0.25.11)
+
+  styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
     optionalDependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.28.4
 
   styled-jsx@5.1.7(@babel/core@7.28.4)(react@19.2.3):
     dependencies:
@@ -21827,18 +21762,6 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.44.0
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-    optionalDependencies:
-      '@swc/core': 1.13.5(@swc/helpers@0.5.17)
-      esbuild: 0.25.11
-
   terser-webpack-plugin@5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -21849,6 +21772,17 @@ snapshots:
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
     optionalDependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.17)
+
+  terser-webpack-plugin@5.3.14(esbuild@0.25.11)(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.44.0
+      webpack: 5.102.1(esbuild@0.25.11)
+    optionalDependencies:
+      esbuild: 0.25.11
 
   terser@5.44.0:
     dependencies:
@@ -21965,14 +21899,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@24.10.4)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@25.0.2)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 24.10.4
+      '@types/node': 25.0.2
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -22362,24 +22296,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.1.10(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.52.4
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 24.10.4
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.30.2
-      terser: 5.44.0
-      tsx: 4.21.0
-      yaml: 2.8.2
-    optional: true
-
   vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
@@ -22469,16 +22385,6 @@ snapshots:
 
   webidl-conversions@8.0.0: {}
 
-  webpack-dev-middleware@6.1.3(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)
-
   webpack-dev-middleware@6.1.3(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))):
     dependencies:
       colorette: 2.0.20
@@ -22488,6 +22394,16 @@ snapshots:
       schema-utils: 4.3.3
     optionalDependencies:
       webpack: 5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))
+
+  webpack-dev-middleware@6.1.3(webpack@5.102.1(esbuild@0.25.11)):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 3.5.3
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.3.3
+    optionalDependencies:
+      webpack: 5.102.1(esbuild@0.25.11)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -22531,7 +22447,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11):
+  webpack@5.102.1(esbuild@0.25.11):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -22555,7 +22471,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.14(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17))(esbuild@0.25.11))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.11)(webpack@5.102.1(esbuild@0.25.11))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/Q2-53
https://jira-knockdog.atlassian.net/browse/Q2-39
아이템 시트에서 하단 영역이 잘리는 문제를 해결합니다.
safe area insets를 css 변수로 주입하도록 추가합니다.
vaul/use-snap-point snap 해석 방식을 확장합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### safe-area inset 관리 방식 변경
- [WebView가 로드되기전에 safe-area-inset를 전역 객체와 CSS 변수로 주입](https://github.com/PetCampus-Inc/daeng_v2_front/commit/22e93a76adec2c0949f3eeac10245ee707dfaf80)되도록 변경함
  - 기존 hook 방식은 캐싱되고 있으나 다른 탭간엔 공유가 안되므로 매번 브릿지 통신을 통해서 값을 받아오고 있었음 → 그래서 통신 후에 반영되므로 적용되는데 약간의 지연 발생함
  - useSafeAreaInsets 훅은 그대로 유지하되 deprecated 처리

#### `vaul/use-snap-point` snap 확장(동적 스냅)
- 스냅포인트 DSL 확장(%, 함수, content min/max)과 수평 축 대응
- drawer ref가 아직 없는 초기 프레임에서도 안정적으로 관측되도록 rAF 기반 관측 시작 로직 추가
- content 스냅 진입 시 즉시 1회 측정해 초기 스냅 계산 오차를 줄임

#### 상·하단 바 높이 변수화
- `--top-bar-height`, `--bottom-bar-height` CSS 변수 및 JS 상수 추가

#### KindergartenItemSheet 변경건
- 동적 스냅으로 전환해 콘텐츠 높이에 맞춰 스냅 포인트 계산
- `container` 준비 전 렌더를 막아 window 기준 → container 기준 점프 제거
- 초기 오픈 위치가 흔들리지 않도록 `--initial-transform` 기준 적용
- `useSheetDragProgress` 드래그 진행 계산 로직에 enabled 토글 + 계산로직 안정화(값이 0이 될때 스킵되도록)
- 하단 액션바를 카드/상세 뷰와 분리

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
