### PR TITLE
setting: supportsTablet false 처리(only iPhone)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -29,7 +29,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     },
   },
   ios: {
-    supportsTablet: true,
+    supportsTablet: false,
     usesAppleSignIn: true,
     bundleIdentifier: 'net.knockdog.petcampus.v2',
     associatedDomains: [`applinks:${WEBVIEW_HOST}`],

--- a/apps/mobile/components/navigation/TabNavigator.tsx
+++ b/apps/mobile/components/navigation/TabNavigator.tsx
@@ -8,9 +8,11 @@ import MypageTab from '@/screens/mypage';
 import SaveTab from '@/screens/save';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import React from 'react';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 const Tab = createBottomTabNavigator();
 
 export default function TabNavigator() {
+  const { bottom } = useSafeAreaInsets();
   return (
     <Tab.Navigator
       screenOptions={({ route }) => {
@@ -38,14 +40,13 @@ export default function TabNavigator() {
           tabBarActiveTintColor: '#41424A',
           tabBarInactiveTintColor: '#8C8C94',
           tabBarStyle: {
-            height: 96,
-            paddingTop: 6,
-            paddingLeft: 16,
-            paddingRight: 16,
+            paddingBottom: bottom,
+            paddingLeft: 12,
+            paddingRight: 12,
           },
           tabBarLabelStyle: {
             fontSize: 12,
-            marginTop: 4
+            marginTop: 2,
           },
           headerShown: false,
         };


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

<!--주요 작업에 대한 요약을 적어주세요-->
<!-- 이 PR 내용에 대한 요약입니다. -->
<!-- 이 변경이 왜 필요한가요? 어떤 문제를 해결하나요? -->
<!-- 이 변경과 연관되는 자세한 내용을 알 수 있는 링크를 추가해주세요. (노션 등) -->

지원 플랫폼을 iPhone only로 설정합니다.
TabNavigator의 스타일을 변경합니다.

## 작업 내용

<!-- 실제 변경이 발생한 부분을 위주로 설명해주세요. -->
<!-- 필요하다면 코드 레벨의 설명도 곁들일 수 있습니다. -->

- app.config.ts에 `ios.supportsTablet: false` 처리
- TabNavigator에 safe area 하단 영역 보장

## 논의할 점

<!-- 변경 내역 중 논의가 필요하거나 의견을 구하고 싶은 점이 있으면 알려주세요. -->
<!-- 리뷰를 받고 싶은 포인트가 있으면 알려주세요. -->

## 스크린샷

<!-- 이 변경과 관련있는 스크린샷을 첨부해 주세요. -->


<img width="720"  alt="Simulator Screenshot - iPad mini (A17 Pro) - 2026-02-08 at 23 08 04" src="https://github.com/user-attachments/assets/07d7d644-91fb-46f4-b60d-7b49667dd904" />
