### PR TITLE
fix: 유치원 상세 페이지 탭 스크롤 및 상태 관리 개선

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenCard.tsx
@@ -2,17 +2,16 @@ import { ActionButton, Icon } from '@knockdog/ui';
 import Image from 'next/image';
 import { overlay } from 'overlay-kit';
 import type { BottomSheetSnapPoint } from './KindergartenItemSheet';
-import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
 import { DeparturePointSheet, ServiceBadgesTruncated, type KindergartenMain } from '@entities/kindergarten';
 
 interface KindergartenCardProps extends KindergartenMain {
   onBookmarkClick: (id: string, bookmarked: boolean) => void;
   onPhoneCall: () => void;
   setActiveSnapPoint: (snapPoint: BottomSheetSnapPoint) => void;
+  setActiveTab: (tab: string) => void;
 }
 
 export function KindergartenCard(props: KindergartenCardProps) {
-  const [, setActiveTab] = useKindergartenTab();
 
   const openDeparturePointSheet = () =>
     overlay.open(({ isOpen, close }) => (
@@ -25,7 +24,7 @@ export function KindergartenCard(props: KindergartenCardProps) {
 
   const handleReviewClick = () => {
     props.setActiveSnapPoint(1); // 시트 확대 (snapPoint[1])
-    setActiveTab('후기'); // 후기 탭 활성화
+    props.setActiveTab('후기'); // 후기 탭 활성화
   };
 
   return (

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenDetail.tsx
@@ -1,6 +1,5 @@
 import { ActionButton, Divider, Icon } from '@knockdog/ui';
-import { useRef, useEffect } from 'react';
-import { useKindergartenTab } from '@widgets/kindergarten-tabs/model';
+import { useRef } from 'react';
 import { KindergartenTabs } from '@widgets/kindergarten-tabs';
 import { KindergartenMainBox, MainBannerSwiper } from '@features/kindergarten-main';
 import type { KindergartenMain } from '@entities/kindergarten';
@@ -8,24 +7,18 @@ import type { KindergartenMain } from '@entities/kindergarten';
 interface KindergartenDetailProps extends KindergartenMain {
   onPhoneCall: () => void;
   onBookmarkClick: (id: string, bookmarked: boolean) => void;
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
 }
 
-export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: KindergartenDetailProps) {
+export function KindergartenDetail({ onPhoneCall, onBookmarkClick, activeTab, setActiveTab, ...props }: KindergartenDetailProps) {
   const scrollableContentRef = useRef<HTMLDivElement>(null);
-  const [, setActiveTab] = useKindergartenTab();
 
   const { banner: images, ...restKindergartenMainData } = props;
 
   const handleReviewClick = () => {
     setActiveTab('후기'); // 후기 탭 활성화
   };
-
-  // DetailView가 마운트될 때 스크롤 위치를 최상단으로 초기화
-  useEffect(() => {
-    if (scrollableContentRef.current) {
-      scrollableContentRef.current.scrollTop = 0;
-    }
-  }, []);
 
   return (
     <div className='flex h-full flex-col bg-white'>
@@ -44,7 +37,12 @@ export function KindergartenDetail({ onPhoneCall, onBookmarkClick, ...props }: K
           <Divider size='thick' />
           {/* 세부 컨텐츠 영역 */}
           {/* 탭 */}
-          <KindergartenTabs kindergartenId={props.id} scrollableDivRef={scrollableContentRef} />
+          <KindergartenTabs
+            kindergartenId={props.id}
+            scrollableDivRef={scrollableContentRef}
+            value={activeTab}
+            onValueChange={setActiveTab}
+          />
         </div>
       </div>
 

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -30,6 +30,7 @@ export function KindergartenItemSheet({ position, isOpen, onClose, ...item }: Ki
 
   const dynamicSnapPoints = useMemo(() => [{ type: 'content' as const, min: MIN_SNAP_POINT_OFFSET }, 1], []);
   const [activeSnapPoint, setActiveSnapPoint] = useState<BottomSheetSnapPoint>(dynamicSnapPoints[0] ?? null);
+  const [activeTab, setActiveTab] = useState('기본정보');
 
   const headerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -122,6 +123,8 @@ export function KindergartenItemSheet({ position, isOpen, onClose, ...item }: Ki
               displayData={displayData}
               activeSnapPoint={activeSnapPoint}
               setActiveSnapPoint={setActiveSnapPoint}
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
               visibleOpacity={visibleOpacity}
               hiddenOpacity={hiddenOpacity}
               cardY={cardY}

--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheetContent.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheetContent.tsx
@@ -14,6 +14,8 @@ interface KindergartenItemSheetContentProps {
   displayData?: KindergartenMain;
   activeSnapPoint: BottomSheetSnapPoint;
   setActiveSnapPoint: (snapPoint: BottomSheetSnapPoint) => void;
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
   visibleOpacity: MotionValue<number>;
   hiddenOpacity: MotionValue<number>;
   cardY: MotionValue<number>;
@@ -28,6 +30,8 @@ export function KindergartenItemSheetContent({
   displayData,
   activeSnapPoint,
   setActiveSnapPoint,
+  activeTab,
+  setActiveTab,
   visibleOpacity,
   hiddenOpacity,
   cardY,
@@ -69,6 +73,7 @@ export function KindergartenItemSheetContent({
           onBookmarkClick={onBookmarkClick}
           onPhoneCall={onPhoneCall}
           setActiveSnapPoint={setActiveSnapPoint}
+          setActiveTab={setActiveTab}
         />
       </motion.div>
 
@@ -84,7 +89,13 @@ export function KindergartenItemSheetContent({
             scale: scaleUp,
           }}
         >
-          <KindergartenDetail {...displayData} onBookmarkClick={onBookmarkClick} onPhoneCall={onPhoneCall} />
+          <KindergartenDetail
+            {...displayData}
+            onBookmarkClick={onBookmarkClick}
+            onPhoneCall={onPhoneCall}
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+          />
         </motion.div>
       </RemoveScroll>
     </>

--- a/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-main-page/ui/KindergartenMainPage.tsx
@@ -124,6 +124,7 @@ function KindergartenMainPageContent() {
 
     overlay.open(({ isOpen, unmount }) => (
       <KindergartenItemSheet
+        key={itemId}
         isOpen={isOpen}
         onClose={() => {
           if (useMarkerState.getState().activeMarkerId === itemId) {

--- a/apps/knockdog/src/widgets/kindergarten-tabs/model/index.ts
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/model/index.ts
@@ -1,1 +1,2 @@
 export { useKindergartenTab } from './useKindergartenTab';
+export { useTabScrollAlignment } from './useTabScrollAlignment';

--- a/apps/knockdog/src/widgets/kindergarten-tabs/model/useTabScrollAlignment.ts
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/model/useTabScrollAlignment.ts
@@ -1,0 +1,104 @@
+import { useRef, useEffect, useCallback, type RefObject } from 'react';
+
+/**
+ * 탭 전환 시 스크롤 정렬을 담당하는 훅
+ *
+ * - spacer 높이 계산 (짧은 컨텐츠에서 탭 헤더가 상단에 고정되도록)
+ * - ResizeObserver로 컨텐츠 변화 감지 → spacer 재계산 + 대기 중인 스크롤 실행
+ * - double-rAF fallback (동일 높이 컨텐츠 전환 등 ResizeObserver 미발생 케이스)
+ */
+export function useTabScrollAlignment(
+  scrollContainerRef: RefObject<HTMLDivElement | null> | undefined,
+  activeTab: string,
+) {
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const spacerRef = useRef<HTMLDivElement>(null);
+  const pendingScrollRef = useRef(false);
+
+  const recalculateSpacer = useCallback(() => {
+    const scrollContainer = scrollContainerRef?.current;
+    const tabsElement = tabsRef.current;
+    const spacerElement = spacerRef.current;
+    if (!scrollContainer || !tabsElement || !spacerElement) return;
+
+    const currentSpacerHeight = spacerElement.offsetHeight;
+    const tabsRect = tabsElement.getBoundingClientRect();
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const targetScrollTop = tabsRect.top - containerRect.top + scrollContainer.scrollTop;
+    const maxScrollWithoutSpacer =
+      scrollContainer.scrollHeight - currentSpacerHeight - scrollContainer.clientHeight;
+    const needed = Math.ceil(Math.max(0, targetScrollTop - maxScrollWithoutSpacer));
+
+    if (needed !== currentSpacerHeight) {
+      spacerElement.style.height = `${needed}px`;
+    }
+  }, [scrollContainerRef]);
+
+  const scrollToTabs = useCallback(() => {
+    const scrollContainer = scrollContainerRef?.current;
+    const tabsElement = tabsRef.current;
+    if (!scrollContainer || !tabsElement) return;
+
+    requestAnimationFrame(() => {
+      const tabsRect = tabsElement.getBoundingClientRect();
+      const containerRect = scrollContainer.getBoundingClientRect();
+      const scrollTop = scrollContainer.scrollTop;
+      const tabOffsetInContainer = tabsRect.top - containerRect.top + scrollTop;
+
+      scrollContainer.scrollTo({
+        top: tabOffsetInContainer,
+        behavior: 'smooth',
+      });
+    });
+  }, [scrollContainerRef]);
+
+  /** recalculateSpacer + 대기 중인 스크롤이 있으면 실행 */
+  const applyAlignment = useCallback(() => {
+    recalculateSpacer();
+
+    if (pendingScrollRef.current) {
+      pendingScrollRef.current = false;
+      scrollToTabs();
+    }
+  }, [recalculateSpacer, scrollToTabs]);
+
+  // ResizeObserver: 컨텐츠 스왑/로딩/뷰포트 변화 후 spacer 재계산 + 대기 중인 스크롤 실행
+  useEffect(() => {
+    const tabsElement = tabsRef.current;
+    const scrollContainer = scrollContainerRef?.current;
+    if (!tabsElement) return;
+
+    const observer = new ResizeObserver(() => {
+      applyAlignment();
+    });
+    observer.observe(tabsElement);
+    if (scrollContainer) {
+      observer.observe(scrollContainer);
+    }
+
+    return () => observer.disconnect();
+  }, [applyAlignment, scrollContainerRef]);
+
+  // Fallback: ResizeObserver가 미발생하는 경우 (동일 높이 컨텐츠 전환 등)
+  useEffect(() => {
+    if (!pendingScrollRef.current) return;
+
+    let cancelled = false;
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        if (cancelled || !pendingScrollRef.current) return;
+        applyAlignment();
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, applyAlignment]);
+
+  const requestScroll = useCallback(() => {
+    pendingScrollRef.current = true;
+  }, []);
+
+  return { tabsRef, spacerRef, scrollToTabs, requestScroll };
+}

--- a/apps/knockdog/src/widgets/kindergarten-tabs/model/useTabScrollAlignment.ts
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/model/useTabScrollAlignment.ts
@@ -14,6 +14,7 @@ export function useTabScrollAlignment(
   const tabsRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
   const pendingScrollRef = useRef(false);
+  const prevTabRef = useRef(activeTab);
 
   const recalculateSpacer = useCallback(() => {
     const scrollContainer = scrollContainerRef?.current;
@@ -79,6 +80,14 @@ export function useTabScrollAlignment(
     return () => observer.disconnect();
   }, [applyAlignment, scrollContainerRef]);
 
+  // activeTab 변경 감지 → pendingScroll 자동 설정 (controlled 모드에서 외부 탭 전환 대응)
+  useEffect(() => {
+    if (prevTabRef.current !== activeTab) {
+      prevTabRef.current = activeTab;
+      pendingScrollRef.current = true;
+    }
+  }, [activeTab]);
+
   // Fallback: ResizeObserver가 미발생하는 경우 (동일 높이 컨텐츠 전환 등)
   useEffect(() => {
     if (!pendingScrollRef.current) return;
@@ -96,9 +105,5 @@ export function useTabScrollAlignment(
     };
   }, [activeTab, applyAlignment]);
 
-  const requestScroll = useCallback(() => {
-    pendingScrollRef.current = true;
-  }, []);
-
-  return { tabsRef, spacerRef, scrollToTabs, requestScroll };
+  return { tabsRef, spacerRef, scrollToTabs };
 }

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Tabs, TabsList, TabsTrigger, TabsContent, Divider } from '@knockdog/ui';
-import { useRef, useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useState, useRef } from 'react';
 
 import { MemoSection } from './MemoSection';
 import { ReviewSection } from './ReviewSection';
@@ -10,6 +10,7 @@ import { BasicSection } from './BasicSection';
 import { KindergartenNearSection } from './KindergartenNearSection';
 import { useUserStore } from '@entities/user';
 import { navigateToLogin } from '@shared/lib/bridge';
+import { useTabScrollAlignment } from '../model/useTabScrollAlignment';
 
 interface KindergartenTabsProps {
   kindergartenId?: string;
@@ -26,7 +27,6 @@ function KindergartenTabs({
   value,
   onValueChange,
 }: KindergartenTabsProps) {
-  const tabsRef = useRef<HTMLDivElement>(null);
   const [uncontrolledValue, setUncontrolledValue] = useState('기본정보');
   const isControlled = value !== undefined;
   const activeTab = isControlled ? value : uncontrolledValue;
@@ -43,26 +43,10 @@ function KindergartenTabs({
     [isControlled, onValueChange]
   );
 
-  const scrollToTabs = useCallback(() => {
-    const scrollContainer = scrollableDivRef?.current;
-    const tabsElement = tabsRef.current;
-
-    if (!scrollContainer || !tabsElement) return;
-
-    requestAnimationFrame(() => {
-      const tabsRect = tabsElement.getBoundingClientRect();
-      const containerRect = scrollContainer.getBoundingClientRect();
-      const scrollTop = scrollContainer.scrollTop;
-
-      // 스크롤 컨테이너 내부에서 탭의 절대 위치
-      const tabOffsetInContainer = tabsRect.top - containerRect.top + scrollTop;
-
-      scrollContainer.scrollTo({
-        top: tabOffsetInContainer,
-        behavior: 'smooth',
-      });
-    });
-  }, [scrollableDivRef]);
+  const { tabsRef, spacerRef, scrollToTabs, requestScroll } = useTabScrollAlignment(
+    scrollableDivRef,
+    activeTab,
+  );
 
   const handleTabChange = async (value: string) => {
     if (value === '메모' && !isLoggedIn) {
@@ -70,12 +54,11 @@ function KindergartenTabs({
       return;
     }
     setActiveTab(value);
-
-    // 탭 변경 시점에 즉시 스크롤 (데이터 로딩 전에도 실행)
-    requestAnimationFrame(() => scrollToTabs());
+    requestScroll();
   };
 
   // 로그인하지 않은 상태에서 메모 탭이 활성화되어 있으면 기본정보 탭으로 변경
+  // lastAutoResetRef: 동일 탭에 대한 무한 리셋 루프 방지 가드
   useEffect(() => {
     if (activeTab === '메모' && !isLoggedIn) {
       if (lastAutoResetRef.current !== '메모') {
@@ -88,37 +71,36 @@ function KindergartenTabs({
   }, [activeTab, isLoggedIn, setActiveTab]);
 
   return (
-    <Tabs value={activeTab} onValueChange={handleTabChange} ref={tabsRef}>
-      <TabsList scrollable className='sticky top-0 z-101 bg-white'>
-        <TabsTrigger value='기본정보'>기본정보</TabsTrigger>
-        <TabsTrigger value='요금'>요금</TabsTrigger>
-        <TabsTrigger value='후기'>후기</TabsTrigger>
-        <TabsTrigger value='메모'>메모</TabsTrigger>
-      </TabsList>
-      <TabsContent value='기본정보' className='min-h-screen'>
-        <>
+    <>
+      <Tabs value={activeTab} onValueChange={handleTabChange} ref={tabsRef}>
+        <TabsList scrollable className='sticky top-0 z-101 bg-white'>
+          <TabsTrigger value='기본정보'>기본정보</TabsTrigger>
+          <TabsTrigger value='요금'>요금</TabsTrigger>
+          <TabsTrigger value='후기'>후기</TabsTrigger>
+          <TabsTrigger value='메모'>메모</TabsTrigger>
+        </TabsList>
+        <TabsContent value='기본정보'>
           <BasicSection kindergartenId={kindergartenId} />
           {showNearSection && (
             <>
-              {/* Divider */}
               <Divider size='thick' className='mb-12' />
-
-              {/* 이 근처 다른 유치원은 어때요? */}
               <KindergartenNearSection kindergartenId={kindergartenId} />
             </>
           )}
-        </>
-      </TabsContent>
-      <TabsContent value='요금' className='min-h-screen'>
-        <PricingSection kindergartenId={kindergartenId} />
-      </TabsContent>
-      <TabsContent value='후기' className='min-h-screen'>
-        <ReviewSection kindergartenId={kindergartenId} onScrollTop={scrollToTabs} />
-      </TabsContent>
-      <TabsContent value='메모' className='min-h-screen'>
-        <MemoSection kindergartenId={kindergartenId} />
-      </TabsContent>
-    </Tabs>
+        </TabsContent>
+        <TabsContent value='요금'>
+          <PricingSection kindergartenId={kindergartenId} />
+        </TabsContent>
+        <TabsContent value='후기'>
+          <ReviewSection kindergartenId={kindergartenId} onScrollTop={scrollToTabs} />
+        </TabsContent>
+        <TabsContent value='메모'>
+          <MemoSection kindergartenId={kindergartenId} />
+        </TabsContent>
+      </Tabs>
+      {/* 동적 여백: 스크롤 가능 범위가 부족할 때 필요한 최소 여백만 추가 */}
+      <div ref={spacerRef} />
+    </>
   );
 }
 

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { Tabs, TabsList, TabsTrigger, TabsContent, Divider } from '@knockdog/ui';
-import { useRef, useEffect, useCallback } from 'react';
-import { useKindergartenTab } from '../model';
+import { useRef, useEffect, useCallback, useState } from 'react';
 
 import { MemoSection } from './MemoSection';
 import { ReviewSection } from './ReviewSection';
@@ -16,12 +15,33 @@ interface KindergartenTabsProps {
   kindergartenId?: string;
   scrollableDivRef?: React.RefObject<HTMLDivElement | null>;
   showNearSection?: boolean;
+  value?: string;
+  onValueChange?: (value: string) => void;
 }
 
-function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = true }: KindergartenTabsProps) {
+function KindergartenTabs({
+  kindergartenId,
+  scrollableDivRef,
+  showNearSection = true,
+  value,
+  onValueChange,
+}: KindergartenTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
-  const [activeTab, setActiveTab] = useKindergartenTab();
+  const [uncontrolledValue, setUncontrolledValue] = useState('기본정보');
+  const isControlled = value !== undefined;
+  const activeTab = isControlled ? value : uncontrolledValue;
   const isLoggedIn = useUserStore((state) => !!state.user);
+  const lastAutoResetRef = useRef<string | null>(null);
+
+  const setActiveTab = useCallback(
+    (nextValue: string) => {
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
 
   const scrollToTabs = useCallback(() => {
     const scrollContainer = scrollableDivRef?.current;
@@ -58,8 +78,13 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
   // 로그인하지 않은 상태에서 메모 탭이 활성화되어 있으면 기본정보 탭으로 변경
   useEffect(() => {
     if (activeTab === '메모' && !isLoggedIn) {
-      setActiveTab('기본정보');
+      if (lastAutoResetRef.current !== '메모') {
+        lastAutoResetRef.current = '메모';
+        setActiveTab('기본정보');
+      }
+      return;
     }
+    lastAutoResetRef.current = null;
   }, [activeTab, isLoggedIn, setActiveTab]);
 
   return (

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -20,7 +20,6 @@ interface KindergartenTabsProps {
 
 function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = true }: KindergartenTabsProps) {
   const tabsRef = useRef<HTMLDivElement>(null);
-  const isInitialMount = useRef(true);
   const [activeTab, setActiveTab] = useKindergartenTab();
   const isLoggedIn = useUserStore((state) => !!state.user);
 
@@ -51,6 +50,9 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
       return;
     }
     setActiveTab(value);
+
+    // 탭 변경 시점에 즉시 스크롤 (데이터 로딩 전에도 실행)
+    requestAnimationFrame(() => scrollToTabs());
   };
 
   // 로그인하지 않은 상태에서 메모 탭이 활성화되어 있으면 기본정보 탭으로 변경
@@ -60,35 +62,6 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
     }
   }, [activeTab, isLoggedIn, setActiveTab]);
 
-  // 탭 변경 시 스크롤
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-
-    if (activeTab === '기본정보') return;
-    if (!scrollableDivRef?.current) return;
-
-    scrollToTabs();
-  }, [activeTab, scrollableDivRef, scrollToTabs]);
-
-  // 탭 컨텐츠 높이 변화 감지하여 스크롤 재조정
-  useEffect(() => {
-    const tabsElement = tabsRef.current;
-    if (!tabsElement) return;
-
-    const resizeObserver = new ResizeObserver(() => {
-      // 기본정보 탭이 아니고, 초기 마운트가 아닐 때만 스크롤 재조정
-      if (activeTab !== '기본정보' && !isInitialMount.current) {
-        scrollToTabs();
-      }
-    });
-
-    resizeObserver.observe(tabsElement);
-    return () => resizeObserver.disconnect();
-  }, [activeTab, scrollToTabs]);
-
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} ref={tabsRef}>
       <TabsList scrollable className='sticky top-0 z-101 bg-white'>
@@ -97,7 +70,7 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
         <TabsTrigger value='후기'>후기</TabsTrigger>
         <TabsTrigger value='메모'>메모</TabsTrigger>
       </TabsList>
-      <TabsContent value='기본정보'>
+      <TabsContent value='기본정보' className='min-h-screen'>
         <>
           <BasicSection kindergartenId={kindergartenId} />
           {showNearSection && (
@@ -111,13 +84,13 @@ function KindergartenTabs({ kindergartenId, scrollableDivRef, showNearSection = 
           )}
         </>
       </TabsContent>
-      <TabsContent value='요금'>
+      <TabsContent value='요금' className='min-h-screen'>
         <PricingSection kindergartenId={kindergartenId} />
       </TabsContent>
-      <TabsContent value='후기'>
+      <TabsContent value='후기' className='min-h-screen'>
         <ReviewSection kindergartenId={kindergartenId} onScrollTop={scrollToTabs} />
       </TabsContent>
-      <TabsContent value='메모'>
+      <TabsContent value='메모' className='min-h-screen'>
         <MemoSection kindergartenId={kindergartenId} />
       </TabsContent>
     </Tabs>

--- a/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
+++ b/apps/knockdog/src/widgets/kindergarten-tabs/ui/KindergartenTabs.tsx
@@ -43,7 +43,7 @@ function KindergartenTabs({
     [isControlled, onValueChange]
   );
 
-  const { tabsRef, spacerRef, scrollToTabs, requestScroll } = useTabScrollAlignment(
+  const { tabsRef, spacerRef, scrollToTabs } = useTabScrollAlignment(
     scrollableDivRef,
     activeTab,
   );
@@ -54,7 +54,6 @@ function KindergartenTabs({
       return;
     }
     setActiveTab(value);
-    requestScroll();
   };
 
   // 로그인하지 않은 상태에서 메모 탭이 활성화되어 있으면 기본정보 탭으로 변경


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

  유치원 상세 페이지에서 탭 전환 시 스크롤 정렬이 안 되거나, 짧은 컨텐츠 탭에서 탭 헤더가 상단에 고정되지 않는 문제를 수정합니다.
  또한 탭 상태를 query string 대신 로컬 상태(controlled/uncontrolled)로 관리하도록 변경하여, 바텀시트 내부에서 탭 상태가 공유되는 문제를 해결합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

  #### 탭 상태 관리 방식 변경
   - `useKindergartenTab` (query string 기반) → 로컬 상태 (controlled/uncontrolled) 방식으로 전환
   - `KindergartenTabs`에 `value`, `onValueChange` prop 추가하여 상위 컴포넌트에서 탭 상태 제어 가능
   - `KindergartenItemSheet` → `KindergartenItemSheetContent` → `KindergartenDetail` / `KindergartenCard`로 탭 상태를 prop drilling

   #### 탭 스크롤 정렬 로직 개선
   - 스크롤 정렬 로직을 `useTabScrollAlignment` 훅으로 추출 (spacer 계산, ResizeObserver, scroll 트리거, fallback)
   - 짧은 컨텐츠 탭에서 동적 spacer를 추가하여 탭 헤더가 상단에 고정 가능하도록 처리
   - `applyAlignment()`으로 ResizeObserver / Fallback 두 경로의 중복 코드 통합
   - `activeTab` 변경을 훅 내부에서 자동 감지하여, controlled 모드에서 외부 탭 전환 시에도 스크롤 정렬 동작

   #### 기타
   - `KindergartenItemSheet`에 `key={itemId}` 추가하여 다른 유치원 선택 시 시트 상태 초기화

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

`useTabScrollAlignment` 훅 내부 effect 순서가 동작에 영향을 줌 (activeTab 감지 effect → Fallback effect 순서 유지 필요)

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
