### PR TITLE
fix: 바텀시트 레이아웃 밀림 현상 수정

### DIFF
--- a/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
+++ b/apps/knockdog/src/features/kindergarten-list/ui/KindergartenItemSheet.tsx
@@ -84,7 +84,7 @@ export function KindergartenItemSheet({ position, isOpen, onClose, ...item }: Ki
       {/* 바텀시트 컨테이너 */}
       <div
         ref={setContainerRef}
-        className='pointer-events-none absolute bottom-0 h-[calc(100%-var(--top-bar-height)-var(--safe-area-inset-top,0px))] w-full'
+        className='pointer-events-none absolute bottom-0 h-[calc(100%-var(--top-bar-height)-var(--safe-area-inset-top,0px))] w-full overflow-hidden'
       >
         <BottomSheet.Root
           open={isOpen}


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/Q2-38
iOS WebView 환경에서 바텀시트 조작(특히 연속으로 검색할 때) 시 화면이 위로 밀리거나 레이아웃 오프셋이 발생하는 이슈를 해결합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- KindergartenItemSheet 컨테이너에 overflow hidden 값 추가하여 화면이 밀리지 않도록 설정합니다.
다음 pr과 동일한 이슈임 #344 


## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
