### PR TITLE
fix: 견종 서비스 태그 키를 API 응답 키에 맞게 수정 (`SMALL_DOGS_ONLY` → `SMALL_DOG_ONLY`)

### DIFF
--- a/apps/knockdog/src/entities/kindergarten/config/enum.ts
+++ b/apps/knockdog/src/entities/kindergarten/config/enum.ts
@@ -19,8 +19,8 @@ const OPERATION_STATUS_TYPE = {
 
 const DOG_BREED_TYPE = {
   ALL_BREEDS: '견종무관',
-  SMALL_DOGS_ONLY: '소형견 전용',
-  MEDIUM_LARGE_DOGS_ONLY: '중대형견 전용',
+  SMALL_DOG_ONLY: '소형견 전용',
+  MEDIUM_LARGE_DOG_ONLY: '중대형견 전용',
   CAT: '고양이',
 } as const;
 

--- a/apps/knockdog/src/entities/kindergarten/model/constants/kindergarten.ts
+++ b/apps/knockdog/src/entities/kindergarten/model/constants/kindergarten.ts
@@ -1,7 +1,7 @@
 const DOG_BREED_MAP = {
   ALL_BREEDS: '견종무관',
-  SMALL_DOGS_ONLY: '소형견 전용',
-  MEDIUM_LARGE_DOGS_ONLY: '중대형견 전용',
+  SMALL_DOG_ONLY: '소형견 전용',
+  MEDIUM_LARGE_DOG_ONLY: '중대형견 전용',
 } as const;
 
 const DOG_SERVICE_MAP = {
@@ -50,8 +50,8 @@ const ALL_SERVICE_MAP = {
 
 const SERVICE_ICON_MAP = {
   ALL_BREEDS: 'Alldogs',
-  SMALL_DOGS_ONLY: 'Smalldog',
-  MEDIUM_LARGE_DOGS_ONLY: 'Largedog',
+  SMALL_DOG_ONLY: 'Smalldog',
+  MEDIUM_LARGE_DOG_ONLY: 'Largedog',
 
   DAYCARE: 'Daycare',
   HOTEL: 'Hotel',


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요
견종 서비스 태그 키를 API 응답 키에 맞게 수정
- `SMALL_DOGS_ONLY` → `SMALL_DOG_ONLY`
- `MEDIUM_LARGE_DOGS_ONLY` → `MEDIUM_LARGE_DOG_ONLY`

키 불일치로 미표시되던 견종 서비스 태그(소형견 전용, 중대형견 전용)이 아래 영역에서 정상 표시됨
- 탐색 유치원 리스트 카드: 견종 서비스 태그 배지
- 탐색 유치원 상세 페이지: 견종 서비스 태그 배지 + 기본 정보 탭의 견종 섹션 활성화 및 견종 서비스 배지
- 비교 결과 페이지: 견종 서비스 배지

## 스크린샷

<img width="409" height="63" alt="image" src="https://github.com/user-attachments/assets/d5c6b686-314a-4882-8c3c-6710fa25829a" />
<img width="425" height="125" alt="image" src="https://github.com/user-attachments/assets/2817a7e6-04f0-4d2f-87e0-c55f886c81eb" />
