### PR TITLE
feat: 비교 결과 딥링크 공유 시 좌표 기반 기준점 지원

### DIFF
--- a/apps/knockdog/src/entities/compare/api/comparisons.ts
+++ b/apps/knockdog/src/entities/compare/api/comparisons.ts
@@ -1,14 +1,23 @@
-import { KindergartenComparison, KindergartenShortInfo } from '../model/types';
+import type { KindergartenComparison, KindergartenShortInfo } from '../model/types';
+import type { Coord } from '@shared/types';
 import { api, ApiResponse } from '@shared/api';
 
 export interface ComparisonsParams {
   ids: string[];
+  basePoint?: Coord;
 }
 
-function getComparisons({ ids }: ComparisonsParams): Promise<ApiResponse<KindergartenComparison[]>> {
-  const queryString = ids.map((id) => `ids=${encodeURIComponent(id)}`).join('&');
+function getComparisons({ ids, basePoint }: ComparisonsParams): Promise<ApiResponse<KindergartenComparison[]>> {
+  const params = new URLSearchParams();
 
-  return api.get(`kindergarten/comparisons?${queryString}`).json();
+  ids.forEach((id) => params.append('ids', id));
+
+  if (basePoint) {
+    params.append('lat', basePoint.lat.toString());
+    params.append('lng', basePoint.lng.toString());
+  }
+
+  return api.get(`kindergarten/comparisons?${params.toString()}`).json();
 }
 
 interface ComparisonHistoryItem {

--- a/apps/knockdog/src/entities/compare/config/comparisonsQueryKeys.ts
+++ b/apps/knockdog/src/entities/compare/config/comparisonsQueryKeys.ts
@@ -1,14 +1,15 @@
-import { getComparisons, getComparisonHistory, deleteComparisonHistory } from '../api/comparisons';
+import { getComparisons, getComparisonHistory } from '../api/comparisons';
+import type { Coord } from '@shared/types';
 
 const comparisonsQueryKeys = {
   all: ['comparisons'] as const,
-  byIds: (ids: string[]) => [...comparisonsQueryKeys.all, ...[...ids].sort()] as const,
+  byIds: (ids: string[], basePoint?: Coord) => [...comparisonsQueryKeys.all, ...[...ids].sort(), ...(basePoint ? [basePoint.lat, basePoint.lng] : [])] as const,
   history: () => [...comparisonsQueryKeys.all, 'history'] as const,
 } as const;
 
-const createComparisonsQueryOptions = (ids: string[]) => ({
-  queryKey: comparisonsQueryKeys.byIds(ids),
-  queryFn: () => getComparisons({ ids }),
+const createComparisonsQueryOptions = (ids: string[], basePoint?: Coord) => ({
+  queryKey: comparisonsQueryKeys.byIds(ids, basePoint),
+  queryFn: () => getComparisons({ ids, basePoint }),
   enabled: ids.length > 0,
 });
 

--- a/apps/knockdog/src/entities/compare/config/comparisonsQueryKeys.ts
+++ b/apps/knockdog/src/entities/compare/config/comparisonsQueryKeys.ts
@@ -3,7 +3,8 @@ import type { Coord } from '@shared/types';
 
 const comparisonsQueryKeys = {
   all: ['comparisons'] as const,
-  byIds: (ids: string[], basePoint?: Coord) => [...comparisonsQueryKeys.all, ...[...ids].sort(), ...(basePoint ? [basePoint.lat, basePoint.lng] : [])] as const,
+  byIds: (ids: string[], basePoint?: Coord) =>
+    [...comparisonsQueryKeys.all, ...[...ids].sort(), ...(basePoint ? [basePoint.lat, basePoint.lng] : [])] as const,
   history: () => [...comparisonsQueryKeys.all, 'history'] as const,
 } as const;
 

--- a/apps/knockdog/src/entities/compare/index.ts
+++ b/apps/knockdog/src/entities/compare/index.ts
@@ -18,7 +18,7 @@ export {
 
 /** lib */
 export { parseTimeStrToMinutes, parseMinutesToTimeStr, getClosedDaysText } from './lib/formatters';
-export { resolveIds, s3ToUrl, mapToSimpleItem, getProduct, getTransitTime, getDistanceString } from './lib/utils';
+export { resolveIds, resolveCoords, s3ToUrl, mapToSimpleItem, getProduct, getTransitTime, getDistanceString } from './lib/utils';
 export { serializeCategories } from './lib/serialize';
 export { isSelectedIds } from './lib/is';
 

--- a/apps/knockdog/src/entities/compare/lib/utils.ts
+++ b/apps/knockdog/src/entities/compare/lib/utils.ts
@@ -28,9 +28,14 @@ function resolveCoords(searchParams: URLSearchParams): Coord | undefined {
   const lng = searchParams.get('lng');
 
   if (lat && lng) {
-    return { lat: Number(lat), lng: Number(lng) };
+    const latNum = Number(lat);
+    const lngNum = Number(lng);
+    
+    if (!Number.isNaN(latNum) && !Number.isNaN(lngNum)) {
+      return { lat: latNum, lng: lngNum };
+    }
   }
-  
+
   return undefined;
 }
 

--- a/apps/knockdog/src/entities/compare/lib/utils.ts
+++ b/apps/knockdog/src/entities/compare/lib/utils.ts
@@ -1,5 +1,6 @@
 import type { KindergartenComparison, ProductType, TransportationType } from '../model/compare';
 import type { SimpleComparisonItem } from '../model/compare-result';
+import { Coord } from '@shared/types';
 
 /**
  * URLSearchParams에서 유치원 ID 목록을 추출합니다.
@@ -20,6 +21,17 @@ function resolveIds(searchParams: URLSearchParams): string[] {
       .filter(Boolean);
   }
   return [];
+}
+
+function resolveCoords(searchParams: URLSearchParams): Coord | undefined {
+  const lat = searchParams.get('lat');
+  const lng = searchParams.get('lng');
+
+  if (lat && lng) {
+    return { lat: Number(lat), lng: Number(lng) };
+  }
+  
+  return undefined;
 }
 
 function s3ToUrl(s3Key?: string) {
@@ -55,4 +67,4 @@ function getDistanceString(kg?: KindergartenComparison | null, refPoint: string 
   return kg?.distance?.find((distance) => distance?.referencePoint === refPoint)?.distance ?? '-';
 }
 
-export { resolveIds, s3ToUrl, mapToSimpleItem, getProduct, getTransitTime, getDistanceString };
+export { resolveIds, resolveCoords, s3ToUrl, mapToSimpleItem, getProduct, getTransitTime, getDistanceString };

--- a/apps/knockdog/src/entities/compare/model/constants/compare.ts
+++ b/apps/knockdog/src/entities/compare/model/constants/compare.ts
@@ -35,7 +35,7 @@ const TRANSPORTATION_ICON_MAP: Record<string, IconType> = {
 const REFERENCE_POINT_TYPE = {
   HOME: '집',
   WORK: '직장',
-  // OTHER: '기타',
+  OTHER: '공유된 위치',
 } as const;
 
 const DAY_OF_WEEK_SHORT = {

--- a/apps/knockdog/src/features/compare/api/useComparisonsQuery.ts
+++ b/apps/knockdog/src/features/compare/api/useComparisonsQuery.ts
@@ -2,10 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import type { KindergartenComparison } from '@entities/compare';
 import { createComparisonsQueryOptions } from '@entities/compare';
 import { ApiResponse } from '@shared/api';
+import type { Coord } from '@shared/types';
 
-function useComparisonsQuery(ids: string[]) {
+function useComparisonsQuery(ids: string[], basePoint?: Coord) {
   return useQuery({
-    ...createComparisonsQueryOptions(ids),
+    ...createComparisonsQueryOptions(ids, basePoint),
     select: (data: ApiResponse<KindergartenComparison[]>) => data.data,
   });
 }

--- a/apps/knockdog/src/features/compare/lib/createDistanceSlides.ts
+++ b/apps/knockdog/src/features/compare/lib/createDistanceSlides.ts
@@ -1,12 +1,13 @@
-import type { KindergartenComparison, SlideProps, TransportationType } from '@entities/compare';
-import { getTransitTime, getDistanceString, REFERENCE_POINT_TYPE, TRANSPORTATION_TYPE } from '@entities/compare';
+import type { KindergartenComparison, ReferencePointType, SlideProps, TransportationType } from '@entities/compare';
+import { getTransitTime, getDistanceString, TRANSPORTATION_TYPE } from '@entities/compare';
 import { getDirectionParticle } from '@shared/utils';
 
 export function createDistanceSlides(
   left: KindergartenComparison | null,
-  right: KindergartenComparison | null
+  right: KindergartenComparison | null,
+  referencePointOptions: { value: ReferencePointType; label: string }[]
 ): SlideProps[] {
-  return Object.entries(REFERENCE_POINT_TYPE).map(([refPoint, refPointLabel]) => {
+  return referencePointOptions.map(({ value: refPoint, label: refPointLabel }) => {
     const directionParticle = getDirectionParticle(refPointLabel);
 
     const transportRows = Object.entries(TRANSPORTATION_TYPE).map(([transportType, transportTypeLabel]) => ({

--- a/apps/knockdog/src/features/compare/ui/DistanceSummary.tsx
+++ b/apps/knockdog/src/features/compare/ui/DistanceSummary.tsx
@@ -7,6 +7,7 @@ interface DistanceSummaryProps {
   shortestInfo: ShortestInfo;
   referencePointOptions: { value: ReferencePointType; label: string }[];
   referencePoint: ReferencePointType;
+  maxLabelLength?: number;
   onReferencePointChange: (value: ReferencePointType) => void;
 }
 
@@ -14,6 +15,7 @@ export function DistanceSummary({
   shortestInfo,
   referencePoint,
   referencePointOptions,
+  maxLabelLength = 5,
   onReferencePointChange,
 }: DistanceSummaryProps) {
   const transportTypeText = TRANSPORTATION_TYPE[shortestInfo.transportType];
@@ -27,7 +29,7 @@ export function DistanceSummary({
           options={referencePointOptions}
           value={referencePoint}
           onChange={onReferencePointChange}
-          maxLabelLength={5}
+          maxLabelLength={maxLabelLength}
           triggerClassName='border-b p-0'
           labelClassName='h2-extrabold'
           iconClassName='text-text-primary'

--- a/apps/knockdog/src/views/compare-complete-page/ui/CompareCompletePage.tsx
+++ b/apps/knockdog/src/views/compare-complete-page/ui/CompareCompletePage.tsx
@@ -34,7 +34,9 @@ function CompareCompletePage() {
   const [referencePoint, setReferencePoint] = useState<ReferencePointType>(coords ? 'OTHER' : 'HOME'); // URL로 공유된 위치라면 OTHER
   const addressOptions = useMemo(
     () =>
-      (savedAddresses ?? []).map(({ type, alias }) => ({
+      (savedAddresses ?? [])
+    .filter((addr): addr is UserAddress & { alias: string } => !!addr.alias)
+    .map(({ type, alias }) => ({
         value: type as ReferencePointType,
         label: alias,
       })),

--- a/apps/knockdog/src/views/compare-complete-page/ui/CompareCompletePage.tsx
+++ b/apps/knockdog/src/views/compare-complete-page/ui/CompareCompletePage.tsx
@@ -1,12 +1,21 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Header } from '@widgets/Header';
 import { CompareCompleteTabs } from '@widgets/compare-complete-tabs';
 import { useComparisonsQuery } from '@features/compare';
-import type { KindergartenComparison } from '@entities/compare';
-import { SelectedCell, serializeCategories, resolveIds, s3ToUrl } from '@entities/compare';
+import type { KindergartenComparison, ReferencePointType } from '@entities/compare';
+import {
+  SelectedCell,
+  serializeCategories,
+  resolveIds,
+  s3ToUrl,
+  resolveCoords,
+  REFERENCE_POINT_TYPE,
+} from '@entities/compare';
+import type { UserAddress } from '@entities/user';
+import { useUserStore } from '@entities/user';
 import { SafeArea } from '@shared/ui/safe-area';
 import { LoadingSpinner } from '@shared/ui/loading-spinner';
 import { useShare } from '@shared/lib/device/useShare';
@@ -14,19 +23,40 @@ import { useShare } from '@shared/lib/device/useShare';
 function CompareCompletePage() {
   const params = useSearchParams();
   const share = useShare();
+  const user = useUserStore((state) => state.user);
+  const savedAddresses = user?.addresses;
 
   // 🔒 안정화: params 객체 대신 문자열 키를 메모이즈해서 파싱
   const qsKey = params.toString();
   const ids = useMemo(() => resolveIds(new URLSearchParams(qsKey)), [qsKey]);
+  const coords = useMemo(() => resolveCoords(new URLSearchParams(qsKey)), [qsKey]);
 
-  const { data, isPending } = useComparisonsQuery(ids);
+  const [referencePoint, setReferencePoint] = useState<ReferencePointType>(coords ? 'OTHER' : 'HOME'); // URL로 공유된 위치라면 OTHER
+  const addressOptions = useMemo(
+    () =>
+      (savedAddresses ?? []).map(({ type, alias }) => ({
+        value: type as ReferencePointType,
+        label: alias,
+      })),
+    [savedAddresses]
+  );
+  const referencePointOptions = coords // URL로 공유된 위치인 경우 기준점 옵션
+    ? [{ value: 'OTHER' as ReferencePointType, label: REFERENCE_POINT_TYPE.OTHER }]
+    : addressOptions;
+
+  const { data, isPending } = useComparisonsQuery(ids, coords);
 
   const [left, right] = useMemo(() => data?.filter((item): item is KindergartenComparison => !!item) ?? [], [data]);
 
   const handleShare = () => {
-    if (!left || !right) return;
+    // 현재 기준점의 좌표를 추출
+    const selectedAddress: UserAddress | undefined =
+      user?.addresses?.find((addr) => addr.type === referencePoint) ?? user?.addresses?.[0];
 
-    const url = `https://app.knockdog.net/compare-complete?ids=${left.id},${right.id}`;
+    if (!left || !right || !selectedAddress) return;
+
+    const url = `https://app.knockdog.net/compare-complete?ids=${left.id},${right.id}&lat=${selectedAddress.lat}&lng=${selectedAddress.lng}`;
+
     const shareData = {
       message: `${left.name}와 ${right.name}의 비교 결과를 확인해보세요!\n ${url}`,
       url,
@@ -44,14 +74,16 @@ function CompareCompletePage() {
           </Header.LeftSection>
           <Header.Title>비교 결과</Header.Title>
           <Header.RightSection>
-            <button
-              type='button'
-              className='label-semibold text-text-primary px-2 py-1'
-              aria-label='비교 결과 공유하기'
-              onClick={handleShare}
-            >
-              공유하기
-            </button>
+            {!coords && (
+              <button
+                type='button'
+                className='label-semibold text-text-primary px-2 py-1'
+                aria-label='비교 결과 공유하기'
+                onClick={handleShare}
+              >
+                공유하기
+              </button>
+            )}
           </Header.RightSection>
         </Header>
 
@@ -75,7 +107,13 @@ function CompareCompletePage() {
             </div>
 
             <div className='min-h-0 flex-1'>
-              <CompareCompleteTabs left={left} right={right} />
+              <CompareCompleteTabs
+                left={left}
+                right={right}
+                referencePoint={referencePoint}
+                referencePointOptions={referencePointOptions}
+                onReferencePointChange={setReferencePoint}
+              />
             </div>
           </>
         )}

--- a/apps/knockdog/src/widgets/compare-complete-tabs/ui/CompareCompleteTabs.tsx
+++ b/apps/knockdog/src/widgets/compare-complete-tabs/ui/CompareCompleteTabs.tsx
@@ -12,16 +12,25 @@ import { PricingSection } from './PricingSection';
 import { SwipeCarousel } from './SwipeCarousel';
 import { Table } from './Table';
 import { createPricingSlides, createDistanceSlides, createOperatingScheduleSlide } from '@features/compare';
-import type { KindergartenComparison } from '@entities/compare';
+import type { KindergartenComparison, ReferencePointType } from '@entities/compare';
 
 interface CompareCompleteTabsProps {
   left: KindergartenComparison;
   right: KindergartenComparison;
+  referencePoint: ReferencePointType;
+  referencePointOptions: { value: ReferencePointType; label: string }[];
+  onReferencePointChange: (value: ReferencePointType) => void;
 }
 
-function CompareCompleteTabs({ left, right }: CompareCompleteTabsProps) {
+function CompareCompleteTabs({
+  left,
+  right,
+  referencePoint,
+  referencePointOptions,
+  onReferencePointChange,
+}: CompareCompleteTabsProps) {
   const pricingSlidesData = createPricingSlides(left, right);
-  const distanceSlidesData = createDistanceSlides(left, right);
+  const distanceSlidesData = createDistanceSlides(left, right, referencePointOptions);
   const operatingSlideData = createOperatingScheduleSlide(left, right);
 
   return (
@@ -48,7 +57,13 @@ function CompareCompleteTabs({ left, right }: CompareCompleteTabsProps) {
           <ComparisonPanel>
             {/* 거리 */}
             <ComparisonSection>
-              <DistanceSection left={left} right={right} />
+              <DistanceSection
+                left={left}
+                right={right}
+                referencePoint={referencePoint}
+                referencePointOptions={referencePointOptions}
+                onReferencePointChange={onReferencePointChange}
+              />
             </ComparisonSection>
           </ComparisonPanel>
 

--- a/apps/knockdog/src/widgets/compare-complete-tabs/ui/DistanceSection.tsx
+++ b/apps/knockdog/src/widgets/compare-complete-tabs/ui/DistanceSection.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import {
   compareDistancesByTransport,
   findShortestTransport,
@@ -7,20 +6,16 @@ import {
 } from '@features/compare';
 import type { KindergartenComparison, TransportationType, ReferencePointType } from '@entities/compare';
 import { TRANSPORTATION_TYPE, TRANSPORTATION_ICON_MAP, Label, Badge } from '@entities/compare';
-import type { UserAddress } from '@entities/user';
-import { useUserStore } from '@entities/user';
 
-function DistanceSection({ left, right }: { left: KindergartenComparison; right: KindergartenComparison }) {
-  const [referencePoint, setReferencePoint] = useState<ReferencePointType>('HOME');
-  const user = useUserStore((state) => state.user);
-  const savedAddresses = user?.addresses;
+interface DistanceSectionProps {
+  left: KindergartenComparison;
+  right: KindergartenComparison;
+  referencePoint: ReferencePointType;
+  referencePointOptions: { value: ReferencePointType; label: string }[];
+  onReferencePointChange: (value: ReferencePointType) => void;
+}
 
-  const refPointOptions = (savedAddresses ?? [])
-    .filter((addr): addr is UserAddress & { alias: string } => !!addr.alias)
-    .map(({ type, alias }) => ({
-      value: type as ReferencePointType,
-      label: alias,
-    }));
+function DistanceSection({ left, right, referencePoint, referencePointOptions, onReferencePointChange }: DistanceSectionProps) {
 
   const comparisonsByTransport = compareDistancesByTransport(left, right, referencePoint);
 
@@ -36,9 +31,10 @@ function DistanceSection({ left, right }: { left: KindergartenComparison; right:
       <Label className='mb-2'>거리</Label>
       <DistanceSummary
         shortestInfo={shortestInfo}
+        maxLabelLength={referencePoint === 'OTHER' ? 6 : 5} // OTHER='공유된 위치' 길이 고려
         referencePoint={referencePoint}
-        referencePointOptions={refPointOptions}
-        onReferencePointChange={setReferencePoint}
+        referencePointOptions={referencePointOptions}
+        onReferencePointChange={onReferencePointChange}
       />
       <div className='mt-7 flex flex-col gap-5'>
         {comparisonItems.map(({ transportType, comparison }) => (


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 비교 API(`getComparisons`)에 `basePoint(Coord)` 파라미터를 추가하여 좌표 기반 조회 지원
- URL에서 `lat`/`lng` 좌표를 추출하는 유틸함수 `resolveCoords` 추가                                                                                                                    
- 비교 결과 페이지에서 `referencePoint` 상태를 `CompareCompletePage`로 끌어올려, 딥링크 진입 시 기준점에 `OTHER`(공유된 위치) 적용
- 공유 URL에 좌표 포함