### PR TITLE
feat: 검색 api 조회시 size 30 으로 수정

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/api/searchQueries.ts
+++ b/apps/knockdog/src/features/kindergarten-map/api/searchQueries.ts
@@ -62,7 +62,7 @@ export const searchQueries = {
       queryFn: ({ pageParam = 1 }) =>
         getKindergartenSearchList({
           page: pageParam,
-          size: 10,
+          size: 30,
           refPoint: params.state.refPoint!,
           zoomLevel: params.state.zoom,
           filters: params.state.filters.length > 0 ? params.state.filters : undefined,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/Q2-35
검색(map-view) api 조회시 size 30으로 변경하여 더 많은 업체가 보이도록 수정합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->


## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
