### PR TITLE
revert: "chore(mobile): 버전 1.0.0 → 1.0.1 패치 업" (#448)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -17,7 +17,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   name: '똑독',
   slug: 'petcampus',
   owner: 'petcampus',
-  version: '1.0.1',
+  version: '1.0.0',
   orientation: 'portrait',
   icon: './assets/images/icon.png',
   scheme: 'daengv2mobile',


### PR DESCRIPTION
## Summary
- #448에서 모바일 마케팅 버전을 1.0.0 → 1.0.1로 올렸으나, 실제 EAS 빌드/스토어 제출이 동반되지 않은 상태에서의 단독 bump였습니다.
- 다음 모바일 리비전이 떠지기 전에 다른 변경이 들어가면 1.0.1이 어떤 변경분을 담은 버전인지 모호해지는 문제가 있어 되돌립니다.
- 마케팅 버전 bump는 **실제 빌드 직전 시점**에 다시 진행하는 것이 정석입니다.

## Test plan
- [ ] develop의 `apps/mobile/app.config.ts`가 다시 1.0.0인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)