### PR TITLE
feat: Google Analytics 추가

### DIFF
--- a/apps/knockdog/app/layout.tsx
+++ b/apps/knockdog/app/layout.tsx
@@ -10,6 +10,8 @@ import { HeaderProvider, HeaderWrapper } from '@widgets/Header';
 import { BridgeProvider } from '@shared/lib/bridge';
 import { SyncWebViewQueryEffect } from '@shared/lib/sync-webview-query';
 
+const GA_MEASUREMENT_ID = 'G-3XK1LPFE9J';
+
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
@@ -23,6 +25,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang='ko' className={cn(suit.variable)} data-env='web' suppressHydrationWarning>
       <HeaderProvider>
         <body className='overflow-hidden'>
+          {/* Google Analytics */}
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+            strategy='afterInteractive'
+          />
+          <Script id='google-analytics' strategy='afterInteractive'>
+            {`
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', '${GA_MEASUREMENT_ID}');
+            `}
+          </Script>
           <NuqsAdapter>
             <ReactQueryProvider>
               <BridgeProvider>

--- a/apps/knockdog/src/features/auth/ui/LoginButton.tsx
+++ b/apps/knockdog/src/features/auth/ui/LoginButton.tsx
@@ -3,6 +3,7 @@
 import { Icon, IconType } from '@knockdog/ui';
 import { cn } from '@knockdog/ui/lib';
 import { useStackNavigation } from '@shared/lib/bridge';
+import { trackSignUpStart } from '@shared/lib/analytics';
 import { useLogin } from '../model/useLogin';
 
 import { SocialProvider, SOCIAL_PROVIDER_ICONS } from '@entities/social-user';
@@ -35,11 +36,16 @@ export function LoginButton({ className, provider, ...props }: LoginButtonProps)
 
   const { text, icon, styles } = BUTTON_STYLE_MAP[provider];
 
+  const handleLogin = () => {
+    trackSignUpStart(provider);
+    login(provider);
+  };
+
   return (
     <button
       type='button'
       className={cn('flex items-center justify-center gap-1 rounded-lg py-4', styles, className)}
-      onClick={() => login(provider)}
+      onClick={handleLogin}
       {...props}
     >
       <Icon icon={icon as IconType} />

--- a/apps/knockdog/src/shared/lib/analytics/events.ts
+++ b/apps/knockdog/src/shared/lib/analytics/events.ts
@@ -1,0 +1,61 @@
+import { event } from './gtag';
+
+export const AnalyticsEvent = {
+  // 회원가입 관련
+  SIGN_UP_START: 'sign_up_start',
+  SIGN_UP_NICKNAME_COMPLETED: 'sign_up_nickname_completed',
+  SIGN_UP_LOCATION_COMPLETED: 'sign_up_location_completed',
+  SIGN_UP_PET_COMPLETED: 'sign_up_pet_completed',
+  SIGN_UP_COMPLETED: 'sign_up_completed',
+
+  // 로그인 관련
+  LOGIN: 'login',
+  LOGOUT: 'logout',
+} as const;
+
+type SocialProvider = 'KAKAO' | 'GOOGLE' | 'APPLE';
+
+export const trackSignUpStart = (provider: SocialProvider) => {
+  event({
+    action: AnalyticsEvent.SIGN_UP_START,
+    category: 'engagement',
+    label: provider,
+  });
+};
+
+export const trackSignUpNicknameCompleted = () => {
+  event({
+    action: AnalyticsEvent.SIGN_UP_NICKNAME_COMPLETED,
+    category: 'engagement',
+  });
+};
+
+export const trackSignUpLocationCompleted = () => {
+  event({
+    action: AnalyticsEvent.SIGN_UP_LOCATION_COMPLETED,
+    category: 'engagement',
+  });
+};
+
+export const trackSignUpPetCompleted = () => {
+  event({
+    action: AnalyticsEvent.SIGN_UP_PET_COMPLETED,
+    category: 'engagement',
+  });
+};
+
+export const trackSignUpCompleted = (marketingConsent: boolean) => {
+  event({
+    action: AnalyticsEvent.SIGN_UP_COMPLETED,
+    category: 'engagement',
+    label: marketingConsent ? 'marketing_agreed' : 'marketing_declined',
+  });
+};
+
+export const trackLogin = (provider: SocialProvider) => {
+  event({
+    action: AnalyticsEvent.LOGIN,
+    category: 'engagement',
+    label: provider,
+  });
+};

--- a/apps/knockdog/src/shared/lib/analytics/gtag.ts
+++ b/apps/knockdog/src/shared/lib/analytics/gtag.ts
@@ -1,0 +1,33 @@
+export const GA_MEASUREMENT_ID = 'G-3XK1LPFE9J';
+
+type GTagEvent = {
+  action: string;
+  category?: string;
+  label?: string;
+  value?: number;
+  [key: string]: string | number | undefined;
+};
+
+declare global {
+  interface Window {
+    gtag: (command: string, ...args: unknown[]) => void;
+    dataLayer: unknown[];
+  }
+}
+
+export const pageview = (url: string) => {
+  if (typeof window.gtag === 'undefined') return;
+  window.gtag('config', GA_MEASUREMENT_ID, {
+    page_path: url,
+  });
+};
+
+export const event = ({ action, category, label, value, ...rest }: GTagEvent) => {
+  if (typeof window.gtag === 'undefined') return;
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value,
+    ...rest,
+  });
+};

