### PR TITLE
[fix] 사진 접근 권한 오류 처리 개선 및 알림 다이얼로그 추가

### DIFF
--- a/apps/knockdog/src/shared/ui/photo-uploader/PhotoUploader.tsx
+++ b/apps/knockdog/src/shared/ui/photo-uploader/PhotoUploader.tsx
@@ -1,11 +1,23 @@
 import { useState, useEffect } from 'react';
-import { ActionButton, Icon } from '@knockdog/ui';
+import {
+  ActionButton,
+  Icon,
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@knockdog/ui';
 import { MiniPhotoBox } from './MiniPhotoBox';
 import { FullImageSheet } from './FullImageSheet';
 import { overlay } from 'overlay-kit';
 import { useImagePicker, type WebImageAsset } from '@shared/lib/media';
 import { toast } from '@shared/ui/toast';
 import { BottomSheet } from '@shared/ui/bottom-sheet';
+import { openSystemSetting } from '@shared/lib/bridge/openSystemSetting';
 
 interface PhotoUploaderProps {
   maxCount?: number;
@@ -40,16 +52,36 @@ function PhotoUploader({ maxCount = 3, quality = 0.8, defaultValue, onChange }: 
         onChange?.(newAssets);
       }
     } catch (error: unknown) {
-      toast({
-        title: error instanceof Error ? error.message : String(error),
-        position: 'bottom-above-nav',
-      });
+      if ((error as string) === 'NO_PERMISSION_LIBRARY' || (error as string) === 'NO_PERMISSION_CAMERA') {
+        overlay.open(({ isOpen, close }) => (
+          <AlertDialog open={isOpen} onOpenChange={close}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>사진 접근 권한이 필요해요</AlertDialogTitle>
+                <AlertDialogDescription>
+                  사용 중인 기기에서 사진 접근 권한을 <br />
+                  '허용'으로 설정해 주세요.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>나중에 하기</AlertDialogCancel>
+                <AlertDialogAction onClick={openSystemSetting}>설정하기</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        ));
+      } else {
+        toast({
+          title: error instanceof Error ? error.message : String(error),
+          position: 'bottom-above-nav',
+        });
+      }
     }
   };
 
   const openSourceSelectSheet = () => {
     overlay.open(({ isOpen, close }) => (
-      <BottomSheet.Root open={isOpen} onOpenChange={close}>
+      <BottomSheet.Root open={isOpen} onOpenChange={close} modal={false}>
         <BottomSheet.Overlay className='z-overlay' />
         <BottomSheet.Body className='z-modal'>
           <BottomSheet.Handle />

--- a/apps/mobile/bridges/handlers/register-image-picker.ts
+++ b/apps/mobile/bridges/handlers/register-image-picker.ts
@@ -81,7 +81,7 @@ export function registerImagePickerHandlers(options: ImagePickerOptions) {
       if (permissionResult.status !== 'granted') {
         sendEvent('media.pickImage.cancel', {
           requestId,
-          reason: source === 'library' ? '사진 접근 권한이 필요합니다.' : '카메라 접근 권한이 필요합니다.',
+          reason: source === 'library' ? 'NO_PERMISSION_LIBRARY' : 'NO_PERMISSION_CAMERA',
         });
         return;
       }


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

- PhotoUploader 컴포넌트에서 사진 접근 권한 오류 발생 시 알림 다이얼로그를 통해 사용자에게 권한 요청 안내
- 권한 오류 메시지를 상수로 변경하여 코드 가독성 향상
- BottomSheet의 modal 속성을 false로 설정하여 비모달로 변경