### PR TITLE
refactor: 위치 브릿지 API 리팩터링

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -28,7 +28,7 @@ import { overlay } from 'overlay-kit';
 import { useFilteredSearchList } from '@features/kindergarten-map';
 import { FILTER_OPTIONS, SHORT_CUT_FILTER_OPTIONS } from '@entities/kindergarten';
 import { useUserStore, USER_ADDRESS_TYPE, USER_ADDRESS_TYPE_KR } from '@entities/user';
-import { GetLocationPermissionError, useBottomSheetSnapIndex } from '@shared/lib';
+import { LocationPermissionError, useBottomSheetSnapIndex } from '@shared/lib';
 import { useGeolocationQuery } from '@shared/lib/geolocation/useGeolocationQuery';
 import { type BasePointType, useBasePointType } from '@shared/store';
 import { useStackNavigation } from '@shared/lib/bridge';
@@ -62,7 +62,7 @@ export function KindergartenList({ onOpenFilter, region }: KindergartenListProps
 
   // 위치 권한 에러 체크
   const { error: locationError } = useGeolocationQuery({ enabled: selectedBaseType === 'CURRENT' });
-  const isPermissionDenied = selectedBaseType === 'CURRENT' && locationError instanceof GetLocationPermissionError;
+  const isPermissionDenied = selectedBaseType === 'CURRENT' && locationError instanceof LocationPermissionError;
 
   const workAlias = user?.addresses?.find((addr) => addr.type === USER_ADDRESS_TYPE.WORK)?.alias || USER_ADDRESS_TYPE_KR[USER_ADDRESS_TYPE.WORK];
 

--- a/apps/knockdog/src/features/kindergarten-list/ui/PermissionSection.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/PermissionSection.tsx
@@ -1,12 +1,12 @@
 import { ActionButton, Icon } from '@knockdog/ui';
 import Image from 'next/image';
 
-import { getCurrentLocation } from '@shared/lib';
+import { requestLocationPermission } from '@shared/lib';
 
 export function PermissionSection() {
   const handlePermissionCheck = async () => {
     // 권한 설정 다이얼로그 열기
-    await getCurrentLocation.openPermissionDialog();
+    await requestLocationPermission();
   };
 
   return (

--- a/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationFAB.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationFAB.tsx
@@ -1,8 +1,6 @@
 import { FloatingActionButton } from '@knockdog/ui';
 import { useSearchMachine } from '../model/useSearchMachine';
 import { useGeolocationQuery } from '@shared/lib';
-import { isNativeWebView } from '@shared/lib/device/isNativeWebView';
-import { getCurrentLocation, GetLocationPermissionError } from '@shared/lib/geolocation/getCurrentLocation';
 import { useBasePointType } from '@shared/store';
 
 export function CurrentLocationFAB() {
@@ -16,18 +14,6 @@ export function CurrentLocationFAB() {
     const result = await refetch();
     if (result.data) {
       dispatch({ type: 'BASEPOINT_SYNC', payload: { basePoint: result.data, reason: 'explicit' } });
-      return;
-    }
-
-    const error = result.error;
-    if (isNativeWebView() && error instanceof GetLocationPermissionError) {
-      const status = await getCurrentLocation.openPermissionDialog().catch(() => null);
-      if (status === 'allowed') {
-        const retried = await refetch();
-        if (retried.data) {
-          dispatch({ type: 'BASEPOINT_SYNC', payload: { basePoint: retried.data, reason: 'explicit' } });
-        }
-      }
     }
   };
 

--- a/apps/knockdog/src/features/location-permission/lib/useLocationPermission.ts
+++ b/apps/knockdog/src/features/location-permission/lib/useLocationPermission.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { PermissionStatus } from '@knockdog/bridge-core';
-import { getCurrentLocation, useGeolocationQuery } from '@shared/lib/geolocation';
+import { getLocationPermission, requestLocationPermission, useGeolocationQuery } from '@shared/lib/geolocation';
 import { useQuery } from '@tanstack/react-query';
 import { geoQueries } from '@entities/address';
 
@@ -41,7 +41,7 @@ function useLocationPermission() {
    */
   const checkPermission = async () => {
     try {
-      const status = await getCurrentLocation.getPermission();
+      const status = await getLocationPermission();
       setPermissionStatus(status);
     } catch (error) {
       console.error('권한 확인 실패:', error);
@@ -52,14 +52,14 @@ function useLocationPermission() {
   /**
    * 권한 요청 (앱 내 팝업)
    */
-  const requestPermission = async () => {
+  const handleRequestPermission = async () => {
     try {
-      const status = await getCurrentLocation.openPermissionDialog();
+      const { status } = await requestLocationPermission();
       setPermissionStatus(status);
       return status;
     } catch (error) {
       console.error('권한 요청 실패:', error);
-      return 'denied';
+      return 'denied' as const;
     }
   };
 
@@ -86,7 +86,7 @@ function useLocationPermission() {
     permissionStatus,
     location,
     address,
-    requestPermission,
+    requestPermission: handleRequestPermission,
     isLoading: locationQuery.isLoading || isAddressLoading,
   };
 }

--- a/apps/knockdog/src/shared/lib/geolocation/errors.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/errors.ts
@@ -1,0 +1,30 @@
+import type { PermissionStatus } from '@knockdog/bridge-core';
+
+/** 위치 권한 에러 */
+export class LocationPermissionError extends Error {
+  readonly status: PermissionStatus;
+  readonly canAskAgain: boolean;
+
+  constructor(status: PermissionStatus, canAskAgain: boolean, message?: string) {
+    super(message ?? '위치 권한이 필요합니다');
+    this.name = 'LocationPermissionError';
+    this.status = status;
+    this.canAskAgain = canAskAgain;
+  }
+}
+
+/** 위치 서비스 OFF 에러 */
+export class LocationServiceDisabledError extends Error {
+  constructor(message?: string) {
+    super(message ?? '위치 서비스가 꺼져 있습니다');
+    this.name = 'LocationServiceDisabledError';
+  }
+}
+
+/** 위치 획득 불가 에러 */
+export class LocationUnavailableError extends Error {
+  constructor(message?: string) {
+    super(message ?? '위치를 가져올 수 없습니다');
+    this.name = 'LocationUnavailableError';
+  }
+}

--- a/apps/knockdog/src/shared/lib/geolocation/getCurrentLocation.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/getCurrentLocation.ts
@@ -1,135 +1,173 @@
-import { METHODS, BridgeException, type Accuracy, type Location, type PermissionStatus } from '@knockdog/bridge-core';
+import {
+  METHODS,
+  LOCATION_ERROR_CODES,
+  BridgeException,
+  type Accuracy,
+  type Location,
+  type PermissionStatus,
+} from '@knockdog/bridge-core';
 import { isNativeWebView } from '../device';
 import { getBridgeInstance } from '../bridge';
+import { LocationPermissionError, LocationServiceDisabledError, LocationUnavailableError } from './errors';
+import { getLocationPermission, isLocationServiceEnabled } from './permission';
 
-interface GeolocationOptions {
-  enableHighAccuracy?: boolean;
-  timeout?: number;
-  maximumAge?: number;
+export type LocationSource = 'lastKnown' | 'gps';
+export type LocationQuality = 'approximate' | 'precise';
+
+export interface GetCurrentLocationResult {
+  location: Location;
+  source: LocationSource;
+  quality: LocationQuality;
 }
 
-interface GetCurrentLocationOptions {
-  accuracy: Accuracy;
-}
-
-/**
- * 현재 위치 권한 에러
- */
-export class GetLocationPermissionError extends Error {
-  constructor(message = '위치 권한이 거부되었습니다') {
-    super(message);
-    this.name = 'GetLocationPermissionError';
-  }
+export interface GetCurrentLocationOptions {
+  /** 캐시 유효 시간 (ms). 기본값: 300000 (5분) */
+  maxAge?: number;
+  /** GPS 정확도. 기본값: 'balanced' */
+  accuracy?: Accuracy;
+  /** last-known 위치를 받았을 때 호출되는 콜백 (UI 즉시 업데이트용) */
+  onLastKnown?: (location: Location) => void;
+  /** 정밀 위치 획득 실패 시 last-known으로 fallback 할지 여부. 기본값: true */
+  fallbackOnError?: boolean;
 }
 
 /**
  * 현재 위치 가져오기
- * - 앱 환경: bridge를 통해 네이티브에서 위치 정보 가져오기
- * - 웹 환경: 브라우저 Geolocation API 사용
+ *
+ * 1. 권한/서비스 체크
+ * 2. last-known + GPS 병렬 시작 (async-parallel)
+ * 3. last-known 먼저 완료되면 onLastKnown 콜백
+ * 4. GPS 완료되면 최종 결과 반환
+ *
+ * @example
+ * ```ts
+ * // 기본 사용
+ * const { location, quality } = await getCurrentLocation();
+ *
+ * // 캐시 위치로 즉시 UI 업데이트
+ * const result = await getCurrentLocation({
+ *   onLastKnown: (loc) => map.setCenter(loc.coords),
+ * });
+ * ```
  */
-export async function getCurrentLocation(
-  options: GetCurrentLocationOptions | GeolocationOptions = { accuracy: 'high' }
-): Promise<Location | { coords: { latitude: number; longitude: number } }> {
-  // 앱 환경
-  if (isNativeWebView()) {
-    const bridge = getBridgeInstance();
-
-    if (!bridge) {
-      throw new Error('Bridge not initialized');
-    }
-
-    try {
-      return await bridge.request<Location>(METHODS.getCurrentLocation, options);
-    } catch (error) {
-      if (error instanceof BridgeException && error.code === 'EPERMISSION') {
-        throw new GetLocationPermissionError(error.message);
-      }
-      throw error;
-    }
-  }
+export async function getCurrentLocation(options: GetCurrentLocationOptions = {}): Promise<GetCurrentLocationResult> {
+  const { maxAge = 300_000, accuracy = 'balanced', onLastKnown, fallbackOnError = true } = options;
 
   // 웹 환경
-  return new Promise((resolve, reject) => {
-    if (typeof window === 'undefined' || !navigator.geolocation) {
-      reject(new Error('geolocation_unavailable'));
-      return;
-    }
+  if (!isNativeWebView()) {
+    return getLocationFromBrowser(accuracy);
+  }
 
-    const browserOptions = {
-      timeout: 10_000,
-      maximumAge: 300_000,
-      enableHighAccuracy: !!(options as GeolocationOptions).enableHighAccuracy,
-      ...(options as GeolocationOptions),
-    };
-
-    navigator.geolocation.getCurrentPosition(
-      (pos) => resolve({ coords: { latitude: pos.coords.latitude, longitude: pos.coords.longitude } }),
-      (err) => {
-        console.warn('위치 정보를 가져올 수 없습니다:', err.message);
-        if (err.code === err.PERMISSION_DENIED) {
-          reject(new GetLocationPermissionError(err.message));
-        } else {
-          reject(err);
-        }
-      },
-      browserOptions
-    );
-  });
-}
-
-/**
- * 위치 권한 상태 확인
- * @description 앱 환경에서만 사용 가능
- */
-getCurrentLocation.getPermission = async (): Promise<PermissionStatus> => {
   const bridge = getBridgeInstance();
-
   if (!bridge) {
     throw new Error('Bridge not initialized');
   }
 
-  const { status } = await bridge.request<{ status: PermissionStatus }>(METHODS.getLocationPermission, {});
-  return status;
-};
+  // 1. 권한 + 서비스 병렬 체크
+  const [permissionStatus, serviceEnabled] = await Promise.all([getLocationPermission(), isLocationServiceEnabled()]);
+
+  if (permissionStatus !== 'allowed') {
+    const canAskAgain = permissionStatus === 'undetermined';
+    throw new LocationPermissionError(permissionStatus, canAskAgain);
+  }
+
+  if (!serviceEnabled) {
+    throw new LocationServiceDisabledError();
+  }
+
+  // 2. last-known + GPS 병렬 시작 (async-parallel)
+  const lastKnownPromise = bridge.request<Location | null>(METHODS.getLastKnownLocation, { maxAge }).catch(() => null); // last-known 실패는 무시
+
+  const gpsPromise = bridge.request<Location>(METHODS.getCurrentLocation, { accuracy }, { timeoutMs: 20_000 });
+
+  // 3. last-known 먼저 처리
+  const lastKnownLocation = await lastKnownPromise;
+  if (lastKnownLocation && onLastKnown) {
+    onLastKnown(lastKnownLocation);
+  }
+
+  // 4. GPS 대기
+  try {
+    const preciseLocation = await gpsPromise;
+    return {
+      location: preciseLocation,
+      source: 'gps',
+      quality: 'precise',
+    };
+  } catch (error) {
+    // GPS 실패 시 fallback
+    if (fallbackOnError && lastKnownLocation) {
+      return {
+        location: lastKnownLocation,
+        source: 'lastKnown',
+        quality: 'approximate',
+      };
+    }
+
+    // 에러 변환
+    if (error instanceof BridgeException) {
+      const errorData = error.data as { permissionStatus?: PermissionStatus; canAskAgain?: boolean } | undefined;
+
+      switch (error.code) {
+        case LOCATION_ERROR_CODES.PERMISSION_DENIED:
+          throw new LocationPermissionError(
+            errorData?.permissionStatus ?? 'denied',
+            errorData?.canAskAgain ?? false,
+            error.message
+          );
+        case LOCATION_ERROR_CODES.SERVICE_DISABLED:
+          throw new LocationServiceDisabledError(error.message);
+        case LOCATION_ERROR_CODES.TIMEOUT:
+        case LOCATION_ERROR_CODES.UNAVAILABLE:
+          throw new LocationUnavailableError(error.message);
+      }
+    }
+
+    throw error;
+  }
+}
 
 /**
- * 위치 권한 요청 다이얼로그 열기
- * - 앱 환경: 권한 요청 팝업을 띄우거나, 명시적 거부 상태일 경우 시스템 설정창으로 이동
- * - 웹 환경: 브라우저 권한 요청 시도
+ * 브라우저 Geolocation API (웹 환경)
  */
-getCurrentLocation.openPermissionDialog = async (): Promise<PermissionStatus> => {
-  /* 앱 환경 */
-  if (isNativeWebView()) {
-    const bridge = getBridgeInstance();
-
-    if (!bridge) {
-      throw new Error('Bridge not initialized');
+async function getLocationFromBrowser(accuracy: Accuracy): Promise<GetCurrentLocationResult> {
+  return new Promise((resolve, reject) => {
+    if (typeof window === 'undefined' || !navigator.geolocation) {
+      reject(new LocationUnavailableError('Geolocation API not available'));
+      return;
     }
 
-    const { status, canAskAgain } = await bridge.request<{ status: PermissionStatus; canAskAgain: boolean }>(
-      METHODS.openLocationPermissionDialog,
-      {}
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        resolve({
+          location: {
+            coords: {
+              latitude: pos.coords.latitude,
+              longitude: pos.coords.longitude,
+              accuracy: pos.coords.accuracy,
+              altitude: pos.coords.altitude,
+              altitudeAccuracy: pos.coords.altitudeAccuracy,
+              heading: pos.coords.heading,
+              speed: pos.coords.speed,
+            },
+            timestamp: pos.timestamp,
+          },
+          source: 'gps',
+          quality: 'precise',
+        });
+      },
+      (err) => {
+        if (err.code === err.PERMISSION_DENIED) {
+          reject(new LocationPermissionError('denied', false, err.message));
+        } else {
+          reject(new LocationUnavailableError(err.message));
+        }
+      },
+      {
+        enableHighAccuracy: accuracy === 'high',
+        timeout: 15_000,
+        maximumAge: 300_000,
+      }
     );
-
-    if (status === 'denied' && !canAskAgain) {
-      await bridge.request('system.openSettings' as const, {});
-    }
-
-    return status;
-  }
-
-  /* 웹 환경: 브라우저 권한 요청 트리거 (재시도) */
-  try {
-    // 웹에서는 명시적 거부(denied) 상태일 경우, JS API로 권한 창을 다시 띄울 수 없음.
-    // 사용자가 직접 브라우저 설정에서 권한을 재설정해야 함.
-    await getCurrentLocation();
-    return 'allowed';
-  } catch (error) {
-    if (error instanceof GetLocationPermissionError) {
-      return 'denied';
-    }
-    // 그 외 에러도 권한이 없는 것으로 간주하거나 prompt 상태일 수 있으나,
-    // 명시적 거부/전환 실패로 보아 denied 리턴 (혹은 'prompt'가 정확할 수 있으나 web api로 확인 불가)
-    return 'denied';
-  }
-};
+  });
+}

--- a/apps/knockdog/src/shared/lib/geolocation/getCurrentLocation.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/getCurrentLocation.ts
@@ -55,7 +55,7 @@ export async function getCurrentLocation(options: GetCurrentLocationOptions = {}
 
   // 웹 환경
   if (!isNativeWebView()) {
-    return getLocationFromBrowser(accuracy);
+    return getLocationFromBrowser(accuracy, maxAge);
   }
 
   const bridge = getBridgeInstance();
@@ -130,7 +130,7 @@ export async function getCurrentLocation(options: GetCurrentLocationOptions = {}
 /**
  * 브라우저 Geolocation API (웹 환경)
  */
-async function getLocationFromBrowser(accuracy: Accuracy): Promise<GetCurrentLocationResult> {
+async function getLocationFromBrowser(accuracy: Accuracy, maxAge: number): Promise<GetCurrentLocationResult> {
   return new Promise((resolve, reject) => {
     if (typeof window === 'undefined' || !navigator.geolocation) {
       reject(new LocationUnavailableError('Geolocation API not available'));
@@ -166,7 +166,7 @@ async function getLocationFromBrowser(accuracy: Accuracy): Promise<GetCurrentLoc
       {
         enableHighAccuracy: accuracy === 'high',
         timeout: 15_000,
-        maximumAge: 300_000,
+        maximumAge: maxAge,
       }
     );
   });

--- a/apps/knockdog/src/shared/lib/geolocation/index.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/index.ts
@@ -1,6 +1,18 @@
+// Utils
 export { isValidCoord, isEqualCoord, isEqualBounds } from './is';
 export { serializeCoords } from './serialize';
-export { getCurrentLocation, GetLocationPermissionError } from './getCurrentLocation';
+
+// Core
+export { getCurrentLocation } from './getCurrentLocation';
+export type { GetCurrentLocationOptions, GetCurrentLocationResult, LocationSource, LocationQuality } from './getCurrentLocation';
+
+// Permission
+export { getLocationPermission, requestLocationPermission, isLocationServiceEnabled } from './permission';
+
+// Errors
+export { LocationPermissionError, LocationServiceDisabledError, LocationUnavailableError } from './errors';
+
+// Hooks
 export { useCurrentLocation } from './useCurrentLocation';
 export { useGeolocationQuery } from './useGeolocationQuery';
 export { useCurrentAddress } from './useCurrentAddress';

--- a/apps/knockdog/src/shared/lib/geolocation/permission.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/permission.ts
@@ -1,0 +1,93 @@
+import { METHODS, type PermissionStatus } from '@knockdog/bridge-core';
+import { isNativeWebView } from '../device';
+import { getBridgeInstance } from '../bridge';
+
+/**
+ * 위치 권한 상태 확인
+ */
+export async function getLocationPermission(): Promise<PermissionStatus> {
+  if (!isNativeWebView()) {
+    // 웹 환경: Permissions API 사용 (지원 시)
+    if (typeof navigator !== 'undefined' && navigator.permissions) {
+      try {
+        const result = await navigator.permissions.query({ name: 'geolocation' });
+        if (result.state === 'granted') return 'allowed';
+        if (result.state === 'denied') return 'denied';
+        return 'undetermined';
+      } catch {
+        return 'undetermined';
+      }
+    }
+    return 'undetermined';
+  }
+
+  const bridge = getBridgeInstance();
+  if (!bridge) {
+    throw new Error('Bridge not initialized');
+  }
+
+  const { status } = await bridge.request<{ status: PermissionStatus }>(METHODS.getLocationPermission, {});
+  return status;
+}
+
+/**
+ * 위치 권한 요청 다이얼로그 표시
+ */
+export async function requestLocationPermission(): Promise<{ status: PermissionStatus; canAskAgain: boolean }> {
+  if (!isNativeWebView()) {
+    // 웹 환경: geolocation 호출로 권한 요청 트리거
+    return new Promise((resolve) => {
+      if (typeof navigator === 'undefined' || !navigator.geolocation) {
+        resolve({ status: 'denied', canAskAgain: false });
+        return;
+      }
+
+      navigator.geolocation.getCurrentPosition(
+        () => resolve({ status: 'allowed', canAskAgain: true }),
+        (err) => {
+          if (err.code === err.PERMISSION_DENIED) {
+            resolve({ status: 'denied', canAskAgain: false });
+          } else {
+            resolve({ status: 'undetermined', canAskAgain: true });
+          }
+        },
+        { timeout: 100 } // 권한 확인만 하므로 짧은 타임아웃
+      );
+    });
+  }
+
+  const bridge = getBridgeInstance();
+  if (!bridge) {
+    throw new Error('Bridge not initialized');
+  }
+
+  const { status, canAskAgain } = await bridge.request<{ status: PermissionStatus; canAskAgain: boolean }>(
+    METHODS.requestLocationPermission,
+    {}
+  );
+
+  // denied + canAskAgain=false면 설정 앱으로 유도
+  if (status === 'denied' && !canAskAgain) {
+    await bridge.request('system.openSettings' as const, {});
+  }
+
+  return { status, canAskAgain };
+}
+
+/**
+ * 위치 서비스(GPS) 활성화 상태 확인
+ */
+export async function isLocationServiceEnabled(): Promise<boolean> {
+  if (!isNativeWebView()) {
+    // 웹 환경: 확인 불가, true로 가정
+    return true;
+  }
+
+  const bridge = getBridgeInstance();
+  if (!bridge) {
+    throw new Error('Bridge not initialized');
+  }
+
+  const { enabled } = await bridge.request<{ enabled: boolean }>(METHODS.isLocationServiceEnabled, {});
+  return enabled;
+}

--- a/apps/knockdog/src/shared/lib/geolocation/useGeolocationQuery.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/useGeolocationQuery.ts
@@ -2,6 +2,8 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getCurrentLocation } from './getCurrentLocation';
+import { LocationPermissionError, LocationServiceDisabledError } from './errors';
+import type { Accuracy } from '@knockdog/bridge-core';
 
 interface UseGeolocationQueryOptions {
   enabled?: boolean;
@@ -13,19 +15,27 @@ interface UseGeolocationQueryOptions {
 }
 
 export function useGeolocationQuery({ enabled = true, options }: UseGeolocationQueryOptions = {}) {
+  const accuracy: Accuracy = options?.enableHighAccuracy ? 'high' : 'balanced';
+  const maxAge = options?.maximumAge ?? 300_000;
   return useQuery({
-    queryKey: ['current', options],
-    queryFn: () =>
-      getCurrentLocation({
-        enableHighAccuracy: true,
-        timeout: 5000,
-        maximumAge: 30_000,
-        ...options,
-      }),
+    queryKey: ['geolocation', accuracy, maxAge],
+    queryFn: async () => {
+      const result = await getCurrentLocation({
+        accuracy,
+        maxAge,
+        fallbackOnError: true,
+      });
+      return result.location;
+    },
     enabled,
     staleTime: 30_000,
     gcTime: 5 * 60_000,
-    retry: false,
+    retry: (failureCount, error) => {
+      // 권한 에러나 서비스 꺼짐은 재시도 불필요
+      if (error instanceof LocationPermissionError) return false;
+      if (error instanceof LocationServiceDisabledError) return false;
+      return failureCount < 1;
+    },
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
     retryOnMount: true,

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { overlay } from 'overlay-kit';
@@ -26,8 +26,8 @@ import { getRegionLevel } from '@features/kindergarten-map/lib/markers';
 import type { BoundsSnapshot } from '@features/kindergarten-map/lib/searchMachine';
 import { boundsSnapshotToBounds, toBoundsSnapshot } from '@features/kindergarten-map/lib/bounds';
 import type { KindergartenListItem } from '@entities/kindergarten';
-import { isEqualCoord, useBottomSheetSnapIndex } from '@shared/lib';
-import { useMarkerState } from '@shared/store';
+import { getLocationPermission, isEqualCoord, requestLocationPermission, useBottomSheetSnapIndex } from '@shared/lib';
+import { useBasePointType, useMarkerState } from '@shared/store';
 
 export default function KindergartenMainPage() {
   return (
@@ -42,12 +42,47 @@ export default function KindergartenMainPage() {
 function KindergartenMainPageContent() {
   const mapRef = useRef<naver.maps.Map | null>(null);
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const { liveState, committedState, searchState, dispatch } = useSearchMachine();
   const { isOnlyBookmarked, isOnlyMemoed, toggleBookmarked, toggleMemoed } = useDisplayFilterContext();
 
   const { setActiveMarker } = useMarkerState();
   const { isFullExtended, setSnapIndex } = useBottomSheetSnapIndex();
+  const { selectedBaseType } = useBasePointType();
 
+  /**
+   * 페이지 진입시 위치 권한 확인 및 요청
+   * - 현재 위치 모드일 때만 실행
+   * - 권한이 없으면 자동으로 요청
+   * - 권한 획득시 위치 쿼리 갱신
+   */
+  useEffect(() => {
+    if (selectedBaseType !== 'CURRENT') return;
+
+    const ensureLocationPermission = async () => {
+      try {
+        const status = await getLocationPermission();
+
+        // 권한이 없거나 미결정 상태면 요청
+        if (status !== 'allowed') {
+          const result = await requestLocationPermission();
+
+          // 권한 획득 성공시 위치 쿼리 무효화하여 자동 재실행
+          if (result.status === 'allowed') {
+            queryClient.invalidateQueries({ queryKey: ['geolocation'] });
+          }
+        }
+      } catch (error) {
+        // 권한 요청 실패
+      }
+    };
+
+    ensureLocationPermission();
+  }, [queryClient, selectedBaseType]);
+
+  /**
+   * 재검색 버튼 표시 여부
+   */
   const shouldShowRefresh = useMemo(() => {
     if (!liveState.viewportBounds) return false;
 
@@ -128,7 +163,8 @@ function KindergartenMainPageContent() {
       ) : (
         <div
           className={cn(
-            `absolute top-0 right-0 left-0 z-50 pt-(--safe-area-inset-top,0px) ${isFullExtended ? 'bg-fill-secondary-0' : ''
+            `absolute top-0 right-0 left-0 z-50 pt-(--safe-area-inset-top,0px) ${
+              isFullExtended ? 'bg-fill-secondary-0' : ''
             }`
           )}
         >

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -63,14 +63,15 @@ function KindergartenMainPageContent() {
       try {
         const status = await getLocationPermission();
 
-        // 권한이 없거나 미결정 상태면 요청
-        if (status !== 'allowed') {
-          const result = await requestLocationPermission();
+        // 이미 허용된 경우 요청 스킵
+        if (status === 'allowed') return;
 
-          // 권한 획득 성공시 위치 쿼리 무효화하여 자동 재실행
-          if (result.status === 'allowed') {
-            queryClient.invalidateQueries({ queryKey: ['geolocation'] });
-          }
+        // 권한이 없거나 미결정 상태면 요청
+        const result = await requestLocationPermission();
+
+        // 권한 획득 성공시 위치 쿼리 무효화하여 자동 재실행
+        if (result.status === 'allowed') {
+          queryClient.invalidateQueries({ queryKey: ['geolocation'] });
         }
       } catch (error) {
         // 권한 요청 실패

--- a/apps/mobile/bridges/handlers/location.ts
+++ b/apps/mobile/bridges/handlers/location.ts
@@ -1,6 +1,6 @@
 import * as Location from 'expo-location';
 import { NativeBridgeRouter } from '@knockdog/bridge-native';
-import { METHODS, type Accuracy, type PermissionStatus } from '@knockdog/bridge-core';
+import { METHODS, LOCATION_ERROR_CODES, type Accuracy, type PermissionStatus } from '@knockdog/bridge-core';
 
 function mapAccuracy(accuracy: Accuracy): Location.LocationAccuracy {
   switch (accuracy) {
@@ -28,16 +28,17 @@ function mapPermissionStatus(status: Location.PermissionStatus): PermissionStatu
   }
 }
 
-/**
- * 위치 정보 핸들러
- */
+// 진행 중인 GPS 요청 (중복 방지용)
+let pendingLocationRequest: Promise<Location.LocationObject> | null = null;
+
 export function registerLocationHandlers(router: NativeBridgeRouter) {
   /**
    * 위도, 경도 가져오기
+   * @deprecated use `getCurrentLocation` instead
    */
   router.register(METHODS.getLatLng, async (options?: { accuracy?: 'balanced' | 'high' }) => {
     const { status } = await Location.requestForegroundPermissionsAsync();
-    if (status !== 'granted') throw { code: 'EPERMISSION', message: '위치 권한 거부' };
+    if (status !== 'granted') throw { code: LOCATION_ERROR_CODES.PERMISSION_DENIED, message: '위치 권한 거부' };
 
     const acc = options?.accuracy === 'high' ? Location.Accuracy.High : Location.Accuracy.Balanced;
 
@@ -51,35 +52,68 @@ export function registerLocationHandlers(router: NativeBridgeRouter) {
    * @param {Accuracy} params.accuracy - 정확도
    */
   router.register(METHODS.getCurrentLocation, async (params: { accuracy: Accuracy }) => {
-    const { status } = await Location.requestForegroundPermissionsAsync();
+    // 1. 권한 체크
+    const { status, canAskAgain } = await Location.getForegroundPermissionsAsync();
 
     if (status !== Location.PermissionStatus.GRANTED) {
       throw {
-        code: 'EPERMISSION',
-        message: '위치 권한 거부',
-        data: { permissionStatus: mapPermissionStatus(status) },
+        code: LOCATION_ERROR_CODES.PERMISSION_DENIED,
+        message: '위치 권한 필요',
+        data: { permissionStatus: mapPermissionStatus(status), canAskAgain },
       };
     }
 
-    const accuracy = mapAccuracy(params.accuracy);
-    const location = await Location.getCurrentPositionAsync({
-      accuracy,
-    });
+    // 2. 서비스 체크
+    const servicesEnabled = await Location.hasServicesEnabledAsync();
+    if (!servicesEnabled) {
+      throw { code: LOCATION_ERROR_CODES.SERVICE_DISABLED, message: '위치 서비스가 꺼져 있습니다.' };
+    }
 
-    return {
-      coords: {
-        latitude: location.coords.latitude,
-        longitude: location.coords.longitude,
-        altitude: location.coords.altitude,
-        accuracy: location.coords.accuracy,
-        altitudeAccuracy: location.coords.altitudeAccuracy,
-        heading: location.coords.heading,
-      },
-      timestamp: location.timestamp,
-    };
+    // 3. 중복 요청 방지: 이미 진행 중인 요청이 있으면 같은 Promise 반환
+    if (pendingLocationRequest) {
+      const location = await pendingLocationRequest;
+      return {
+        coords: {
+          latitude: location.coords.latitude,
+          longitude: location.coords.longitude,
+          altitude: location.coords.altitude,
+          accuracy: location.coords.accuracy,
+          altitudeAccuracy: location.coords.altitudeAccuracy,
+          heading: location.coords.heading,
+          speed: location.coords.speed,
+        },
+        timestamp: location.timestamp,
+      };
+    }
+
+    // 4. GPS fix
+    const accuracy = mapAccuracy(params.accuracy);
+
+    pendingLocationRequest = Location.getCurrentPositionAsync({ accuracy });
+
+    try {
+      const location = await pendingLocationRequest;
+
+      return {
+        coords: {
+          latitude: location.coords.latitude,
+          longitude: location.coords.longitude,
+          altitude: location.coords.altitude,
+          accuracy: location.coords.accuracy,
+          altitudeAccuracy: location.coords.altitudeAccuracy,
+          heading: location.coords.heading,
+          speed: location.coords.speed,
+        },
+        timestamp: location.timestamp,
+      };
+    } finally {
+      pendingLocationRequest = null;
+    }
   });
 
-  /** 위치 권한 확인하기 */
+  /**
+   * 위치 권한 확인
+   */
   router.register(METHODS.getLocationPermission, async () => {
     const { status } = await Location.getForegroundPermissionsAsync();
 
@@ -88,13 +122,56 @@ export function registerLocationHandlers(router: NativeBridgeRouter) {
     };
   });
 
-  /** 위치 권한 요청 다이얼로그 열기 */
-  router.register(METHODS.openLocationPermissionDialog, async () => {
+  /**
+   * 위치 권한 요청
+   */
+  router.register(METHODS.requestLocationPermission, async () => {
     const { status, canAskAgain } = await Location.requestForegroundPermissionsAsync();
 
     return {
       status: mapPermissionStatus(status),
       canAskAgain,
+    };
+  });
+
+  /**
+   * 위치 서비스(GPS) ON/OFF 상태 확인
+   */
+  router.register(METHODS.isLocationServiceEnabled, async () => {
+    const enabled = await Location.hasServicesEnabledAsync();
+    return { enabled };
+  });
+
+  /**
+   * 캐시된 마지막 위치 즉시 반환 (GPS 호출 없음)
+   * @param params.maxAge - 캐시 유효 시간 (ms). 기본값: 300000 (5분)
+   */
+  router.register(METHODS.getLastKnownLocation, async (params?: { maxAge?: number }) => {
+    const maxAge = params?.maxAge ?? 300_000; // 기본 5분
+
+    const lastKnown = await Location.getLastKnownPositionAsync();
+
+    if (!lastKnown) {
+      return null;
+    }
+
+    // maxAge 검증: timestamp가 maxAge보다 오래되었으면 null 반환
+    const age = Date.now() - lastKnown.timestamp;
+    if (age > maxAge) {
+      return null;
+    }
+
+    return {
+      coords: {
+        latitude: lastKnown.coords.latitude,
+        longitude: lastKnown.coords.longitude,
+        altitude: lastKnown.coords.altitude,
+        accuracy: lastKnown.coords.accuracy,
+        altitudeAccuracy: lastKnown.coords.altitudeAccuracy,
+        heading: lastKnown.coords.heading,
+        speed: lastKnown.coords.speed,
+      },
+      timestamp: lastKnown.timestamp,
     };
   });
 }

--- a/apps/mobile/bridges/handlers/location.ts
+++ b/apps/mobile/bridges/handlers/location.ts
@@ -147,17 +147,16 @@ export function registerLocationHandlers(router: NativeBridgeRouter) {
    * @param params.maxAge - 캐시 유효 시간 (ms). 기본값: 300000 (5분)
    */
   router.register(METHODS.getLastKnownLocation, async (params?: { maxAge?: number }) => {
-    const maxAge = params?.maxAge ?? 300_000; // 기본 5분
+    // maxAge 검증 및 sanitize: finite, non-negative 검증
+    const sanitizedMaxAge =
+      typeof params?.maxAge === 'number' && isFinite(params.maxAge) && params.maxAge >= 0
+        ? params.maxAge
+        : 300_000;
 
-    const lastKnown = await Location.getLastKnownPositionAsync();
+    // expo-location의 maxAge 옵션 활용 (수동 계산 불필요)
+    const lastKnown = await Location.getLastKnownPositionAsync({ maxAge: sanitizedMaxAge });
 
     if (!lastKnown) {
-      return null;
-    }
-
-    // maxAge 검증: timestamp가 maxAge보다 오래되었으면 null 반환
-    const age = Date.now() - lastKnown.timestamp;
-    if (age > maxAge) {
       return null;
     }
 

--- a/apps/mobile/bridges/ui/BridgeWebView.tsx
+++ b/apps/mobile/bridges/ui/BridgeWebView.tsx
@@ -141,7 +141,7 @@ export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
       geolocationEnabled
       webviewDebuggingEnabled={__DEV__}
       injectedJavaScriptBeforeContentLoaded={Platform.OS === 'ios' ? INJECT_BEFORE : undefined}
-      injectedJavaScript={Platform.OS === 'android' ? INJECT_SAFE_AREA : undefined}
+      injectedJavaScript={Platform.OS === 'android' ? INJECT_BEFORE : undefined}
       renderError={() => <ErrorScreen onRefresh={() => {
         refToUse.current?.reload();
       }} />}

--- a/apps/mobile/bridges/ui/BridgeWebView.tsx
+++ b/apps/mobile/bridges/ui/BridgeWebView.tsx
@@ -1,6 +1,7 @@
 import WebView from 'react-native-webview';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type RefObject, useRef, useMemo, useEffect } from 'react';
+import { Platform } from 'react-native';
 import { makeOnMessage } from '../lib/onMessage';
 import { createBridgeForWebView } from '../wiring/createBridge';
 import { buildConsolePatch } from '../lib/consolePatch';
@@ -69,6 +70,7 @@ function buildSafeAreaInjector(insets: { top: number; bottom: number; left: numb
       style.setProperty('--safe-area-inset-left', '${left}px');
       style.setProperty('--safe-area-inset-right', '${right}px');
     })();
+    true;
   `;
 }
 
@@ -123,14 +125,23 @@ export function BridgeWebView({ uri, webviewRef, initialState }: Props) {
       ref={refToUse}
       source={{ uri }}
       onMessage={handleOnMessage}
-      onLoadEnd={notifyReady}
+      onLoadEnd={() => {
+        if (Platform.OS === 'android') {
+          const ref = refToUse.current;
+          if (ref) {
+            ref.injectJavaScript(buildSafeAreaInjector(insets));
+          }
+        }
+        notifyReady();
+      }}
       javaScriptEnabled
       domStorageEnabled
       originWhitelist={['*']}
       cacheEnabled
       geolocationEnabled
       webviewDebuggingEnabled={__DEV__}
-      injectedJavaScriptBeforeContentLoaded={INJECT_BEFORE}
+      injectedJavaScriptBeforeContentLoaded={Platform.OS === 'ios' ? INJECT_BEFORE : undefined}
+      injectedJavaScript={Platform.OS === 'android' ? INJECT_SAFE_AREA : undefined}
       renderError={() => <ErrorScreen onRefresh={() => {
         refToUse.current?.reload();
       }} />}

--- a/packages/bridge-core/src/error.ts
+++ b/packages/bridge-core/src/error.ts
@@ -1,17 +1,31 @@
-type BridgeErrorCode =
-  | 'ETIMEDOUT'
-  | 'ENOTFOUND'
-  | 'ECONNREFUSED'
-  | 'ECONNRESET'
-  | 'EPIPE'
-  | 'EHOSTUNREACH'
-  | 'EADDRINUSE'
-  | 'EACCES'
-  | 'EPERMISSION'
-  | 'EDESTROYED'
-  | 'EUNKNOWN'
-  | 'EINVALID'
-  | 'EUNAVAILABLE';
+/**
+ * 브릿지 에러 코드
+ *
+ * string 타입으로 정의하여 각 도메인(위치, 인증, 결제 등)에서
+ * 자유롭게 에러 코드를 정의할 수 있도록 함.
+ */
+type BridgeErrorCode = string;
+
+/**
+ * 공통 에러 코드 상수
+ *
+ * 각 도메인은 별도 파일에서 자체 에러 코드를 정의하는 것을 권장
+ */
+const COMMON_ERROR_CODES = {
+  TIMEOUT: 'ETIMEDOUT',
+  NOT_FOUND: 'ENOTFOUND',
+  CONN_REFUSED: 'ECONNREFUSED',
+  CONN_RESET: 'ECONNRESET',
+  PIPE: 'EPIPE',
+  HOST_UNREACH: 'EHOSTUNREACH',
+  ADDR_INUSE: 'EADDRINUSE',
+  ACCESS: 'EACCES',
+  PERMISSION: 'EPERMISSION',
+  DESTROYED: 'EDESTROYED',
+  UNKNOWN: 'EUNKNOWN',
+  INVALID: 'EINVALID',
+  UNAVAILABLE: 'EUNAVAILABLE',
+} as const;
 
 interface BridgeErrorShape {
   code: BridgeErrorCode;
@@ -38,4 +52,4 @@ const makeBridgeError = (code: BridgeErrorCode, message: string, extra?: Partial
   new BridgeException({ code, message, ...extra });
 
 export type { BridgeErrorCode, BridgeErrorShape };
-export { BridgeException, makeBridgeError };
+export { BridgeException, makeBridgeError, COMMON_ERROR_CODES };

--- a/packages/bridge-core/src/index.ts
+++ b/packages/bridge-core/src/index.ts
@@ -1,4 +1,4 @@
-export { METHODS } from './methods';
+export { METHODS, LOCATION_ERROR_CODES } from './methods';
 export type { BridgeEventMap } from './event-types';
 export { BRIDGE_VERSION, safeParse, makeId } from './utils';
 export type {

--- a/packages/bridge-core/src/methods.ts
+++ b/packages/bridge-core/src/methods.ts
@@ -3,7 +3,11 @@ const METHODS = {
   getSafeAreaInsets: 'device.getSafeAreaInsets',
   getCurrentLocation: 'device.getCurrentLocation',
   getLocationPermission: 'device.getLocationPermission',
-  openLocationPermissionDialog: 'device.openLocationPermissionDialog',
+  requestLocationPermission: 'device.requestLocationPermission',
+  /** 기기 위치 서비스(GPS) ON/OFF 상태 확인 */
+  isLocationServiceEnabled: 'device.isLocationServiceEnabled',
+  /** 캐시된 마지막 위치 즉시 반환 (GPS 호출 없음) */
+  getLastKnownLocation: 'device.getLastKnownLocation',
   callPhone: 'system.callPhone',
   copyToClipboard: 'system.copyToClipboard',
   share: 'system.share',
@@ -130,6 +134,33 @@ interface LocationCoords {
 
 type PermissionStatus = 'allowed' | 'denied' | 'undetermined';
 
+/**
+ * 위치 에러 코드
+ */
+const LOCATION_ERROR_CODES = {
+  /** 위치 권한 거부 */
+  PERMISSION_DENIED: 'LOCATION_PERMISSION_DENIED',
+  /** 위치 서비스(GPS) OFF */
+  SERVICE_DISABLED: 'LOCATION_SERVICE_DISABLED',
+  /** 위치 획득 불가 (실내, 지하 등) */
+  UNAVAILABLE: 'LOCATION_UNAVAILABLE',
+  /** 위치 획득 타임아웃 */
+  TIMEOUT: 'LOCATION_TIMEOUT',
+} as const;
+
+/** isLocationServiceEnabled 결과 */
+type IsLocationServiceEnabledResult = {
+  enabled: boolean;
+};
+
+/** getLastKnownLocation 파라미터 */
+type GetLastKnownLocationParams = {
+  maxAge?: number;
+};
+
+/** getLastKnownLocation 결과 */
+type GetLastKnownLocationResult = Location | null;
+
 type PickImageParams = {
   source?: 'camera' | 'library';
   allowsEditing?: boolean; // 이미지 편집 허용 여부
@@ -162,7 +193,7 @@ type GetAppVersionResult = {
   version: string;
 };
 
-export { METHODS };
+export { METHODS, LOCATION_ERROR_CODES };
 export type {
   CallPhoneParams,
   CallPhoneResult,
@@ -178,6 +209,9 @@ export type {
   Accuracy,
   Location,
   PermissionStatus,
+  IsLocationServiceEnabledResult,
+  GetLastKnownLocationParams,
+  GetLastKnownLocationResult,
   PickImageParams,
   PickImageResult,
   ImageAsset,

--- a/packages/bridge-core/src/rpc-schema.ts
+++ b/packages/bridge-core/src/rpc-schema.ts
@@ -36,7 +36,7 @@ interface RPCSchema {
     params: {};
     result: { status: PermissionStatus };
   };
-  [METHODS.openLocationPermissionDialog]: {
+  [METHODS.requestLocationPermission]: {
     params: {};
     result: { status: PermissionStatus; canAskAgain: boolean };
   };

--- a/packages/bridge-core/src/rpc-schema.ts
+++ b/packages/bridge-core/src/rpc-schema.ts
@@ -12,6 +12,9 @@ import {
   type Location,
   type PermissionStatus,
   type GetAppVersionResult,
+  type IsLocationServiceEnabledResult,
+  type GetLastKnownLocationParams,
+  type GetLastKnownLocationResult,
 } from './methods';
 
 interface RPCSchema {
@@ -39,6 +42,14 @@ interface RPCSchema {
   [METHODS.requestLocationPermission]: {
     params: {};
     result: { status: PermissionStatus; canAskAgain: boolean };
+  };
+  [METHODS.isLocationServiceEnabled]: {
+    params: {};
+    result: IsLocationServiceEnabledResult;
+  };
+  [METHODS.getLastKnownLocation]: {
+    params: GetLastKnownLocationParams;
+    result: GetLastKnownLocationResult;
   };
   [METHODS.openSettings]: {
     params: {};


### PR DESCRIPTION
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
https://jira-knockdog.atlassian.net/browse/KDDEV-311
위치 브릿지 API를 개선하고, 메인 페이지 진입 시 위치 권한을 자동으로 요청하도록 개선했습니다.

**배경:**
- 기존에는 권한 확인/요청과 위치 획득이 하나의 함수에 결합되어 있어 유연성이 떨어짐
- 사용자가 지도 화면 진입 후 여러 컴포넌트에서 개별적으로 권한/위치를 요청하여 비효율적
- GPS 위치 획득이 느려 초기 로딩 경험이 좋지 않음

**해결:**
- 권한 관련 API를 분리하고, 위치 획득 방식을 개선
- 메인 페이지 진입 시 proactive하게 권한을 요청하여 이후 컴포넌트들이 캐시된 데이터를 활용

## 작업 내용

### 1. 위치 브릿지 API 리팩토링 (Breaking Change)

**권한 관련 API 분리:**
- `getLocationPermission()`: 현재 권한 상태 확인
- `requestLocationPermission()`: 권한 요청 (앱 내 팝업)
- 기존 `getCurrentLocation()`에서 권한 로직 제거

**새로운 위치 획득 메서드:**
- `getLastKnownLocation()`: 캐시된 마지막 위치 반환 (빠름)
- `isLocationServiceEnabled()`: GPS 서비스 활성화 상태 확인

**성능 최적화:**
- async-parallel 패턴 적용:
  - 권한 확인 + 서비스 상태 확인 병렬 실행
  - lastKnown 위치 + GPS 위치 병렬 획득
- 중복 GPS 요청 방지 (deduplication)

**에러 처리 개선:**
- 도메인별 에러 코드 분리: `LOCATION_PERMISSION_DENIED`, `LOCATION_SERVICE_DISABLED`, `LOCATION_TIMEOUT` 등
- `GeolocationError`, `LocationPermissionError`, `LocationServiceError` 클래스 추가

**파일 구조:**
```
apps/knockdog/src/shared/lib/geolocation/
├── errors.ts              # 새로 추가: 에러 클래스 정의
├── permission.ts          # 새로 추가: 권한 관련 API
├── getCurrentLocation.ts  # 리팩토링: 위치 획득 로직만 담당
├── useGeolocationQuery.ts # 업데이트: 새 API 적용
└── index.ts              # 업데이트: export 정리
```

### 2. 메인 페이지 위치 권한 자동 요청

**KindergartenMainPage.tsx:**
- 페이지 진입 시 `selectedBaseType === 'CURRENT'`일 때 자동으로 권한 확인 및 요청
- 권한 획득 성공 시 `queryClient.invalidateQueries({ queryKey: ['geolocation'] })`로 위치 쿼리 무효화
- 이후 모든 컴포넌트가 React Query 캐시를 통해 위치 정보 공유

**정책 비교:**
- **메인 페이지**: 진입 시 자동 요청 (지도가 핵심 기능)
- **마이페이지**: 수동 요청 (Switch 토글 시, 현재 위치는 옵션)

### 3. 영향받는 컴포넌트 업데이트

- `PermissionSection.tsx`: 새 권한 API 사용
- `useLocationPermission.ts`: 새 권한 API 사용
- `CurrentLocationFAB.tsx`: 권한 요청 로직 제거 (상위에서 처리)
- `KindergartenList.tsx`: 타입 import 정리

### 4. 모바일 브릿지 핸들러 개선

**location.ts (React Native):**
- `getLocationPermission`, `requestLocationPermission` 핸들러 추가
- `getLastKnownLocation`, `isLocationServiceEnabled` 핸들러 추가
- 권한 체크 로직을 `getCurrentLocation`에서 분리
- iOS/Android 플랫폼별 에러 코드 매핑

**bridge-core 패키지:**
- RPC 메서드 스키마 업데이트
- `PermissionStatus` 타입 추가: `'allowed' | 'denied' | 'undetermined'`
- 에러 타입 및 코드 확장

## 논의할 점

### 1. Breaking Change 영향도
권한 관련 API가 분리되어 기존 코드가 영향을 받을 수 있습니다. 현재 파악된 범위는 모두 수정했으나, 혹시 누락된 부분이 있는지 검토 부탁드립니다.

### 2. 자동 권한 요청 정책
메인 페이지 진입 시 자동으로 권한을 요청하는 것이 UX 관점에서 적절한지 의견 부탁드립니다.
- 장점: 사용자가 지도를 사용할 때 이미 위치가 준비되어 있음
- 단점: 권한을 원하지 않는 사용자에게 부담이 될 수 있음

### 3. Error Boundary 적용
위치 관련 에러가 발생했을 때 Error Boundary에서 처리할지, 각 컴포넌트에서 개별 처리할지 논의가 필요합니다.

### 4. 성능 모니터링
- async-parallel 패턴이 실제로 성능 개선을 가져오는지 측정 필요
- `getLastKnownLocation` 캐시 hit rate 확인 필요

## 스크린샷

<!-- 위치 권한 요청 플로우 스크린샷을 추가해주세요 -->