--- a/apps/knockdog/src/shared/lib/analytics/index.ts
+++ b/apps/knockdog/src/shared/lib/analytics/index.ts
@@ -1,0 +1,2 @@
+export * from './gtag';
+export * from './events';

--- a/apps/knockdog/src/views/register/marketing-consent/ui/MarketingConsentPage.tsx
+++ b/apps/knockdog/src/views/register/marketing-consent/ui/MarketingConsentPage.tsx
@@ -6,6 +6,7 @@ import { ActionButton, Icon } from '@knockdog/ui';
 import Image from 'next/image';
 import { BottomSheet } from '@shared/ui/bottom-sheet';
 import { useStackNavigation } from '@shared/lib/bridge';
+import { trackSignUpCompleted } from '@shared/lib/analytics';
 import { route } from '@shared/constants/route';
 
 function MarketingConsentPage() {
@@ -16,10 +17,14 @@ function MarketingConsentPage() {
   const handleOpenBottomSheet = () => setIsOpen(true);
 
   /** [아니오] 버튼 클릭 */
-  const handleSkip = () => reset(route.root);
+  const handleSkip = () => {
+    trackSignUpCompleted(false);
+    reset(route.root);
+  };
 
   /** [예] 버튼 클릭 */
   const handleAgree = () => {
+    trackSignUpCompleted(true);
     // TODO: 수신 동의 로직 추가
     reset(route.root);
   };

--- a/apps/knockdog/src/views/register/user-nickname/ui/UserNicknamePage.tsx
+++ b/apps/knockdog/src/views/register/user-nickname/ui/UserNicknamePage.tsx
@@ -4,12 +4,14 @@ import { useUserStore } from '@entities/user';
 import { ActionButton, TextField, TextFieldInput } from '@knockdog/ui';
 import { route } from '@shared/constants/route';
 import { useStackNavigation } from '@shared/lib/bridge';
+import { trackSignUpNicknameCompleted } from '@shared/lib/analytics';
 
 function UserNicknamePage() {
   const user = useUserStore((state) => state.user);
   const { push } = useStackNavigation();
 
   const handleNext = () => {
+    trackSignUpNicknameCompleted();
     // TODO: 닉네임 변경 API 호출
     push({ pathname: route.register.welcome.root });
   };


### PR DESCRIPTION
## Summary
- GA4 측정 ID (G-3XK1LPFE9J) 연동
- 페이지뷰 자동 추적 활성화
- `apps/knockdog/app/layout.tsx`에 GA 스크립트 추가

## 변경 사항
- `GA_MEASUREMENT_ID` 상수 추가
- `gtag.js` 스크립트 로드 (afterInteractive)
- 페이지뷰 자동 전송 설정

## Test plan
- [ ] 로컬에서 앱 실행 후 GA 실시간 보고서에서 트래픽 확인
- [ ] 브라우저 개발자 도구 Network 탭에서 gtag.js 로드 확인
- [ ] GA 디버그 모드로 이벤트 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)