### PR TITLE
feat: 웹/웹뷰 환경별 컨테이너 너비 사이즈 대응

### DIFF
--- a/apps/knockdog/app/(main)/(home)/@modal/(...)search/page.tsx
+++ b/apps/knockdog/app/(main)/(home)/@modal/(...)search/page.tsx
@@ -26,7 +26,7 @@ export default function Page() {
   }
   return (
     <Suspense>
-      <FloatingPortal>
+      <FloatingPortal root={document.getElementById('main')}>
         <FloatingFocusManager
           context={context}
           initialFocus={searchInputRef}
@@ -37,7 +37,7 @@ export default function Page() {
           outsideElementsInert
         >
           <RemoveScroll ref={refs.setFloating} className='z-float absolute inset-0'>
-            <SafeArea edges={['top']} className='bg-fill-secondary-0 mx-auto h-full max-w-screen-sm'>
+            <SafeArea edges={['top']} className='bg-fill-secondary-0 mx-auto h-full'>
               <SearchPage inputRef={searchInputRef} />
             </SafeArea>
           </RemoveScroll>

--- a/apps/knockdog/app/globals.css
+++ b/apps/knockdog/app/globals.css
@@ -9,6 +9,7 @@
 @theme {
   /* breakpoint */
   --breakpoint-sm: 30rem;
+  --breakpoint-md: 48rem;
 
   /* z-index */
   --z-index-float: 100;

--- a/apps/knockdog/app/layout.tsx
+++ b/apps/knockdog/app/layout.tsx
@@ -27,7 +27,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <ReactQueryProvider>
               <BridgeProvider>
                 <SyncWebViewQueryEffect />
-                <div id='root' className='relative mx-auto flex h-dvh w-screen max-w-screen-sm flex-col shadow-lg'>
+                <div
+                  id='root'
+                  className='webview:max-w-full relative mx-auto flex h-dvh w-screen max-w-120 flex-col shadow-lg'
+                >
                   <OverlayProvider>
                     {/* @TODO HeaderWrapper 추후 삭제 필요 */}
                     <HeaderWrapper />

--- a/apps/knockdog/src/shared/ui/bottom-sheet/ui/BottomSheet.tsx
+++ b/apps/knockdog/src/shared/ui/bottom-sheet/ui/BottomSheet.tsx
@@ -19,7 +19,7 @@ function BottomSheetPortal({ ...props }: React.ComponentProps<typeof BottomSheet
 }
 
 function BottomSheetOverlay({ className, ...props }: React.ComponentProps<typeof BottomSheetPrimitive.Overlay>) {
-  return <BottomSheetPrimitive.Overlay className={cn('mx-auto max-w-screen-sm', className)} {...props} />;
+  return <BottomSheetPrimitive.Overlay className={cn('webview:max-w-full mx-auto max-w-120', className)} {...props} />;
 }
 
 function BottomSheetBody({ className, ...props }: React.ComponentProps<typeof BottomSheetPrimitive.Body>) {
@@ -34,7 +34,7 @@ function BottomSheetBody({ className, ...props }: React.ComponentProps<typeof Bo
   }
   return (
     <BottomSheetPrimitive.Body
-      className={cn('mx-auto max-h-[calc(100vh-64px)] max-w-screen-sm', className)}
+      className={cn('webview:max-w-full mx-auto max-h-[calc(100vh-64px)] max-w-120', className)}
       {...props}
     />
   );

--- a/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
+++ b/apps/knockdog/src/views/kindergarten-detail-page/ui/KindergartenDetailPage.tsx
@@ -115,7 +115,7 @@ function KindergartenDetailPage() {
           </div>
         </main>
         {/* 하단 고정 버튼 영역 */}
-        <aside className='gap-x2 p-x4 flex w-full max-w-screen-sm shrink-0 items-center border-t border-t-gray-100 bg-white'>
+        <aside className='gap-x2 p-x4 flex w-full shrink-0 items-center border-t border-t-gray-100 bg-white'>
           <ActionButton disabled={!kindergartenMain.phoneNumber} variant='primaryLine' onClick={openPhoneCallSheet}>
             전화하기
           </ActionButton>

--- a/apps/knockdog/src/widgets/bottom-nav-bar/ui/BottomNavBar.tsx
+++ b/apps/knockdog/src/widgets/bottom-nav-bar/ui/BottomNavBar.tsx
@@ -16,7 +16,7 @@ function BottomNavBarContent() {
     <div className='fixed inset-x-0 bottom-0 z-99'>
       <nav
         style={{ height: `${BOTTOM_BAR_HEIGHT}px` }}
-        className='border-t-line-100 bg-bg-0 mx-auto flex w-full max-w-screen-sm border-t px-4 text-center shadow-[0px_-2px_12px_0px_rgba(0,0,0,0.05)]'
+        className='border-t-line-100 bg-bg-0 mx-auto flex w-full max-w-120 border-t px-4 text-center shadow-[0px_-2px_12px_0px_rgba(0,0,0,0.05)]'
       >
         {NAV_ITEMS.map((item) => (
           <Link key={item.href} href={item.href} className='flex flex-1 flex-col items-center justify-center gap-y-1'>


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

https://jira-knockdog.atlassian.net/browse/KDDEV-320
디바이스 사이즈가 아닌 웹/웹뷰 환경별로 컨테이너 너비 사이즈를 대응합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

웹에서 접근했을 때는 컨테이너 너비 사이즈를 480px, 웹뷰로 접근했을 때는 컨테이너 너비 사이즈를 full로 준다.

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->

<img width="1488" height="2266" alt="Simulator Screenshot - iPad mini (A17 Pro) - 2026-02-03 at 00 32 39" src="https://github.com/user-attachments/assets/312f7616-66db-4919-9c8c-e153a3a6b982" />
아이패드 미니

