### PR TITLE
ci: build 단계에서 turbo cache 캐시 사용하도록 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,11 @@ jobs:
       - name: Run ${{ matrix.command }}
         run: |
           if [ "${{ matrix.command }}" = "build" ]; then
-            COMMAND="pnpm --filter=knockdog... build"
+            COMMAND="pnpm turbo run build --filter=knockdog..."
           elif [ "${{ matrix.command }}" = "type-check" ]; then
-            COMMAND="pnpm --filter=knockdog type-check"
+            COMMAND="pnpm turbo run type-check --filter=knockdog"
           else
-            COMMAND="pnpm --filter=knockdog ${{ matrix.command }}"
+            COMMAND="pnpm turbo run ${{ matrix.command }} --filter=knockdog"
           fi
 
           if eval "$COMMAND"; then
@@ -81,6 +81,7 @@ jobs:
             exit 1
           fi
         env:
+          TURBO_CACHE_DIR: .turbo
           NEXT_TELEMETRY_DISABLED: 1
           # CI 빌드용 환경변수
           NEXT_PUBLIC_API_BASE_URL: 'https://example.com'


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

CI 빌드 단계에서 Turbo 캐시 효과가 없었던 문제를 해결합니다

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

1. Turbo 엔진 명시적 사용: pnpm --filter... 대신 pnpm turbo run ...을 사용하도록 수정했습니다.
  - Turbo의 핵심인 증분 빌드(Incremental Build)와 입출력 캐싱 기능을 활성화하기 위함입니다.
2. 캐시 경로 정렬: TURBO_CACHE_DIR: .turbo 환경 변수를 추가했습니다.
  - Turbo가 생성하는 캐시 데이터를 GitHub Actions의 actions/cache가 추적 중인 .turbo 디렉토리에 저장하도록 강제했습니다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
