### PR TITLE
fix: 웹뷰 외부 입력 포커스 시 바텀시트 높이 축소 방지

### DIFF
--- a/packages/headless-ui/vaul/src/index.tsx
+++ b/packages/headless-ui/vaul/src/index.tsx
@@ -510,7 +510,13 @@ export function Root({
       if (!drawerRef.current || !repositionInputs) return;
 
       const focusedElement = document.activeElement as HTMLElement;
-      if (isInput(focusedElement) || keyboardIsOpen.current) {
+      // Only react to keyboard/viewport changes when the focused input is inside the drawer.
+      // This prevents unrelated page inputs from collapsing the drawer height.
+      const isFocusedInput = isInput(focusedElement);
+      const isFocusedInsideDrawer = !!(drawerRef.current && focusedElement && drawerRef.current.contains(focusedElement));
+      const shouldHandleViewportChange = (isFocusedInput && isFocusedInsideDrawer) || keyboardIsOpen.current;
+
+      if (shouldHandleViewportChange) {
         const visualViewportHeight = window.visualViewport?.height || 0;
         const totalHeight = window.innerHeight;
         // This is the height of the keyboard
@@ -558,6 +564,14 @@ export function Root({
           // Negative bottom value would never make sense
           drawerRef.current.style.bottom = `${Math.max(diffFromInitial, 0)}px`;
         }
+      } else if (!isMobileFirefox()) {
+        // Restore height/bottom when focus leaves inputs or keyboard closes.
+        if (initialDrawerHeight.current) {
+          drawerRef.current.style.height = `${initialDrawerHeight.current}px`;
+        } else {
+          drawerRef.current.style.removeProperty('height');
+        }
+        drawerRef.current.style.bottom = `0px`;
       }
     }
 


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/KDDEV-296
iOS 웹뷰에서 바텀시트가 재검색 시 보이지 않는 문제를 해결합니다. 

원인은 키보드 리사이즈 처리 로직이 바텀시트 외부의 input 포커스에도 반응하면서, 키보드 높이 계산에 “스냅포인트 오프셋(translate 값)”을 더해 height를 과도하게 줄이던 것이었습니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

#### vaul 라이브러리
  - `onVisualViewportChange`가 실행되는 조건을 강화했습니다.
    - 포커스된 input이 **바텀시트 내부일 때만** 처리하도록 제한
    - 외부 입력(검색창 등)으로 인한 불필요한 height 조정 차단
  - 조건이 해제되었을 때(포커스 해제/키보드 닫힘) 바텀시트의 height/bottom을 **원복**하도록 복구 로직 추가

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->
