### PR TITLE
feat: 유치원 상세 페이지 후기 접근성 및 탭 스크롤 UX 개선

### DIFF
--- a/apps/knockdog/app/(stack)/kindergarten/[id]/page.tsx
+++ b/apps/knockdog/app/(stack)/kindergarten/[id]/page.tsx
@@ -1,9 +1,5 @@
 import { KindergartenDetailPage } from '@views/kindergarten-detail-page';
 
 export default function Page() {
-  return (
-    <div>
-      <KindergartenDetailPage />
-    </div>
-  );
+  return <KindergartenDetailPage />;
 }

--- a/apps/knockdog/app/(stack)/layout.tsx
+++ b/apps/knockdog/app/(stack)/layout.tsx
@@ -4,7 +4,7 @@ import { SafeArea } from '@shared/ui/safe-area';
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <SafeArea className='flex h-dvh flex-col' edges={['top']}>
+    <SafeArea className='flex h-dvh flex-col' edges={['top', 'bottom']}>
       {children}
     </SafeArea>
   );

--- a/apps/knockdog/app/(stack)/layout.tsx
+++ b/apps/knockdog/app/(stack)/layout.tsx
@@ -3,5 +3,9 @@
 import { SafeArea } from '@shared/ui/safe-area';
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-  return <SafeArea className='flex h-dvh flex-col'>{children}</SafeArea>;
+  return (
+    <SafeArea className='flex h-dvh flex-col' edges={['top']}>
+      {children}
+    </SafeArea>
+  );
 }

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
@@ -1,19 +1,24 @@
 import { ActionButton, Icon } from '@knockdog/ui';
 import Image from 'next/image';
 import { overlay } from 'overlay-kit';
+import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
 import {
   DeparturePointSheet,
   SERVICE_TAGS,
   ServiceBadgesTruncated,
   type KindergartenMain,
 } from '@entities/kindergarten';
