### PR TITLE
fix: 보관함 유치원 썸네일 기본 이미지 변경

### DIFF
--- a/apps/knockdog/src/entities/compare/ui/CircleAvatar.tsx
+++ b/apps/knockdog/src/entities/compare/ui/CircleAvatar.tsx
@@ -15,8 +15,10 @@ export function CircleAvatar({
     <Avatar style={{ width: size, height: size }} className={className}>
       <AvatarImage src={src} alt={alt} className='object-cover' />
       <AvatarFallback>
-        <div className='flex h-full w-full items-center justify-center bg-primitive-neutral-100'>
-          <Icon icon='Kindergarten' className={`text-fill-neutral-100 w-[${size/2}px] h-[${size/2}px]`} />
+        <div className='bg-primitive-neutral-100 flex h-full w-full items-center justify-center'>
+          <div style={{ width: size / 2, height: size / 2 }}>
+            <Icon icon='Kindergarten' className='text-fill-neutral-100 h-full w-full' />
+          </div>
         </div>
       </AvatarFallback>
     </Avatar>

--- a/apps/knockdog/src/entities/compare/ui/CircleAvatar.tsx
+++ b/apps/knockdog/src/entities/compare/ui/CircleAvatar.tsx
@@ -1,5 +1,4 @@
-import { Avatar, AvatarFallback, AvatarImage } from '@knockdog/ui';
-import Image from 'next/image';
+import { Avatar, AvatarFallback, AvatarImage, Icon } from '@knockdog/ui';
 
 export function CircleAvatar({
   size = 80,
@@ -16,7 +15,9 @@ export function CircleAvatar({
     <Avatar style={{ width: size, height: size }} className={className}>
       <AvatarImage src={src} alt={alt} className='object-cover' />
       <AvatarFallback>
-        <Image src='/images/img_default_image.png' alt='default' width={size} height={size} className='object-cover' />
+        <div className='flex h-full w-full items-center justify-center bg-primitive-neutral-100'>
+          <Icon icon='Kindergarten' className={`text-fill-neutral-100 w-[${size/2}px] h-[${size/2}px]`} />
+        </div>
       </AvatarFallback>
     </Avatar>
   );

--- a/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
+++ b/apps/knockdog/src/features/bookmarked-list/ui/BookmarkedListItem.tsx
@@ -36,7 +36,9 @@ function BookmarkedListItem({
         <Avatar style={{ width: 90, height: 90 }} className='shrink-0 rounded-lg'>
           <AvatarImage src={s3ToUrl(kindergarten.thumbnailS3Key)} alt={kindergarten.name} className='object-cover' />
           <AvatarFallback>
-            <Image src='/images/img_default_image.png' alt='default' width={90} height={90} className='object-cover' />
+            <div className='flex h-full w-full items-center justify-center bg-primitive-neutral-100'>
+              <Icon icon='Kindergarten' className='text-fill-neutral-100 w-[45px] h-[45px]' />
+            </div>
           </AvatarFallback>
         </Avatar>
 

--- a/apps/knockdog/src/features/compare/ui/ComparisonHistoryCard.tsx
+++ b/apps/knockdog/src/features/compare/ui/ComparisonHistoryCard.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import Image from 'next/image';
-import { KindergartenShortInfo, s3ToUrl, CTAG_MAP } from '@entities/compare';
-import { Icon } from '@knockdog/ui';
+import { Avatar, AvatarFallback, AvatarImage, Icon } from '@knockdog/ui';
 import { useDeleteComparisonHistoryMutation } from '../api/useDeleteComparisonHistoryMutation';
+import { KindergartenShortInfo, s3ToUrl, CTAG_MAP } from '@entities/compare';
 import { useStackNavigation } from '@shared/lib/bridge';
 
 interface ComparisonHistoryCardProps {
@@ -49,24 +48,34 @@ function ComparisonHistoryCard({ id, kindergartens, className = '' }: Comparison
       </button>
       <div className='flex flex-col gap-3'>
         <div className='flex items-center gap-2'>
-          <div className='aspect-[4/3] w-full overflow-hidden rounded-lg'>
-            <Image
-              className='h-full w-full object-cover'
-              src={s3ToUrl(left.thumbnailS3Key) || '/images/img_default_image.png'}
-              alt={`${left.name} 이미지`}
-              width={160}
-              height={120}
-            />
+          <div className='aspect-4/3 flex-1'>
+            <Avatar className='h-full w-full rounded-lg'>
+              <AvatarImage
+                className='object-cover'
+                src={s3ToUrl(left.thumbnailS3Key)}
+                alt={`${left.name} 이미지`}
+              />
+              <AvatarFallback>
+                <div className='flex h-full w-full items-center justify-center bg-primitive-neutral-100'>
+                  <Icon icon='Kindergarten' className='text-fill-neutral-100 h-15 w-15' />
+                </div>
+              </AvatarFallback>
+            </Avatar>
           </div>
           <span className='h3-extrabold shrink-0'>:</span>
-          <div className='aspect-[4/3] w-full overflow-hidden rounded-lg'>
-            <Image
-              className='h-full w-full object-cover'
-              src={s3ToUrl(right.thumbnailS3Key) || '/images/img_default_image.png'}
-              alt={`${right.name} 이미지`}
-              width={160}
-              height={120}
-            />
+          <div className='aspect-4/3 flex-1'>
+            <Avatar className='h-full w-full rounded-lg'>
+              <AvatarImage
+                className='object-cover'
+                src={s3ToUrl(right.thumbnailS3Key)}
+                alt={`${right.name} 이미지`}
+              />
+              <AvatarFallback>
+                <div className='flex h-full w-full items-center justify-center bg-primitive-neutral-100'>
+                  <Icon icon='Kindergarten' className='text-fill-neutral-100 h-15 w-15' />
+                </div>
+              </AvatarFallback>
+            </Avatar>
           </div>
         </div>
         <div className='flex gap-3'>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교결과 CircleAvatar fallback 이미지 변경
- 보관함 유치원 썸네일 fallback 이미지 변경
- 비교 기록 유치원 썸네일 Next Image에서 Avatar로 변경 및 fallback 적용