### PR TITLE
fix: 딥링크 진입 시 네비게이션 스택에 홈 추가하여 뒤로가기 동작 개선

### DIFF
--- a/apps/mobile/components/navigation/model/useLinking.ts
+++ b/apps/mobile/components/navigation/model/useLinking.ts
@@ -44,7 +44,11 @@ function useLinking(): LinkingOptions<RootStackParamList> {
         const fullUrl = path.startsWith('http') ? path : `${WEBVIEW_URL}/${normalizedPath}`;
 
         return {
-          routes: [{ name: 'Stack', params: { path: fullUrl } }],
+          routes: [
+            // 홈(Tabs)을 스택에 먼저 추가하여 뒤로가기 시 홈으로 돌아갈 수 있게 함
+            { name: 'Tabs', state: { routes: [{ name: 'Explore' }] } },
+            { name: 'Stack', params: { path: fullUrl } },
+          ],
         };
       },
     }),


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 딥링크 진입 시 네비게이션 스택에 홈을 먼저 추가하여 뒤로가기 시 홈으로 돌아갈 수 있게 함