+import type { BottomSheetSnapPoint } from './KindergartenItemSheet';
 
 interface KindergartenCardProps extends KindergartenMain {
   onBookmarkClick: (id: string, bookmarked: boolean) => void;
   onPhoneCall: () => void;
+  setActiveSnapPoint: (snapPoint: BottomSheetSnapPoint) => void;
 }
 
 export function KindergartenCard(props: KindergartenCardProps) {
+  const [, setActiveTab] = useKindergartenTab();
+
   const openDeparturePointSheet = () =>
     overlay.open(({ isOpen, close }) => (
       <DeparturePointSheet
@@ -22,6 +27,11 @@ export function KindergartenCard(props: KindergartenCardProps) {
         to={{ lat: props.coords.lat, lng: props.coords.lng, name: props.title }}
       />
     ));
+
+  const handleReviewClick = () => {
+    props.setActiveSnapPoint(1); // 시트 확대 (snapPoint[1])
+    setActiveTab('후기'); // 후기 탭 활성화
+  };
 
   return (
     <>
@@ -57,13 +67,13 @@ export function KindergartenCard(props: KindergartenCardProps) {
 
             {/* 리뷰 및 메모 영역 */}
             <div className='gap-x1 flex'>
-              <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-[2px]'>
+              <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-0.5'>
                 <Icon icon='Naver' className='size-x4' />
                 <span className='caption1-semibold text-text-primary text-center'>리뷰 {props.reviewCount}개</span>
               </div>
 
               {props.memo?.memoDate && (
-                <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-[2px]'>
+                <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-0.5'>
                   <Icon icon='Note' className='size-x4' />
                   <span className='caption1-semibold text-text-primary'>{props.memo.memoDate}</span>
                   <span className='caption1-semibold text-text-primary'>메모</span>
@@ -113,12 +123,12 @@ export function KindergartenCard(props: KindergartenCardProps) {
         <ActionButton variant='primaryLine' size='medium' onClick={props.onPhoneCall}>
           전화하기
         </ActionButton>
-        <ActionButton variant='primaryFill' size='medium' disabled>
-          비교하기
+        <ActionButton variant='primaryFill' size='medium' onClick={handleReviewClick}>
+          후기보기
         </ActionButton>
         <button
           aria-label='보관하기'
-          className='radius-r3 bg-fill-primary-50 flex size-[44px] shrink-0 items-center justify-center'
+          className='radius-r3 bg-fill-primary-50 flex size-11 shrink-0 items-center justify-center'
           onClick={() => props.onBookmarkClick(props.id, props.bookmarked ?? false)}
         >
           <Icon icon={props.bookmarked ? 'BookmarkFill' : 'BookmarkLine'} className='size-x6 text-fill-primary-500' />

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
@@ -1,4 +1,5 @@
 import { ActionButton, Divider, Icon } from '@knockdog/ui';
+import { useRef } from 'react';
 import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
 import { KindergartenTabs } from '@widgets/kindergarten-tabs';
 import { KindergartenMainBox, MainBannerSwiper } from '@features/kindergarten-main';
@@ -10,6 +11,7 @@ interface KindergartenDetailProps extends KindergartenMain {
 }
 
 export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: KindergartenDetailProps) {
+  const scrollableContentRef = useRef<HTMLDivElement>(null);
   const [, setActiveTab] = useKindergartenTab();
 
   const { banner: images, ...restKindergartenMainData } = props;
@@ -20,7 +22,7 @@ export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: K
 
   return (
     <div className='flex h-full flex-col bg-white'>
-      <div className='flex-1 overflow-y-auto'>
+      <div ref={scrollableContentRef} className='flex-1 overflow-y-auto'>
         <div>
           {/* 업체 메인이미지 슬라이드형 */}
           <MainBannerSwiper images={images ?? []} />
@@ -35,12 +37,12 @@ export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: K
           <Divider size='thick' />
           {/* 세부 컨텐츠 영역 */}
           {/* 탭 */}
-          <KindergartenTabs kindergartenId={props.id} />
+          <KindergartenTabs kindergartenId={props.id} scrollableDivRef={scrollableContentRef} />
         </div>
       </div>
 
       {/* 하단 고정 버튼 영역 */}
-      <div className='p-x4 gap-x2 flex shrink-0 items-center border-t border-t-gray-100 bg-white'>
+      <aside className='p-x4 gap-x2 flex shrink-0 items-center border-t border-t-gray-100 bg-white'>
         <ActionButton variant='primaryLine' size='medium' onClick={onPhoneCall}>
           전화하기
         </ActionButton>
@@ -54,7 +56,7 @@ export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: K
         >
           <Icon icon={props.bookmarked ? 'BookmarkFill' : 'BookmarkLine'} className='size-x6 text-fill-primary-500' />
         </button>
-      </div>
+      </aside>
     </div>
   );
 }

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
@@ -1,5 +1,5 @@
 import { ActionButton, Divider, Icon } from '@knockdog/ui';
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
 import { KindergartenTabs } from '@widgets/kindergarten-tabs';
 import { KindergartenMainBox, MainBannerSwiper } from '@features/kindergarten-main';
@@ -19,6 +19,13 @@ export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: K
   const handleReviewClick = () => {
     setActiveTab('후기'); // 후기 탭 활성화
   };
+
+  // DetailView가 마운트될 때 스크롤 위치를 최상단으로 초기화
+  useEffect(() => {
+    if (scrollableContentRef.current) {
+      scrollableContentRef.current.scrollTop = 0;
+    }
+  }, []);
 
   return (
     <div className='flex h-full flex-col bg-white'>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
@@ -1,4 +1,5 @@
 import { ActionButton, Divider, Icon } from '@knockdog/ui';
+import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
 import { KindergartenTabs } from '@widgets/kindergarten-tabs';
 import { KindergartenMainBox, MainBannerSwiper } from '@features/kindergarten-main';
 import type { KindergartenMain } from '@entities/kindergarten';
@@ -9,7 +10,13 @@ interface KindergartenDetailProps extends KindergartenMain {
 }
 
 export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: KindergartenDetailProps) {
+  const [, setActiveTab] = useKindergartenTab();
+
   const { banner: images, ...restKindergartenMainData } = props;
+
+  const handleReviewClick = () => {
+    setActiveTab('후기'); // 후기 탭 활성화
+  };
 
   return (
     <div className='flex h-full flex-col bg-white'>
@@ -37,8 +44,8 @@ export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: K
         <ActionButton variant='primaryLine' size='medium' onClick={onPhoneCall}>
           전화하기
         </ActionButton>
-        <ActionButton variant='primaryFill' size='medium' disabled>
-          비교하기
+        <ActionButton variant='primaryFill' size='medium' onClick={handleReviewClick}>
+          후기보기
         </ActionButton>
         <button
           aria-label='보관하기'

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -16,7 +16,8 @@ import { TOP_BAR_HEIGHT } from '@shared/constants';
 
 const MIN_SNAP_POINT_OFFSET = 328;
 
-type BottomSheetSnapPoint = ComponentProps<typeof BottomSheet.Root>['activeSnapPoint'];
+export type BottomSheetSnapPoint = ComponentProps<typeof BottomSheet.Root>['activeSnapPoint'];
+
 interface KindergartenItemSheetProps extends KindergartenListItem {
   isOpen: boolean;
   onClose: () => void;
@@ -121,6 +122,7 @@ export function KindergartenItemSheet({ coords, isOpen, onClose, ...item }: Kind
             <KindergartenItemSheetContent
               displayData={displayData}
               activeSnapPoint={activeSnapPoint}
+              setActiveSnapPoint={setActiveSnapPoint}
               visibleOpacity={visibleOpacity}
               hiddenOpacity={hiddenOpacity}
               cardY={cardY}

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheetContent.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheetContent.tsx
@@ -13,6 +13,7 @@ type BottomSheetSnapPoint = ComponentProps<typeof BottomSheet.Root>['activeSnapP
 interface KindergartenItemSheetContentProps {
   displayData?: KindergartenMain;
   activeSnapPoint: BottomSheetSnapPoint;
+  setActiveSnapPoint: (snapPoint: BottomSheetSnapPoint) => void;
   visibleOpacity: MotionValue<number>;
   hiddenOpacity: MotionValue<number>;
   cardY: MotionValue<number>;
@@ -26,6 +27,7 @@ interface KindergartenItemSheetContentProps {
 export function KindergartenItemSheetContent({
   displayData,
   activeSnapPoint,
+  setActiveSnapPoint,
   visibleOpacity,
   hiddenOpacity,
   cardY,
@@ -62,7 +64,12 @@ export function KindergartenItemSheetContent({
       >
         <BottomSheet.Handle />
         <BottomSheet.Title className='sr-only'>강아지 유치원 상세 정보</BottomSheet.Title>
-        <KindergartenCard {...displayData} onBookmarkClick={onBookmarkClick} onPhoneCall={onPhoneCall} />
+        <KindergartenCard
+          {...displayData}
+          onBookmarkClick={onBookmarkClick}
+          onPhoneCall={onPhoneCall}
+          setActiveSnapPoint={setActiveSnapPoint}
+        />
       </motion.div>
 
       <RemoveScroll forwardProps noIsolation enabled={activeSnapPoint === 1}>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenList.tsx
@@ -64,7 +64,9 @@ export function KindergartenList({ onOpenFilter, region }: KindergartenListProps
   const { error: locationError } = useGeolocationQuery({ enabled: selectedBaseType === 'CURRENT' });
   const isPermissionDenied = selectedBaseType === 'CURRENT' && locationError instanceof LocationPermissionError;
 
-  const workAlias = user?.addresses?.find((addr) => addr.type === USER_ADDRESS_TYPE.WORK)?.alias || USER_ADDRESS_TYPE_KR[USER_ADDRESS_TYPE.WORK];
+  const workAlias =
+    user?.addresses?.find((addr) => addr.type === USER_ADDRESS_TYPE.WORK)?.alias ||
+    USER_ADDRESS_TYPE_KR[USER_ADDRESS_TYPE.WORK];
 
   const handleBasePointTypeChange = (value: string) => {
     const newType = value as BasePointType;
@@ -145,10 +147,10 @@ export function KindergartenList({ onOpenFilter, region }: KindergartenListProps
   return (
     <>
       <main
-        id="test-id"
+        id='test-id'
         ref={containerRef}
         className={cn(
-          'scrollbar-hide relative flex h-full w-full flex-col',
+          'relative flex h-full w-full flex-col',
           isFullExtended ? 'overflow-y-auto' : 'min-h-full overflow-hidden'
         )}
       >
@@ -170,10 +172,11 @@ export function KindergartenList({ onOpenFilter, region }: KindergartenListProps
               {/* 고정 버튼 영역 */}
               <div className='pl-x4 flex shrink-0 items-center gap-x-2'>
                 <button
-                  className={`gap-x0.5 radius-full px-x3 py-x2 body2-semibold flex shrink-0 cursor-pointer items-center outline-[1.5] outline-offset-[-1.5px] ${isEmptyFilters
-                    ? 'outline-line-200 bg-fill-secondary-0 text-text-primary'
-                    : 'outline-line-accent bg-fill-primary-50 text-text-accent'
-                    }`}
+                  className={`gap-x0.5 radius-full px-x3 py-x2 body2-semibold flex shrink-0 cursor-pointer items-center outline-[1.5] outline-offset-[-1.5px] ${
+                    isEmptyFilters
+                      ? 'outline-line-200 bg-fill-secondary-0 text-text-primary'
+                      : 'outline-line-accent bg-fill-primary-50 text-text-accent'
+                  }`}
                   onClick={onOpenFilter}
                 >
                   <Icon

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
@@ -41,13 +41,13 @@ export function KindergartenListItem({
   return (
     <div onClick={handleClick} className='gap-x4 px-x4 py-x6 flex w-full flex-col items-center'>
       {/* 이미지 컨테이너 */}
-      <div className='relative aspect-[16/9] w-full overflow-hidden'>
+      <div className='relative aspect-video w-full overflow-hidden'>
         <BannerImageSlider id={id} name={title} slides={banner} />
         <CardBtnClipDefs id={id} />
         {/* 북마크 버튼 */}
         <button
           aria-label='보관하기'
-          className='bg-bg-0 absolute top-0 right-0 z-10 flex h-[19.9%] min-h-[32px] w-[11.17%] min-w-[32px] items-center justify-center border-0 p-0'
+          className='bg-bg-0 absolute top-0 right-0 z-10 flex h-[19.9%] min-h-8 w-[11.17%] min-w-8 items-center justify-center border-0 p-0'
           style={{ clipPath: `url(#card-btn-${id})` }}
           onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
             event.stopPropagation();
@@ -66,7 +66,7 @@ export function KindergartenListItem({
         {/* 컨텐츠 상단 영역 */}
         <div className='gap-x2 flex min-w-0 items-start justify-between self-stretch'>
           {/* 타이틀 */}
-          <div className='flex min-w-0 flex-col items-start justify-center gap-[2px]'>
+          <div className='flex min-w-0 flex-col items-start justify-center gap-0.5'>
             <h1 className='h2-extrabold text-text-primary w-full truncate'>{title}</h1>
             <p className='body2-regular text-text-tertiary w-full truncate'>
               {ctg
@@ -77,7 +77,7 @@ export function KindergartenListItem({
           </div>
 
           {/* 네이버 리뷰 badge */}
-          <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-[2px]'>
+          <div className='px-x2 py-x1 radius-r2 bg-fill-secondary-50 flex shrink-0 items-center gap-0.5'>
             <Icon icon='Naver' className='size-x4' />
             <span className='caption1-semibold text-text-primary text-center'>리뷰 {reviewCount}개</span>
           </div>

--- a/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef } from 'react';
-import { Divider, ActionButton } from '@knockdog/ui';
+import { Divider, ActionButton, Icon } from '@knockdog/ui';
 import { useParams } from 'next/navigation';
 import { overlay } from 'overlay-kit';
 import { useRecentKindergartenView } from '../model/useRecentKindergartenView';
@@ -11,7 +11,7 @@ import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
 import { Header } from '@widgets/Header';
 import { useKindergartenMainQuery, KindergartenMainBox, MainBannerSwiper } from '@features/kindergarten-main';
 import { PhoneCallSheet } from '@features/kindergarten-list';
-import { BookmarkToggleIcon } from '@entities/bookmark';
+import { useDetailBookmarkToggle } from '@features/kindergarten-list/model/useDetailBookmarkToggle';
 import { useCurrentLocation } from '@shared/lib/geolocation';
 import { useShare } from '@shared/lib/device';
 import { useNavigationResult, useStackNavigation } from '@shared/lib/bridge';
@@ -29,6 +29,7 @@ function KindergartenDetailPage() {
   const { lng, lat } = position || { lng: 126.883439, lat: 37.511281 };
 
   const { data: kindergartenMain } = useKindergartenMainQuery({ id, lng, lat });
+  const { mutate: toggleBookmark } = useDetailBookmarkToggle({ id, lng, lat });
 
   const share = useShare();
 
@@ -38,12 +39,6 @@ function KindergartenDetailPage() {
   if (lng == null || lat == null || !kindergartenMain) return null;
 
   const { banner: images, ...restKindergartenMainData } = kindergartenMain;
-
-  const openPhoneCallSheet = () => {
-    overlay.open(({ isOpen, close }) => (
-      <PhoneCallSheet phoneNumber={kindergartenMain.phoneNumber} isOpen={isOpen} close={close} />
-    ));
-  };
 
   const handleShare = () => {
     const shareData = {
@@ -62,6 +57,14 @@ function KindergartenDetailPage() {
     setActiveTab('후기'); // 후기 탭 활성화
   };
 
+  const handleBookmarkClick = (targetId: string, bookmarked: boolean) => toggleBookmark({ id: targetId, bookmarked });
+
+  const openPhoneCallSheet = () => {
+    overlay.open(({ isOpen, close }) => (
+      <PhoneCallSheet phoneNumber={kindergartenMain.phoneNumber} isOpen={isOpen} close={close} />
+    ));
+  };
+
   return (
     <>
       <Header>
@@ -76,39 +79,44 @@ function KindergartenDetailPage() {
           <Header.ShareButton onClick={handleShare} />
         </Header.RightSection>
       </Header>
-      <div className='h-[calc(100vh-206px)] overflow-y-auto' ref={scrollableDivRef}>
-        <div>
-          {/* 업체 메인이미지 슬라이드형 */}
-          <MainBannerSwiper images={images ?? []} />
-        </div>
+      <div className='flex h-[calc(100%-var(--top-bar-height))] w-full flex-col'>
+        <main className='flex-1 overflow-y-auto' ref={scrollableDivRef}>
+          <div>
+            {/* 업체 메인이미지 슬라이드형 */}
+            <MainBannerSwiper images={images ?? []} />
+          </div>
 
-        {/* 컨텐츠 영역 */}
-        <div className='relative'>
-          <div className='absolute top-[-50px]' />
-          {/* 대표 컨텐츠 영역 */}
-          <KindergartenMainBox {...restKindergartenMainData} />
-          {/* Divider */}
-          <Divider size='thick' />
-          {/* 세부 컨텐츠 영역 */}
-          {/* 탭 */}
-          <KindergartenTabs kindergartenId={id} scrollableDivRef={scrollableDivRef} />
-        </div>
-      </div>
-      {/* 하단 고정 버튼 영역 */}
-      <div className='absolute bottom-3 z-10 flex w-full items-center gap-1 bg-white p-4'>
-        <ActionButton
-          disabled={!kindergartenMain.phoneNumber}
-          variant='primaryLine'
-          className='flex-1'
-          onClick={openPhoneCallSheet}
-        >
-          전화 걸기
-        </ActionButton>
-        <ActionButton className='flex-1' onClick={handleReviewClick}>
-          후기보기
-        </ActionButton>
-
-        <BookmarkToggleIcon id={id} bookmarked={kindergartenMain?.bookmarked ?? false} />
+          {/* 컨텐츠 영역 */}
+          <div className='relative'>
+            <div className='absolute top-[-50px]' />
+            {/* 대표 컨텐츠 영역 */}
+            <KindergartenMainBox {...restKindergartenMainData} />
+            {/* Divider */}
+            <Divider size='thick' />
+            {/* 세부 컨텐츠 영역 */}
+            {/* 탭 */}
+            <KindergartenTabs kindergartenId={id} scrollableDivRef={scrollableDivRef} />
+          </div>
+        </main>
+        {/* 하단 고정 버튼 영역 */}
+        <aside className='gap-x2 p-x4 flex w-full max-w-screen-sm shrink-0 items-center border-t border-t-gray-100 bg-white'>
+          <ActionButton disabled={!kindergartenMain.phoneNumber} variant='primaryLine' onClick={openPhoneCallSheet}>
+            전화하기
+          </ActionButton>
+          <ActionButton variant='primaryFill' onClick={handleReviewClick}>
+            후기보기
+          </ActionButton>
+          <button
+            aria-label='보관하기'
+            className='radius-r3 bg-fill-primary-50 flex size-11 shrink-0 items-center justify-center'
+            onClick={() => handleBookmarkClick(kindergartenMain.id, kindergartenMain.bookmarked ?? false)}
+          >
+            <Icon
+              icon={kindergartenMain.bookmarked ? 'BookmarkFill' : 'BookmarkLine'}
+              className='size-x6 text-fill-primary-500'
+            />
+          </button>
+        </aside>
       </div>
     </>
   );

--- a/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
@@ -7,22 +7,21 @@ import { overlay } from 'overlay-kit';
 import { useRecentKindergartenView } from '../model/useRecentKindergartenView';
 
 import { KindergartenTabs } from '@widgets/kindergarten-tabs';
+import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
 import { Header } from '@widgets/Header';
 import { useKindergartenMainQuery, KindergartenMainBox, MainBannerSwiper } from '@features/kindergarten-main';
 import { PhoneCallSheet } from '@features/kindergarten-list';
 import { BookmarkToggleIcon } from '@entities/bookmark';
 import { useCurrentLocation } from '@shared/lib/geolocation';
 import { useShare } from '@shared/lib/device';
-import { SafeArea } from '@shared/ui/safe-area';
 import { useNavigationResult, useStackNavigation } from '@shared/lib/bridge';
 
 function KindergartenDetailPage() {
   const scrollableDivRef = useRef<HTMLDivElement>(null);
+  const [, setActiveTab] = useKindergartenTab();
 
-  const params = useParams();
-  const rawId = (params as Record<string, string | string[] | undefined>)?.id;
-  const id = Array.isArray(rawId) ? rawId[0] : rawId;
-  if (!id) return null;
+  const params = useParams<{ id: string }>();
+  const id = params?.id;
 
   const { back } = useStackNavigation();
   const navResult = useNavigationResult<boolean>();
@@ -33,6 +32,7 @@ function KindergartenDetailPage() {
 
   const share = useShare();
 
+  /** 최근 본 업체 저장 */
   useRecentKindergartenView(kindergartenMain);
 
   if (lng == null || lat == null || !kindergartenMain) return null;
@@ -47,10 +47,9 @@ function KindergartenDetailPage() {
 
   const handleShare = () => {
     const shareData = {
-      message: `${kindergartenMain.title}\n https://app.knockdog.net/kindergarten/${id}`,
-      url: `https://app.knockdog.net/kindergarten/${id}`,
+      message: `${kindergartenMain.title}\n ${process.env.NEXT_PUBLIC_WEB_URL}/kindergarten/${kindergartenMain.id}`,
+      url: `${process.env.NEXT_PUBLIC_WEB_URL}/kindergarten/${kindergartenMain.id}`,
     };
-
     share(shareData);
   };
 
@@ -59,8 +58,12 @@ function KindergartenDetailPage() {
     back();
   };
 
+  const handleReviewClick = () => {
+    setActiveTab('후기'); // 후기 탭 활성화
+  };
+
   return (
-    <SafeArea edges={['bottom']}>
+    <>
       <Header>
         <Header.LeftSection>
           <Header.BackButton />
@@ -88,7 +91,7 @@ function KindergartenDetailPage() {
           <Divider size='thick' />
           {/* 세부 컨텐츠 영역 */}
           {/* 탭 */}
-          <KindergartenTabs scrollableDivRef={scrollableDivRef} />
+          <KindergartenTabs kindergartenId={id} scrollableDivRef={scrollableDivRef} />
         </div>
       </div>
       {/* 하단 고정 버튼 영역 */}
@@ -101,14 +104,13 @@ function KindergartenDetailPage() {
         >
           전화 걸기
         </ActionButton>
-        {/* @TODO 비교하기 페이지로 Route */}
-        <ActionButton className='flex-1' disabled>
-          비교하기
+        <ActionButton className='flex-1' onClick={handleReviewClick}>
+          후기보기
         </ActionButton>
 
         <BookmarkToggleIcon id={id} bookmarked={kindergartenMain?.bookmarked ?? false} />
       </div>
-    </SafeArea>
+    </>
   );
 }
 

--- a/apps/knockdog/src/widgets/kindergarten-tabs/model/index.ts
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/model/index.ts
@@ -1,0 +1,1 @@
+export { useKindergartenTab } from './useKindergartenTab';

--- a/apps/knockdog/src/widgets/kindergarten-tabs/model/useKindergartenTab.ts
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/model/useKindergartenTab.ts
@@ -1,0 +1,19 @@
+import { useQueryState } from 'nuqs';
+
+/**
+ * 유치원 탭 상태를 Query String으로 관리하는 커스텀 훅
+ *
+ * @returns [activeTab, setActiveTab] - 현재 활성 탭과 탭 변경 함수
+ *
+ * @example
+ * ```tsx
+ * const [activeTab, setActiveTab] = useKindergartenTab();
+ * setActiveTab('후기'); // URL: ?tab=후기
+ * ```
+ */
+export function useKindergartenTab() {
+  return useQueryState('tab', {
+    defaultValue: '기본정보',
+    shallow: true,
+  });
+}

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Tabs, TabsList, TabsTrigger, TabsContent, Divider } from '@knockdog/ui';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback } from 'react';
 import { useKindergartenTab } from '../model';
 
 import { MemoSection } from './MemoSection';
@@ -20,23 +20,30 @@ interface KindergartenTabsProps {
 
 function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = true }: KindergartenTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
+  const isInitialMount = useRef(true);
   const [activeTab, setActiveTab] = useKindergartenTab();
   const isLoggedIn = useUserStore((state) => !!state.user);
 
-  const handleScrollToDivider = () => {
-    if (!tabsRef.current || !scrollableDivRef?.current) return;
+  const scrollToTabs = useCallback(() => {
+    const scrollContainer = scrollableDivRef?.current;
+    const tabsElement = tabsRef.current;
 
-    const headerHeight = 66;
+    if (!scrollContainer || !tabsElement) return;
 
-    const rect = tabsRef.current.getBoundingClientRect();
-    const scrollTop = scrollableDivRef.current?.scrollTop ?? 0;
-    const targetY = rect.top - headerHeight + scrollTop;
+    requestAnimationFrame(() => {
+      const tabsRect = tabsElement.getBoundingClientRect();
+      const containerRect = scrollContainer.getBoundingClientRect();
+      const scrollTop = scrollContainer.scrollTop;
 
-    scrollableDivRef.current?.scrollTo({
-      top: targetY,
-      behavior: 'smooth',
+      // 스크롤 컨테이너 내부에서 탭의 절대 위치
+      const tabOffsetInContainer = tabsRect.top - containerRect.top + scrollTop;
+
+      scrollContainer.scrollTo({
+        top: tabOffsetInContainer,
+        behavior: 'smooth',
+      });
     });
-  };
+  }, [scrollableDivRef]);
 
   const handleTabChange = async (value: string) => {
     if (value === '메모' && !isLoggedIn) {
@@ -52,6 +59,19 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
       setActiveTab('기본정보');
     }
   }, [activeTab, isLoggedIn, setActiveTab]);
+
+  // 탭 변경 시 스크롤
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+
+    if (activeTab === '기본정보') return;
+    if (!scrollableDivRef?.current) return;
+
+    scrollToTabs();
+  }, [activeTab, scrollableDivRef, scrollToTabs]);
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} ref={tabsRef}>
@@ -79,7 +99,7 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
         <PricingSection kindergartenId={kindergartenId} />
       </TabsContent>
       <TabsContent value='후기'>
-        <ReviewSection kindergartenId={kindergartenId} onScrollTop={handleScrollToDivider} />
+        <ReviewSection kindergartenId={kindergartenId} onScrollTop={scrollToTabs} />
       </TabsContent>
       <TabsContent value='메모'>
         <MemoSection kindergartenId={kindergartenId} />

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Tabs, TabsList, TabsTrigger, TabsContent, Divider } from '@knockdog/ui';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
+import { useKindergartenTab } from '../model';
 
 import { MemoSection } from './MemoSection';
 import { ReviewSection } from './ReviewSection';
@@ -19,7 +20,7 @@ interface KindergartenTabsProps {
 
 function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = true }: KindergartenTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
-  const [activeTab, setActiveTab] = useState('기본정보');
+  const [activeTab, setActiveTab] = useKindergartenTab();
   const isLoggedIn = useUserStore((state) => !!state.user);
 
   const handleScrollToDivider = () => {
@@ -50,7 +51,7 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
     if (activeTab === '메모' && !isLoggedIn) {
       setActiveTab('기본정보');
     }
-  }, [activeTab, isLoggedIn]);
+  }, [activeTab, isLoggedIn, setActiveTab]);
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} ref={tabsRef}>

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -73,6 +73,22 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
     scrollToTabs();
   }, [activeTab, scrollableDivRef, scrollToTabs]);
 
+  // 탭 컨텐츠 높이 변화 감지하여 스크롤 재조정
+  useEffect(() => {
+    const tabsElement = tabsRef.current;
+    if (!tabsElement) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      // 기본정보 탭이 아니고, 초기 마운트가 아닐 때만 스크롤 재조정
+      if (activeTab !== '기본정보' && !isInitialMount.current) {
+        scrollToTabs();
+      }
+    });
+
+    resizeObserver.observe(tabsElement);
+    return () => resizeObserver.disconnect();
+  }, [activeTab, scrollToTabs]);
+
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} ref={tabsRef}>
       <TabsList scrollable className='sticky top-0 z-101 bg-white'>


### PR DESCRIPTION
## 작업 개요

유치원 상세 페이지의 후기 접근성 및 탭 스크롤 UX를 개선했습니다.

### 주요 변경 사항
- 후기보기 버튼 클릭 시 후기 탭으로 자동 이동 및 스크롤
- 탭 변경 시 스크롤 위치 정확도 개선
- 데이터 패칭 타이밍에 따른 스크롤 오류 해결
- BottomSheet DetailView 스크롤 위치 초기화

## 작업 내용

### 1. 후기보기 버튼 → 후기 탭 자동 활성화
**파일:** `KindergartenDetailPage.tsx`, `KindergartenDetail.tsx`, `KindergartenTabs.tsx`

- Query String 기반 탭 상태 관리로 URL 공유 및 뒤로가기 지원
- `useKindergartenTab` 커스텀 훅으로 코드 중복 제거
- 후기보기 버튼 클릭 시 후기 탭으로 즉시 이동 및 스크롤

### 2. 탭 스크롤 위치 수정 및 성능 최적화
**파일:** `KindergartenTabs.tsx`, `KindergartenDetail.tsx`

**문제:**
- 스크롤 계산 시 좌표계 불일치 (`getBoundingClientRect()`: window 좌표 vs `scrollTop`: 컨테이너 좌표)
- BottomSheet DetailView에서 `scrollableDivRef` 미전달로 스크롤 미동작

**해결:**
- 좌표계 통일: `tabsRect.top - containerRect.top + scrollContainer.scrollTop`
- `requestAnimationFrame`으로 layout read 배치 처리 (성능 최적화)
- `useCallback`으로 안정적인 함수 참조 유지
- `KindergartenDetail`에 `scrollableContentRef` 추가

### 3. 데이터 패칭 타이밍 이슈 해결
**파일:** `KindergartenTabs.tsx`

**문제:**
- 탭 변경 직후 데이터 패칭 전 스크롤 계산으로 위치 부정확
- 이미지 로드 등으로 컨텐츠 높이 변경 시 스크롤 위치 틀어짐

**해결:**
- `ResizeObserver`로 탭 컨텐츠 높이 변화 감지
- 높이 변경 시 자동 스크롤 재조정
- 기본정보 탭 및 초기 마운트 시 제외 처리

### 4. DetailView 스크롤 위치 초기화
**파일:** `KindergartenDetail.tsx`

**문제:**
- BottomSheet의 DetailView는 snap point 변화로 보이거나 숨겨지지만 언마운트되지 않음
- 이전 스크롤 위치가 유지되어 DetailView 재오픈 시 스크롤된 상태로 표시

**해결:**
- 마운트 시 `scrollTop = 0`으로 초기화

### 5. 기타 리팩터링
- SafeArea 사용 위치를 `(stack)/layout`으로 이동
- stack layout safe area edges에 bottom 추가
- lint fix 적용

## 논의할 점

### 1. ResizeObserver 성능
- 탭 컨텐츠 높이 변화마다 스크롤 재조정이 발생
- 현재는 requestAnimationFrame으로 throttle 처리 중
- 추가 최적화 필요 시 debounce 고려 가능

### 2. 스크롤 애니메이션
- \`behavior: 'smooth'\` 사용 중
- ResizeObserver로 인한 추가 스크롤 발생 시 애니메이션 중복 우려
- 현재 테스트 결과 자연스러움, 문제 발생 시 조정 가능

## 스크린샷

<!-- 후기보기 버튼 클릭 → 후기 탭 이동 스크린샷 추가 예정 -->
<!-- BottomSheet DetailView 스크롤 동작 스크린샷 추가 예정 -->