### PR TITLE
refactor: 위치 권한 설정 앱 유도 방식 개선

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationFAB.tsx
+++ b/apps/knockdog/src/features/kindergarten-map/ui/CurrentLocationFAB.tsx
@@ -1,6 +1,6 @@
 import { FloatingActionButton } from '@knockdog/ui';
 import { useSearchMachine } from '../model/useSearchMachine';
-import { useGeolocationQuery } from '@shared/lib';
+import { getLocationPermission, requestLocationPermission, useGeolocationQuery, openSystemSetting } from '@shared/lib';
 import { useBasePointType } from '@shared/store';
 
 export function CurrentLocationFAB() {
@@ -11,9 +11,33 @@ export function CurrentLocationFAB() {
   const handleClick = async () => {
     setBaseType('CURRENT');
 
-    const result = await refetch();
-    if (result.data) {
-      dispatch({ type: 'BASEPOINT_SYNC', payload: { basePoint: result.data, reason: 'explicit' } });
+    try {
+      const status = await getLocationPermission();
+
+      // 권한이 없으면 요청
+      if (status !== 'allowed') {
+        const permissionResult = await requestLocationPermission();
+
+        // 권한 거부시 처리
+        if (permissionResult.status === 'denied' && !permissionResult.canAskAgain) {
+          // 더 이상 물어볼 수 없으면 설정 앱으로 유도
+          openSystemSetting();
+          return;
+        }
+
+        // 권한이 허용되지 않았으면 중단
+        if (permissionResult.status !== 'allowed') {
+          return;
+        }
+      }
+
+      // 권한이 있을 때만 위치 정보 가져오기
+      const result = await refetch();
+      if (result.data) {
+        dispatch({ type: 'BASEPOINT_SYNC', payload: { basePoint: result.data, reason: 'explicit' } });
+      }
+    } catch (error) {
+      // 권한 요청 실패 시 조용히 처리
     }
   };
 

--- a/apps/knockdog/src/shared/lib/bridge/index.ts
+++ b/apps/knockdog/src/shared/lib/bridge/index.ts
@@ -5,3 +5,4 @@ export { useNavigationResult } from './useNavigationResult';
 export { useOpenExternalLink } from './useOpenExternalLink';
 export { StackLink } from './StackLink';
 export { navigateToLogin } from './navigateToLogin';
+export { openSystemSetting } from './openSystemSetting';

--- a/apps/knockdog/src/shared/lib/geolocation/permission.ts
+++ b/apps/knockdog/src/shared/lib/geolocation/permission.ts
@@ -66,11 +66,6 @@ export async function requestLocationPermission(): Promise<{ status: PermissionS
     {}
   );
 
-  // denied + canAskAgain=false면 설정 앱으로 유도
-  if (status === 'denied' && !canAskAgain) {
-    await bridge.request('system.openSettings' as const, {});
-  }
-
   return { status, canAskAgain };
 }
 

--- a/apps/knockdog/src/shared/lib/index.ts
+++ b/apps/knockdog/src/shared/lib/index.ts
@@ -1,4 +1,5 @@
 export * from './bottom-sheet';
+export * from './bridge';
 export * from './device';
 export * from './dom';
 export * from './react';


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/Q2-65?focusedCommentId=11849

현재 위치 FAB 명시적으로 클릭 시에 위치 권한이 거부되어있으면 설정창으로 이동하도록 추가.
메인페이지 진입시 위치 권한 거부되어있을 때 설정창으로 이동하는 로직 제거.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

  - 메인 진입 → denied → 조용히 처리 (PermissionSection에서 안내)                                                                                                            
  - FAB 클릭 → denied + canAskAgain=false → 설정 앱 이동 (사용자 의도적 요청)          

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

#### 위치 권한 요청 플로우 정리
 1.  메인 페이지 진입 (자동)                                                                                                                                                                                                                                                                                                                    
  - 페이지 진입 시 자동으로 권한 확인 → 요청                                                                                                                              
  - 이미 허용됨: 재요청 안함                                                                                                                                              
  - 거부됨: 조용히 처리 (설정 앱 안 열음)                                                                                                                                 
                                                                                                                                                                             
  2. 현재 위치 FAB 클릭 (명시적)                                                                                                                                                                                                                                                                                          
  - 사용자가 명시적으로 위치 기능 요청                                                                                                                                    
  - 영구 거부됨: 설정 앱 자동 오픈 ⚠️                                                                                                                                     
  - 허용됨: 즉시 위치 조회                                                                                                                                                
                                                                                                                                                                             
  3. 설정 페이지 토글 (수동)                                                                                                                                                                                                                                                                                                            
  - 마이페이지에서 수동 제어                                                                                                                                              
  - 이미 허용/거부: 설정 앱 오픈 (변경 유도)                                                                                                                              
  - 미정: 권한 요청 다이얼로그    

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
