### PR TITLE
fix: 비교 거리 기준점 타입에서 기타 옵션 비활성화

### DIFF
--- a/apps/knockdog/src/entities/compare/model/constants/compare.ts
+++ b/apps/knockdog/src/entities/compare/model/constants/compare.ts
@@ -35,7 +35,7 @@ const TRANSPORTATION_ICON_MAP: Record<string, IconType> = {
 const REFERENCE_POINT_TYPE = {
   HOME: '집',
   WORK: '직장',
-  OTHER: '기타',
+  // OTHER: '기타',
 } as const;
 
 const DAY_OF_WEEK_SHORT = {


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교 거리 기준점 타입에서 기타 옵션 비활성화(주석 처리)
- 관련 jira 티켓: https://jira-knockdog.atlassian.net/browse/Q2-64