### PR TITLE
[fix] 이미지 선택 실패 시 알림 처리 개선

### DIFF
--- a/apps/knockdog/src/features/dog-profile/ui/ProfileImageUploader.tsx
+++ b/apps/knockdog/src/features/dog-profile/ui/ProfileImageUploader.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { Avatar, AvatarImage, AvatarFallback, Icon } from '@knockdog/ui';
 import { useImagePicker, type WebImageAsset } from '@shared/lib/media';
+import { toast } from '@shared/ui/toast';
 
 interface ProfileImageUploaderProps {
   profileImage?: string;
@@ -34,6 +35,17 @@ function ProfileImageUploader({ profileImage, onImageSelect }: ProfileImageUploa
       }
     } catch (error) {
       console.error('이미지 선택 실패:', error);
+      if ((error as string) === 'NO_PERMISSION_LIBRARY') {
+        toast({
+          title: '사진 접근 권한이 필요합니다.',
+          position: 'bottom-above-nav',
+        });
+      } else {
+        toast({
+          title: error instanceof Error ? error.message : String(error),
+          position: 'bottom-above-nav',
+        });
+      }
     }
   };
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

- 사진 접근 권한 오류에 대한 사용자 알림 추가
- 기타 오류 발생 시 적절한 메시지로 알림 처리
