### PR TITLE
Fix: 메모 탭 Application Error 픽스, 상태바 텍스트 검정색으로 변경

### DIFF
--- a/apps/knockdog/src/features/checklist/ui/ChecklistSection.tsx
+++ b/apps/knockdog/src/features/checklist/ui/ChecklistSection.tsx
@@ -8,9 +8,13 @@ import { QUESTION_MAP } from '@entities/checklist';
 import { useUserStore } from '@entities/user/model/store/useUserStore';
 import { useChecklistAnswersQuery } from '../api/useChecklistQuery';
 
-function CheckListSection() {
+interface CheckListSectionProps {
+  kindergartenId?: string;
+}
+
+function CheckListSection({ kindergartenId }: CheckListSectionProps) {
   const params = useParams<{ id: string }>();
-  const id = params?.id;
+  const id = kindergartenId ?? params?.id;
   const { push } = useStackNavigation();
   const isLoggedIn = useUserStore((state) => !!state.user);
 

--- a/apps/knockdog/src/features/memo/ui/FreeMemoSection.tsx
+++ b/apps/knockdog/src/features/memo/ui/FreeMemoSection.tsx
@@ -13,9 +13,13 @@ import { useUserStore } from '@entities/user';
 
 const MEMO_PHOTO_MAX_COUNT = 5;
 
-export function FreeMemoSection() {
+interface FreeMemoSectionProps {
+  kindergartenId?: string;
+}
+
+export function FreeMemoSection({ kindergartenId }: FreeMemoSectionProps) {
   const params = useParams<{ id: string }>();
-  const id = params?.id;
+  const id = kindergartenId ?? params?.id;
   const { push } = useStackNavigation();
   const user = useUserStore((state) => state.user);
 

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -81,7 +81,7 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
         <ReviewSection kindergartenId={kindergartenId} onScrollTop={handleScrollToDivider} />
       </TabsContent>
       <TabsContent value='메모'>
-        <MemoSection />
+        <MemoSection kindergartenId={kindergartenId} />
       </TabsContent>
     </Tabs>
   );

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/MemoSection.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/MemoSection.tsx
@@ -4,15 +4,19 @@ import { FreeMemoSection } from '@features/memo';
 import { CheckListSection } from '@features/checklist';
 import { useUserStore } from '@entities/user';
 
-function MemoSection() {
+interface MemoSectionProps {
+  kindergartenId?: string;
+}
+
+function MemoSection({ kindergartenId }: MemoSectionProps) {
   const isLoggedIn = useUserStore((state) => !!state.user);
 
   if (!isLoggedIn) return null;
 
   return (
     <div className='mt-8 mb-12 flex flex-col gap-4 px-4'>
-      <FreeMemoSection />
-      <CheckListSection />
+      <FreeMemoSection kindergartenId={kindergartenId} />
+      <CheckListSection kindergartenId={kindergartenId} />
     </div>
   );
 }

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -13,7 +13,7 @@ import { GoogleSignin } from '@react-native-google-signin/google-signin';
 import { RootStackNavigator, useLinking } from './components/navigation';
 
 // 앱 시작 시 스플래시 자동 숨김 방지
-SplashScreen.preventAutoHideAsync().catch(() => {});
+SplashScreen.preventAutoHideAsync().catch(() => { });
 
 export default function App() {
   const [appIsReady, setAppIsReady] = useState(false);
@@ -48,7 +48,7 @@ export default function App() {
   // 루트 레이아웃이 그려지면 스플래시 숨김
   const onLayoutRootView = useCallback(async () => {
     if (appIsReady) {
-      await SplashScreen.hideAsync().catch(() => {});
+      await SplashScreen.hideAsync().catch(() => { });
     }
   }, [appIsReady]);
 
@@ -65,7 +65,7 @@ export default function App() {
         {/* 포털 루트: 토스트가 네비게이션 위 레이어로 뜨도록 */}
         <PortalProvider>
           {/* 상태바는 취향에 따라 */}
-          <StatusBar style='light' />
+          <StatusBar style='dark' />
           {/* onLayout에서 스플래시 숨김 */}
           <View style={{ flex: 1 }} onLayout={onLayoutRootView}>
             {/* 토스트 프로바이더가 네비게이션 바/스크린 “밖”에 있어야 어디서든 toast() 가능 */}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 티켓

[Q2-71 [IOS/Apple] 상태 바 텍스트 색상 검정색으로 변경](https://jira-knockdog.atlassian.net/browse/Q2-71)
[Q2-15 [iOS/카카오/탐색] 메모 탭 누르면 'Application error' 뜸](https://jira-knockdog.atlassian.net/browse/Q2-15)
