### PR TITLE
fix: 딥링크로 접속 시 유치원 상세, 비교결과 페이지 뒤로가기 버튼 숨김 처리

### DIFF
--- a/apps/knockdog/src/views/compare-complete-page/ui/CompareCompletePage.tsx
+++ b/apps/knockdog/src/views/compare-complete-page/ui/CompareCompletePage.tsx
@@ -19,12 +19,14 @@ import { useUserStore } from '@entities/user';
 import { SafeArea } from '@shared/ui/safe-area';
 import { LoadingSpinner } from '@shared/ui/loading-spinner';
 import { useShare } from '@shared/lib/device/useShare';
+import { isNativeWebView } from '@shared/lib/device';
 
 function CompareCompletePage() {
   const params = useSearchParams();
   const share = useShare();
   const user = useUserStore((state) => state.user);
   const savedAddresses = user?.addresses;
+  const isNative = useMemo(() => isNativeWebView(), []);
 
   // 🔒 안정화: params 객체 대신 문자열 키를 메모이즈해서 파싱
   const qsKey = params.toString();
@@ -72,7 +74,7 @@ function CompareCompletePage() {
       <div className='flex h-screen flex-col bg-white pb-16'>
         <Header>
           <Header.LeftSection>
-            <Header.BackButton />
+            {isNative && <Header.BackButton />}
           </Header.LeftSection>
           <Header.Title>비교 결과</Header.Title>
           <Header.RightSection>

--- a/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { Divider, ActionButton, Icon } from '@knockdog/ui';
 import { useParams } from 'next/navigation';
 import { overlay } from 'overlay-kit';
@@ -13,7 +13,7 @@ import { useKindergartenMainQuery, KindergartenMainBox, MainBannerSwiper } from 
 import { PhoneCallSheet } from '@features/kindergarten-list';
 import { useDetailBookmarkToggle } from '@features/kindergarten-list/model/useDetailBookmarkToggle';
 import { useCurrentLocation } from '@shared/lib/geolocation';
-import { useShare } from '@shared/lib/device';
+import { isNativeWebView, useShare } from '@shared/lib/device';
 import { useNavigationResult, useStackNavigation } from '@shared/lib/bridge';
 
 function KindergartenDetailPage() {
@@ -32,6 +32,7 @@ function KindergartenDetailPage() {
   const { mutate: toggleBookmark } = useDetailBookmarkToggle({ id, lng, lat });
 
   const share = useShare();
+  const isNative = useMemo(() => isNativeWebView(), []);
 
   /** 최근 본 업체 저장 */
   useRecentKindergartenView(kindergartenMain);
@@ -69,8 +70,12 @@ function KindergartenDetailPage() {
     <>
       <Header>
         <Header.LeftSection>
-          <Header.BackButton />
-          <Header.HomeButton onClick={handleHomeClick} />
+          {isNative && (
+            <>
+              <Header.BackButton />
+              <Header.HomeButton onClick={handleHomeClick} />
+            </>
+          )}
         </Header.LeftSection>
 
         <Header.Title>{kindergartenMain?.title}</Header.Title>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
- 딥링크로 접속 시 다른 페이지로의 이동을 막기 위해 유치원 상세, 비교결과 페이지의 뒤로가기 버튼을 숨김 처리