### PR TITLE
fix(knockdog): 메모 업데이트 오류 수정 

### DIFF
--- a/apps/knockdog/src/views/edit-memo-page/ui/EditMemoPage.tsx
+++ b/apps/knockdog/src/views/edit-memo-page/ui/EditMemoPage.tsx
@@ -46,7 +46,8 @@ export function EditMemoPage() {
   }, [memoData?.content]);
 
   const handleSave = () => {
-    updateMemo({ targetId: id, content: memo });
+    const photoKeys = memoData?.photos?.map((photo) => photo.key) ?? [];
+    updateMemo({ targetId: id, content: memo, photoKeys });
   };
 
   const originalContent = memoData?.content ?? '';


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

[JIRA 티켓](https://jira-knockdog.atlassian.net/browse/Q2-80?atlOrigin=eyJpIjoiYWI2MTMzYzY2MTZkNDkyMWI1ZmIwZDRhOTM4M2I2NmEiLCJwIjoiaiJ9)

- 메모 편집시, 이미지 삭제 되는 오류 수정 
- update시 이전 이미지 데이터도 보내주도록 수정