### PR TITLE
fix(mobile): 로그아웃 후 탭바 사라지는 문제 해결

### DIFF
--- a/apps/mobile/bridges/handlers/register-navigation.ts
+++ b/apps/mobile/bridges/handlers/register-navigation.ts
@@ -95,8 +95,8 @@ function toRoute(
   try {
     const urlObj = new URL(name);
     isFullUrl = true;
-    // 외부 URL인지 확인 (NEXT_PUBLIC_WEB_URL과 다른 도메인)
-    const webUrl = process.env.NEXT_PUBLIC_WEB_URL || '';
+    // 외부 URL인지 확인 (EXPO_PUBLIC_WEBVIEW_URL과 다른 도메인)
+    const webUrl = process.env.EXPO_PUBLIC_WEBVIEW_URL || '';
     isExternalUrl = urlObj.origin !== new URL(webUrl || 'http://localhost').origin;
     pathname = urlObj.pathname;
   } catch {


### PR DESCRIPTION
## Summary
- `apps/mobile/bridges/handlers/register-navigation.ts`의 `toRoute()`가 Next.js 전용 변수인 `NEXT_PUBLIC_WEB_URL`을 참조하고 있었습니다. Expo 빌드에서는 정의되지 않아 항상 빈 문자열로 평가되어, 모든 웹 URL이 외부 URL로 잘못 분류되었습니다.
- 그 결과 `MypageProfileManagePage`의 로그아웃 흐름 마지막에 호출되는 `reset({ pathname: '/' })`가 `Tabs`가 아닌 `Stack`으로 리셋되면서 루트 네비게이션 상태에 `Tabs` 스크린이 없어지고, 탭바가 영구적으로 사라지는 증상이 있었습니다.
- `EXPO_PUBLIC_WEBVIEW_URL`로 교체해 origin 비교가 정상 동작하도록 수정했습니다. 같은 변수는 이미 `useLinking.ts`, `StackScreen.tsx`에서 사용 중이므로 일관성도 맞춰집니다.

## Test plan
- [ ] 로그인 → 마이 탭 → 프로필 관리 → 로그아웃 후 홈 화면 진입 시 하단 탭바가 정상 노출되는지 확인
- [ ] 일반 페이지 push/replace 이동(상세, 검색 등)에서 동작 변화 없는지 확인
- [ ] 딥링크/탭 이동(`navigateToTab`)에 영향 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)