### PR TITLE
chore(mobile): 버전 1.0.0 → 1.0.1 패치 업

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -17,7 +17,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: '똑독',
   slug: 'petcampus',
   owner: 'petcampus',
-  version: '1.0.0',
+  version: '1.0.1',
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: 'daengv2mobile',


### PR DESCRIPTION
## Summary
- 로그아웃 후 탭바 사라지는 버그(#447) 수정 사항을 스토어 정식 리비전으로 배포하기 위한 마케팅 버전 업입니다.
- App Store는 동일 marketing version 재제출이 불가하므로 1.0.0 → 1.0.1로 올립니다. (buildNumber는 `eas.json`에 `autoIncrement: true`라 자동 처리)

## Test plan
- [ ] EAS production 빌드 정상 통과
- [ ] iOS TestFlight 업로드 후 본인 폰에서 로그아웃 흐름 검증
- [ ] Android internal track에서도 검증
- [ ] 검증 OK 후 정식 스토어 제출

🤖 Generated with [Claude Code](https://claude.com/claude-code)