### PR TITLE
config: ESLint 공통 설정 정리 및 패키지 parser 의존 제거

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,11 +8,33 @@ on:
       - packages/ui/src/**
 
 jobs:
-  chromatic:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      storybook: ${{ steps.changes.outputs.storybook }}
 
     # Dependabot 봇인 경우 배포 스킵
     if: github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Storybook changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            storybook:
+              - 'apps/storybook/**'
+              - 'packages/ui/src/**'
+
+  chromatic:
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.storybook == 'true'
     permissions:
       pull-requests: write
       contents: read
@@ -28,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile # 의존성 버전 불일치 허용
 
-      - name: Build Storybook
+      - name: Build Storybook dependencies
         run: pnpm build --filter=storybook...
 
       - name: Run Chromatic

--- a/apps/storybook/eslint.config.mjs
+++ b/apps/storybook/eslint.config.mjs
@@ -1,7 +1,11 @@
 import { config } from '@knockdog/eslint-config/react-internal';
 import { defineConfig } from 'eslint/config';
-import tsParser from '@typescript-eslint/parser';
 import storybook from 'eslint-plugin-storybook';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /** @type {import("eslint").Linter.Config} */
 export default defineConfig([
@@ -13,9 +17,9 @@ export default defineConfig([
   {
     files: ['src/**/*.ts', 'src/**/*.tsx', 'svg.d.ts'],
     languageOptions: {
-      parser: tsParser,
       parserOptions: {
         projectService: true,
+        tsconfigRootDir: __dirname,
       },
     },
   },

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -21,6 +21,7 @@
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-only-warn": "^1.1.0",
     "eslint-plugin-prettier": "^5.5.4",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-turbo": "^2.6.3",
     "globals": "^16.5.0",

--- a/packages/config-eslint/react-internal.js
+++ b/packages/config-eslint/react-internal.js
@@ -1,17 +1,13 @@
-import js from '@eslint/js';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import neostandard from 'neostandard';
-import tseslint from 'typescript-eslint';
+import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
 import globals from 'globals';
 import { config as baseConfig } from './base.js';
 
 export const config = [
   ...baseConfig,
-  js.configs.recommended,
   ...neostandard({ noStyle: true }),
-  eslintConfigPrettier,
-  ...tseslint.configs.recommended,
   {
     // eslint-plugin-react
     languageOptions: {
@@ -23,6 +19,7 @@ export const config = [
   },
   {
     plugins: {
+      react: pluginReact,
       'react-hooks': pluginReactHooks,
     },
     settings: { react: { version: 'detect' } },
@@ -32,4 +29,5 @@ export const config = [
       'react/react-in-jsx-scope': 'off',
     },
   },
+  eslintConfigPrettier,
 ];

--- a/packages/icons/eslint.config.mjs
+++ b/packages/icons/eslint.config.mjs
@@ -1,5 +1,4 @@
 import { config } from '@knockdog/eslint-config/react-internal';
-import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -13,7 +12,6 @@ export default [
     files: ['src/**/*.ts', 'src/**/*.tsx'],
     ignores: ['scripts/**/*.js'],
     languageOptions: {
-      parser: tsParser,
       parserOptions: {
         project: './tsconfig.json',
         tsconfigRootDir: __dirname,

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -10,11 +10,12 @@
     "type-check": "tsc --noEmit",
     "extract-icons": "node scripts/extract-figma-icon/index.js && pnpm fix-all"
   },
-  "dependencies": {},
+  "dependencies": {
+    "react": "^19.2.3"
+  },
   "devDependencies": {
     "@knockdog/eslint-config": "workspace:*",
     "@knockdog/typescript-config": "workspace:*",
-    "@typescript-eslint/parser": "^8.49.0",
     "dotenv": "^17.2.1"
   },
   "exports": {

--- a/packages/naver-map/eslint.config.mjs
+++ b/packages/naver-map/eslint.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'eslint/config';
 import { config } from '@knockdog/eslint-config/react-internal';
-import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -16,7 +15,6 @@ export default defineConfig([
   {
     files: ['src/**/*.ts', 'src/**/*.tsx'],
     languageOptions: {
-      parser: tsParser,
       parserOptions: {
         projectService: true,
         tsconfigRootDir: __dirname,

--- a/packages/react-naver-map/eslint.config.mjs
+++ b/packages/react-naver-map/eslint.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'eslint/config';
 import { config } from '@knockdog/eslint-config/react-internal';
-import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -16,7 +15,6 @@ export default defineConfig([
   {
     files: ['src/**/*.ts', 'src/**/*.tsx'],
     languageOptions: {
-      parser: tsParser,
       parserOptions: {
         projectService: true,
         tsconfigRootDir: __dirname,

--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from 'eslint/config';
 import { config } from '@knockdog/eslint-config/react-internal';
-import tsParser from '@typescript-eslint/parser';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -16,7 +15,6 @@ export default defineConfig([
   {
     files: ['src/**/*.ts', 'src/**/*.tsx', 'svg.d.ts'],
     languageOptions: {
-      parser: tsParser,
       parserOptions: {
         projectService: true,
         tsconfigRootDir: __dirname,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,7 +127,7 @@ importers:
         version: 2.4.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next:
         specifier: ^15.5.9
-        version: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nuqs:
         specifier: ^2.7.3
         version: 2.8.1(next@15.5.9(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -400,7 +400,7 @@ importers:
         version: 9.1.10(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@storybook/nextjs':
         specifier: 9.1.10
-        version: 9.1.10(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))
+        version: 9.1.10(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))
       '@tailwindcss/postcss':
         specifier: ^4.1.18
         version: 4.1.18
@@ -496,6 +496,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.4
         version: 5.5.4(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))(prettier@3.7.4)
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.1(jiti@2.6.1))
@@ -824,6 +827,10 @@ importers:
         version: 5.2.2
 
   packages/icons:
+    dependencies:
+      react:
+        specifier: ^19.2.3
+        version: 19.2.3
     devDependencies:
       '@knockdog/eslint-config':
         specifier: workspace:*
@@ -831,9 +838,6 @@ importers:
       '@knockdog/typescript-config':
         specifier: workspace:*
         version: link:../config-typescript
-      '@typescript-eslint/parser':
-        specifier: ^8.49.0
-        version: 8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       dotenv:
         specifier: ^17.2.1
         version: 17.2.3
@@ -979,7 +983,7 @@ importers:
         version: link:../config-typescript
       '@storybook/nextjs':
         specifier: 9.1.10
-        version: 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
+        version: 9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       '@svgr/cli':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.9.3)
@@ -14157,7 +14161,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/nextjs@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))':
+  '@storybook/nextjs@9.1.10(@swc/core@1.13.5(@swc/helpers@0.5.17))(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
@@ -14181,7 +14185,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
       postcss: 8.5.6
       postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(@swc/core@1.13.5(@swc/helpers@0.5.17)))
@@ -14217,7 +14221,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@storybook/nextjs@9.1.10(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))':
+  '@storybook/nextjs@9.1.10(esbuild@0.25.11)(next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(vite@7.1.10(@types/node@25.0.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(type-fest@2.19.0)(typescript@5.9.3)(webpack-hot-middleware@2.26.1)(webpack@5.102.1(esbuild@0.25.11))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
@@ -14241,7 +14245,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.102.1(esbuild@0.25.11))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.102.1(esbuild@0.25.11))
       postcss: 8.5.6
       postcss-loader: 8.2.0(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1(esbuild@0.25.11))
@@ -14958,18 +14962,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.49.0
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/project-service@8.46.1(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.1(typescript@5.8.3)
@@ -14997,15 +14989,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.49.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.49.0
-      debug: 4.4.3
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@8.46.1':
     dependencies:
       '@typescript-eslint/types': 8.46.1
@@ -15027,10 +15010,6 @@ snapshots:
   '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.8.3)':
     dependencies:
       typescript: 5.8.3
-
-  '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
 
   '@typescript-eslint/type-utils@8.46.1(eslint@9.39.1(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
@@ -15104,21 +15083,6 @@ snapshots:
       tinyglobby: 0.2.15
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@8.49.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/visitor-keys': 8.49.0
-      debug: 4.4.3
-      minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19752,7 +19716,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 15.5.9
       '@swc/helpers': 0.5.15
@@ -19760,7 +19724,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.7
       '@next/swc-darwin-x64': 15.5.7
@@ -19899,7 +19863,7 @@ snapshots:
       '@standard-schema/spec': 1.0.0
       react: 19.2.3
     optionalDependencies:
-      next: 15.5.9(@babel/core@7.28.4)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 15.5.9(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   ob1@0.82.5:
     dependencies:
@@ -20516,7 +20480,7 @@ snapshots:
       '@types/doctrine': 0.0.9
       '@types/resolve': 1.20.6
       doctrine: 3.0.0
-      resolve: 1.22.10
+      resolve: 1.22.11
       strip-indent: 4.1.1
     transitivePeerDependencies:
       - supports-color
@@ -21654,12 +21618,12 @@ snapshots:
     dependencies:
       webpack: 5.102.1(esbuild@0.25.11)
 
-  styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
     optionalDependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.28.5
 
   styled-jsx@5.1.7(@babel/core@7.28.4)(react@19.2.3):
     dependencies:


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)
## 작업 개요

- react-internal ESLint 설정에서 중복을 제거하고 Prettier 적용 순서를 정리했습니다.
- 타입스크립트 파서 import를 패키지별로 두지 않고 공통 설정에 의존하도록 정리했습니다.
- icons 패키지에 React 의존성을 추가하고 lockfile을 동기화했습니다.

## 작업 내용
#### eslint config 관련
- `packages/config-eslint/react-internal.js`
  - `eslint-plugin-react` 등록
  - 중복 설정 제거, Prettier를 마지막에 적용
- `packages/config-eslint/package.json`
  - `eslint-plugin-react` 의존성 추가
- 패키지별 `eslint.config.mjs`
  - `@typescript-eslint/parser` 직접 import 제거
  - `parserOptions.projectService` 기반의 타입 설정 유지
  - storybook에 `tsconfigRootDir` 추가
- `packages/icons/package.json`
  - React 의존성 추가
#### ci 관련
- `chromatic.yml` 스토리북 파일 변경  없을 시 배포 job 스킵하도록 변경

## 논의할 점

- 없음

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
