### PR TITLE
feat: map-view, main api 수정사항 반영

### DIFF
--- a/apps/knockdog/src/entities/kindergarten/model/kindergarten.ts
+++ b/apps/knockdog/src/entities/kindergarten/model/kindergarten.ts
@@ -7,7 +7,10 @@ export interface Kindergarten {
     startTime: string;
     endTime: string;
   };
-  operationDescription: string;
+  businessStatus: {
+    title: string;
+    description: string;
+  };
   operationStatus: keyof typeof OPERATION_STATUS;
   price: number;
   dist: number;

--- a/apps/knockdog/src/entities/kindergarten/model/search-list.ts
+++ b/apps/knockdog/src/entities/kindergarten/model/search-list.ts
@@ -26,7 +26,10 @@ export interface KindergartenListItemDto {
     endTime: string;
   };
   operationStatus: keyof typeof OPERATION_STATUS;
-  operationDescription: string;
+  businessStatus: {
+    title: string;
+    description: string;
+  };
   price: number;
   dist: number;
   roadAddress: string;

--- a/apps/knockdog/src/features/kindergarten-list/model/useKindergartenItemSheetData.ts
+++ b/apps/knockdog/src/features/kindergarten-list/model/useKindergartenItemSheetData.ts
@@ -14,7 +14,7 @@ function toFallbackMain(item: KindergartenListItem, fallbackCoords: { lat: numbe
     ctg: item.ctg as KindergartenMain['ctg'],
     operationTimes: item.operationTimes,
     operationStatus: item.operationStatus,
-    operationDescription: item.operationDescription,
+    businessStatus: item.businessStatus,
     price: item.price,
     dist: item.dist,
     coords: {

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
@@ -1,14 +1,9 @@
 import { ActionButton, Icon } from '@knockdog/ui';
 import Image from 'next/image';
 import { overlay } from 'overlay-kit';
-import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
-import {
-  DeparturePointSheet,
-  SERVICE_TAGS,
-  ServiceBadgesTruncated,
-  type KindergartenMain,
-} from '@entities/kindergarten';
 import type { BottomSheetSnapPoint } from './KindergartenItemSheet';
+import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
+import { DeparturePointSheet, ServiceBadgesTruncated, type KindergartenMain } from '@entities/kindergarten';
 
 interface KindergartenCardProps extends KindergartenMain {
   onBookmarkClick: (id: string, bookmarked: boolean) => void;
@@ -81,19 +76,17 @@ export function KindergartenCard(props: KindergartenCardProps) {
         {/* 영업 정보 및 주소 영역 */}
         <div className='flex flex-col gap-y-1 self-stretch'>
           <div className='grid grid-cols-[minmax(52px,max-content)_1fr] grid-rows-2 gap-x-2 gap-y-2 self-stretch'>
-            <span className='body2-extrabold text-text-accent col-start-1 row-start-1 overflow-hidden text-ellipsis whitespace-nowrap'>
-              {props.operationStatus === 'OPEN' ? '영업중' : '영업종료'}
-            </span>
-            <span className='body2-regular text-text-primary col-start-2 row-start-1 overflow-hidden text-ellipsis'>
-              {props.operationStatus === 'OPEN'
-                ? `${props.operationTimes.endTime}에 영업종료`
-                : `${props.operationTimes.startTime}에 영업시작`}
-            </span>
-            <span className='body2-extrabold text-text-primary col-start-1 row-start-2 overflow-hidden text-ellipsis whitespace-nowrap'>
+            <span className='body2-extrabold text-text-primary col-start-1 row-start-1 overflow-hidden text-ellipsis whitespace-nowrap'>
               {props.dist}
             </span>
-            <span className='body2-regular text-text-primary col-start-2 row-start-2 overflow-hidden text-ellipsis'>
+            <span className='body2-regular text-text-primary col-start-2 row-start-1 overflow-hidden text-ellipsis'>
               {props.roadAddress}
+            </span>
+            <span className='body2-extrabold text-text-accent col-start-1 row-start-2 overflow-hidden text-ellipsis whitespace-nowrap'>
+              {props.businessStatus.title}
+            </span>
+            <span className='body2-regular text-text-primary col-start-2 row-start-2 overflow-hidden text-ellipsis'>
+              {props.businessStatus.description}
             </span>
           </div>
         </div>

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenListItem.tsx
@@ -1,11 +1,7 @@
 import { Icon } from '@knockdog/ui';
 import { CardBtnClipDefs } from './CardBtnClipDefs';
 import { BannerImageSlider } from './BannerImageSlider';
-import {
-  SERVICE_TAGS,
-  ServiceBadgesTruncated,
-  type KindergartenListItem as KindergartenListItemType,
-} from '@entities/kindergarten';
+import { ServiceBadgesTruncated, type KindergartenListItem as KindergartenListItemType } from '@entities/kindergarten';
 import { useStackNavigation } from '@shared/lib/bridge';
 import { useBottomSheetSnapIndex } from '@shared/lib';
 
@@ -21,8 +17,7 @@ export function KindergartenListItem({
   dist,
   roadAddress,
   reviewCount,
-  operationStatus,
-  operationTimes,
+  businessStatus,
   price,
   serviceTags,
   pickupType,
@@ -68,12 +63,7 @@ export function KindergartenListItem({
           {/* 타이틀 */}
           <div className='flex min-w-0 flex-col items-start justify-center gap-0.5'>
             <h1 className='h2-extrabold text-text-primary w-full truncate'>{title}</h1>
-            <p className='body2-regular text-text-tertiary w-full truncate'>
-              {ctg
-                .split(',')
-                .map((tag) => SERVICE_TAGS[tag.trim() as keyof typeof SERVICE_TAGS] || tag.trim())
-                .join(' ・ ')}
-            </p>
+            <p className='body2-regular text-text-tertiary w-full truncate'>{ctg}</p>
           </div>
 
           {/* 네이버 리뷰 badge */}
@@ -87,12 +77,10 @@ export function KindergartenListItem({
         <div className='flex flex-col gap-y-1 self-stretch'>
           <div className='grid grid-cols-[minmax(52px,max-content)_1fr] grid-rows-2 gap-x-2 gap-y-2 self-stretch'>
             <span className='body2-extrabold text-text-accent col-start-1 row-start-1 overflow-hidden text-ellipsis whitespace-nowrap'>
-              {operationStatus === 'OPEN' ? '영업중' : '영업종료'}
+              {businessStatus.title}
             </span>
             <span className='body2-regular text-text-primary col-start-2 row-start-1 overflow-hidden text-ellipsis'>
-              {operationStatus === 'OPEN'
-                ? `${operationTimes.endTime}에 영업종료`
-                : `${operationTimes.startTime}에 영업시작`}
+              {businessStatus.description}
             </span>
             <span className='body2-extrabold text-text-primary col-start-1 row-start-2 overflow-hidden text-ellipsis whitespace-nowrap'>
               {dist}

--- a/apps/knockdog/src/features/kindergarten-main/ui/KindergartenMainBox.tsx
+++ b/apps/knockdog/src/features/kindergarten-main/ui/KindergartenMainBox.tsx
@@ -3,8 +3,7 @@ import { overlay } from 'overlay-kit';
 import { Icon, Divider } from '@knockdog/ui';
 import { DeparturePointSheet, ServiceBadgeList } from '@entities/kindergarten';
 
-import { OPEN_STATUS_MAP, type KindergartenMain } from '@entities/kindergarten';
-import { Skeleton } from '@shared/ui/skeleton';
+import { type KindergartenMain } from '@entities/kindergarten';
 
 interface KindergartenMainBoxProps extends Omit<KindergartenMain, 'banner'> {}
 
@@ -13,8 +12,7 @@ const KindergartenMainBox = ({
   ctg,
   dist,
   roadAddress,
-  operationStatus,
-  operationDescription,
+  businessStatus,
   price,
   serviceTags,
   reviewCount,
@@ -48,13 +46,9 @@ const KindergartenMainBox = ({
         </div>
         <div>
           <span className='body2-extrabold text-text-accent mr-1 inline-block min-w-[52px]'>
-            {OPEN_STATUS_MAP[operationStatus]}
+            {businessStatus.title}
           </span>
-          {operationDescription ? (
-            <span className='body2-regular'>{operationDescription}</span>
-          ) : (
-            <Skeleton aria-hidden='true' className='radius-r1 inline-block h-[16px] w-[160px] align-middle' />
-          )}
+          <span className='body2-regular'>{businessStatus.description}</span>
         </div>
       </div>
       {/* 뱃지 및 가격영역 */}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/KDDEV-316
- 영업상태, 영업시간 표시를 서버에서 관리하도록 변경됨
- `businessStatus`필드가 추가되어 이 값을 사용해 ui에 정보를 표시하도록 변경함.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
