### PR TITLE
fix: Vaul 스냅 흔들림 완화 + Detail View 드래그 안정화

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/model/useViewportProgress.ts
+++ b/apps/knockdog/src/features/kindergarten-list/model/useViewportProgress.ts
@@ -37,7 +37,6 @@ const useSheetDragProgress = ({
     let lastProgress = -1;
     const threshold = 0.005; // 0.5%
     const snapEpsilon = 0.01; // 스냅 완료 시 0/1로 정렬
-
     const calculateProgress = () => {
       if (viewRef.current) {
         const rect = viewRef.current.getBoundingClientRect();

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { type ComponentProps, useCallback, useMemo, useRef, useState } from 'react';
-import { BottomSheet } from '@shared/ui/bottom-sheet';
 import { cn } from '@knockdog/ui/lib';
 import { useTransform } from 'framer-motion';
 import { useSheetDragProgress } from '../model/useViewportProgress';
-import { isNativeWebView, useSafeAreaInsets } from '@shared/lib';
-import { TOP_BAR_HEIGHT } from '@shared/constants';
-import type { KindergartenListItem } from '@entities/kindergarten';
 import { FloatingPortal } from '@floating-ui/react';
 import { KindergartenItemSheetContent } from './KindergartenItemSheetContent';
 import { KindergartenItemSheetHeader } from './KindergartenItemSheetHeader';
 import { useKindergartenItemSheetActions } from '../model/useKindergartenItemSheetActions';
 import { useKindergartenItemSheetData } from '../model/useKindergartenItemSheetData';
+import type { KindergartenListItem } from '@entities/kindergarten';
+import { BottomSheet } from '@shared/ui/bottom-sheet';
+import { isNativeWebView, useSafeAreaInsets } from '@shared/lib';
+import { TOP_BAR_HEIGHT } from '@shared/constants';
 
 const MIN_SNAP_POINT_OFFSET = 328;
 

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheetContent.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheetContent.tsx
@@ -2,6 +2,7 @@ import { type ComponentProps } from 'react';
 import { BottomSheet } from '@shared/ui/bottom-sheet';
 import { cn } from '@knockdog/ui/lib';
 import { motion, type MotionValue } from 'framer-motion';
+import { RemoveScroll } from 'react-remove-scroll';
 import { LoadingSpinner } from '@shared/ui/loading-spinner';
 import type { KindergartenMain } from '@entities/kindergarten';
 import { KindergartenCard } from './KindergartenCard';
@@ -64,19 +65,21 @@ export function KindergartenItemSheetContent({
         <KindergartenCard {...displayData} onBookmarkClick={onBookmarkClick} onPhoneCall={onPhoneCall} />
       </motion.div>
 
-      <motion.div
-        className={cn(
-          'pointer-events-none h-full bg-white',
-          activeSnapPoint === 1 ? 'pointer-events-auto relative w-full' : 'absolute inset-0'
-        )}
-        style={{
-          opacity: hiddenOpacity,
-          y: detailY,
-          scale: scaleUp,
-        }}
-      >
-        <KindergartenDetail {...displayData} onBookmarkClick={onBookmarkClick} onPhoneCall={onPhoneCall} />
-      </motion.div>
+      <RemoveScroll forwardProps noIsolation enabled={activeSnapPoint === 1}>
+        <motion.div
+          className={cn(
+            'pointer-events-none h-full bg-white',
+            activeSnapPoint === 1 ? 'pointer-events-auto relative w-full' : 'absolute inset-0'
+          )}
+          style={{
+            opacity: hiddenOpacity,
+            y: detailY,
+            scale: scaleUp,
+          }}
+        >
+          <KindergartenDetail {...displayData} onBookmarkClick={onBookmarkClick} onPhoneCall={onPhoneCall} />
+        </motion.div>
+      </RemoveScroll>
     </>
   );
 }

--- a/packages/headless-ui/vaul/src/index.tsx
+++ b/packages/headless-ui/vaul/src/index.tsx
@@ -212,12 +212,16 @@ export function Root({
   const [hasBeenOpened, setHasBeenOpened] = React.useState<boolean>(false);
   const [isDragging, setIsDragging] = React.useState<boolean>(false);
   const [justReleased, setJustReleased] = React.useState<boolean>(false);
+  // Tracks "real" drag (movement beyond threshold). Keep separate from isDragging,
+  // which is set on pointer down for legacy UX/scroll/lock behaviors.
+  const [isDragActive, setIsDragActive] = React.useState<boolean>(false);
   const overlayRef = React.useRef<HTMLDivElement>(null);
   const openTime = React.useRef<Date | null>(null);
   const dragStartTime = React.useRef<Date | null>(null);
   const dragEndTime = React.useRef<Date | null>(null);
   const lastTimeDragPrevented = React.useRef<Date | null>(null);
   const isAllowedToDrag = React.useRef<boolean>(false);
+  const isPointerDown = React.useRef<boolean>(false);
   const nestedOpenChangeTimer = React.useRef<NodeJS.Timeout | null>(null);
   const pointerStart = React.useRef(0);
   const keyboardIsOpen = React.useRef(false);
@@ -255,7 +259,7 @@ export function Root({
     snapToSequentialPoint,
     onSnapPointsResolved,
     isOpen,
-    isDragging,
+    isDragging: isDragActive,
     shouldAnimate: shouldAnimate.current,
   });
   usePreventScroll({
@@ -282,8 +286,10 @@ export function Root({
 
     drawerHeightRef.current = drawerRef.current?.getBoundingClientRect().height || 0;
     drawerWidthRef.current = drawerRef.current?.getBoundingClientRect().width || 0;
+    isPointerDown.current = true;
     setIsDragging(true);
     dragStartTime.current = new Date();
+    setIsDragActive(false);
 
     // iOS doesn't trigger mouseUp after scrolling so we need to listen to touched in order to disallow dragging
     if (isIOS()) {
@@ -376,111 +382,116 @@ export function Root({
       return;
     }
 
+    if (!isPointerDown.current) return;
+
     // We need to know how much of the drawer has been dragged in percentages so that we can transform background accordingly
-    if (isDragging) {
-      const directionMultiplier = direction === 'bottom' || direction === 'right' ? 1 : -1;
-      const draggedDistance =
-        (pointerStart.current - (isVertical(direction) ? event.pageY : event.pageX)) * directionMultiplier;
-      const isDraggingInDirection = draggedDistance > 0;
+    const directionMultiplier = direction === 'bottom' || direction === 'right' ? 1 : -1;
+    const draggedDistance =
+      (pointerStart.current - (isVertical(direction) ? event.pageY : event.pageX)) * directionMultiplier;
+    const isDraggingInDirection = draggedDistance > 0;
 
-      // Pre condition for disallowing dragging in the close direction.
-      const noCloseSnapPointsPreCondition = snapPoints && !dismissible && !isDraggingInDirection;
+    // Pre condition for disallowing dragging in the close direction.
+    const noCloseSnapPointsPreCondition = snapPoints && !dismissible && !isDraggingInDirection;
 
-      // Disallow dragging down to close when first snap point is the active one and dismissible prop is set to false.
-      if (noCloseSnapPointsPreCondition && activeSnapPointIndex === 0) return;
+    // Disallow dragging down to close when first snap point is the active one and dismissible prop is set to false.
+    if (noCloseSnapPointsPreCondition && activeSnapPointIndex === 0) return;
 
-      // We need to capture last time when drag with scroll was triggered and have a timeout between
-      const absDraggedDistance = Math.abs(draggedDistance);
-      const wrapper = document.querySelector('[data-vaul-drawer-wrapper]');
-      const drawerDimension =
-        direction === 'bottom' || direction === 'top' ? drawerHeightRef.current : drawerWidthRef.current;
+    // We need to capture last time when drag with scroll was triggered and have a timeout between
+    const absDraggedDistance = Math.abs(draggedDistance);
+    const wrapper = document.querySelector('[data-vaul-drawer-wrapper]');
+    const drawerDimension =
+      direction === 'bottom' || direction === 'top' ? drawerHeightRef.current : drawerWidthRef.current;
 
-      // Calculate the percentage dragged, where 1 is the closed position
-      let percentageDragged = absDraggedDistance / drawerDimension;
-      const snapPointPercentageDragged = getSnapPointsPercentageDragged(absDraggedDistance, isDraggingInDirection);
+    // Calculate the percentage dragged, where 1 is the closed position
+    let percentageDragged = absDraggedDistance / drawerDimension;
+    const snapPointPercentageDragged = getSnapPointsPercentageDragged(absDraggedDistance, isDraggingInDirection);
 
-      if (snapPointPercentageDragged !== null) {
-        percentageDragged = snapPointPercentageDragged;
-      }
+    if (snapPointPercentageDragged !== null) {
+      percentageDragged = snapPointPercentageDragged;
+    }
 
-      // Disallow close dragging beyond the smallest snap point.
-      if (noCloseSnapPointsPreCondition && percentageDragged >= 1) {
-        return;
-      }
+    // Disallow close dragging beyond the smallest snap point.
+    if (noCloseSnapPointsPreCondition && percentageDragged >= 1) {
+      return;
+    }
 
-      if (!isAllowedToDrag.current && !shouldDrag(event.target, isDraggingInDirection)) return;
-      drawerRef.current.classList.add(DRAG_CLASS);
-      // If shouldDrag gave true once after pressing down on the drawer, we set isAllowedToDrag to true and it will remain true until we let go, there's no reason to disable dragging mid way, ever, and that's the solution to it
-      isAllowedToDrag.current = true;
+    if (!isAllowedToDrag.current && !shouldDrag(event.target, isDraggingInDirection)) return;
+
+    if (!isDragActive) {
+      setIsDragActive(true);
+    }
+
+    drawerRef.current.classList.add(DRAG_CLASS);
+    // If shouldDrag gave true once after pressing down on the drawer, we set isAllowedToDrag to true and it will remain true until we let go, there's no reason to disable dragging mid way, ever, and that's the solution to it
+    isAllowedToDrag.current = true;
+    set(drawerRef.current, {
+      transition: 'none',
+    });
+
+    set(overlayRef.current, {
+      transition: 'none',
+    });
+
+    if (snapPoints) {
+      onDragSnapPoints({ draggedDistance });
+    }
+
+    // Run this only if snapPoints are not defined or if we are at the last snap point (highest one)
+    if (isDraggingInDirection && !snapPoints) {
+      const dampenedDraggedDistance = dampenValue(draggedDistance);
+
+      const translateValue = Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier;
       set(drawerRef.current, {
-        transition: 'none',
+        transform: isVertical(direction)
+          ? `translate3d(0, ${translateValue}px, 0)`
+          : `translate3d(${translateValue}px, 0, 0)`,
       });
+      return;
+    }
 
-      set(overlayRef.current, {
-        transition: 'none',
+    const opacityValue = 1 - percentageDragged;
+
+    if (shouldFade || (fadeFromIndex && activeSnapPointIndex === fadeFromIndex - 1)) {
+      onDragProp?.(event, percentageDragged);
+
+      set(
+        overlayRef.current,
+        {
+          opacity: `${opacityValue}`,
+          transition: 'none',
+        },
+        true,
+      );
+    }
+
+    if (wrapper && overlayRef.current && shouldScaleBackground) {
+      // Calculate percentageDragged as a fraction (0 to 1)
+      const scaleValue = Math.min(getScale() + percentageDragged * (1 - getScale()), 1);
+      const borderRadiusValue = 8 - percentageDragged * 8;
+
+      const translateValue = Math.max(0, 14 - percentageDragged * 14);
+
+      set(
+        wrapper,
+        {
+          borderRadius: `${borderRadiusValue}px`,
+          transform: isVertical(direction)
+            ? `scale(${scaleValue}) translate3d(0, ${translateValue}px, 0)`
+            : `scale(${scaleValue}) translate3d(${translateValue}px, 0, 0)`,
+          transition: 'none',
+        },
+        true,
+      );
+    }
+
+    if (!snapPoints) {
+      const translateValue = absDraggedDistance * directionMultiplier;
+
+      set(drawerRef.current, {
+        transform: isVertical(direction)
+          ? `translate3d(0, ${translateValue}px, 0)`
+          : `translate3d(${translateValue}px, 0, 0)`,
       });
-
-      if (snapPoints) {
-        onDragSnapPoints({ draggedDistance });
-      }
-
-      // Run this only if snapPoints are not defined or if we are at the last snap point (highest one)
-      if (isDraggingInDirection && !snapPoints) {
-        const dampenedDraggedDistance = dampenValue(draggedDistance);
-
-        const translateValue = Math.min(dampenedDraggedDistance * -1, 0) * directionMultiplier;
-        set(drawerRef.current, {
-          transform: isVertical(direction)
-            ? `translate3d(0, ${translateValue}px, 0)`
-            : `translate3d(${translateValue}px, 0, 0)`,
-        });
-        return;
-      }
-
-      const opacityValue = 1 - percentageDragged;
-
-      if (shouldFade || (fadeFromIndex && activeSnapPointIndex === fadeFromIndex - 1)) {
-        onDragProp?.(event, percentageDragged);
-
-        set(
-          overlayRef.current,
-          {
-            opacity: `${opacityValue}`,
-            transition: 'none',
-          },
-          true,
-        );
-      }
-
-      if (wrapper && overlayRef.current && shouldScaleBackground) {
-        // Calculate percentageDragged as a fraction (0 to 1)
-        const scaleValue = Math.min(getScale() + percentageDragged * (1 - getScale()), 1);
-        const borderRadiusValue = 8 - percentageDragged * 8;
-
-        const translateValue = Math.max(0, 14 - percentageDragged * 14);
-
-        set(
-          wrapper,
-          {
-            borderRadius: `${borderRadiusValue}px`,
-            transform: isVertical(direction)
-              ? `scale(${scaleValue}) translate3d(0, ${translateValue}px, 0)`
-              : `scale(${scaleValue}) translate3d(${translateValue}px, 0, 0)`,
-            transition: 'none',
-          },
-          true,
-        );
-      }
-
-      if (!snapPoints) {
-        const translateValue = absDraggedDistance * directionMultiplier;
-
-        set(drawerRef.current, {
-          transform: isVertical(direction)
-            ? `translate3d(0, ${translateValue}px, 0)`
-            : `translate3d(${translateValue}px, 0, 0)`,
-        });
-      }
     }
   }
 
@@ -614,16 +625,20 @@ export function Root({
 
     drawerRef.current.classList.remove(DRAG_CLASS);
     isAllowedToDrag.current = false;
+    isPointerDown.current = false;
     setIsDragging(false);
+    setIsDragActive(false);
     dragEndTime.current = new Date();
   }
 
   function onRelease(event: React.PointerEvent<HTMLDivElement> | null) {
+    isPointerDown.current = false;
     if (!isDragging || !drawerRef.current) return;
 
     drawerRef.current.classList.remove(DRAG_CLASS);
     isAllowedToDrag.current = false;
     setIsDragging(false);
+    setIsDragActive(false);
     dragEndTime.current = new Date();
     const swipeAmount = getTranslate(drawerRef.current, direction);
 

--- a/packages/headless-ui/vaul/src/use-snap-points.ts
+++ b/packages/headless-ui/vaul/src/use-snap-points.ts
@@ -30,6 +30,8 @@ export function useSnapPoints({
   container,
   snapToSequentialPoint,
   isOpen,
+  // "isDragging" here means real drag movement, not pointer-down state.
+  // This keeps dynamic content measurement stable on taps/clicks.
   isDragging,
   shouldAnimate = true,
   onSnapPointsResolved,


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

  - ItemSheet에서 탭 시 스냅 흔들림 및 Detail View 드래그 끊김 문제를 해결했습니다.
  - Vaul 내부 드래그 상태 분리를 통해 탭/클릭 시 스냅 오프셋 흔들림 방지.
    https://jira-knockdog.atlassian.net/browse/Q2-69 리포트
  - Detail View에 RemoveScroll 적용으로 터치 드래그가 pointerout으로 끊기는 현상을 완화했습니다.


## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### headless-ui/vaul
- pointer down 상태(isDragging)와 실제 드래그 이동(isDragActive) 분리.
- 동적 스냅 측정 가드를 isDragActive 기준으로 적용하여 탭 시 측정 흔들림 방지.
 - isDragging 의미 주석 보강(실제 드래그 기준).
#### KindergartenItemSheet
  - Detail View 영역을 RemoveScroll로 감싸서 스크롤/터치 이벤트 충돌로 인한 드래그 끊김 완화.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
