### PR TITLE
fix(knockdog): 로그아웃 후 탭바 사라지는 문제 — 웹측 우회

### DIFF
--- a/apps/knockdog/src/views/mypage-profile-manage-page/ui/MypageProfileManagePage.tsx
+++ b/apps/knockdog/src/views/mypage-profile-manage-page/ui/MypageProfileManagePage.tsx
@@ -27,11 +27,12 @@ import { DogSelectSheet } from '@features/dog-profile';
 import { usePetRepresentativeQuery, RELATIONSHIP_LABEL, usePetListQuery } from '@entities/pet';
 import { useUserInfoQuery, useUserStore, useUserUpdateUserEmailMutation } from '@entities/user';
 import { useSocialUserStore, SOCIAL_PROVIDER_ICONS } from '@entities/social-user';
-import { useStackNavigation } from '@shared/lib/bridge';
+import { useStackNavigation, useTabNavigation } from '@shared/lib/bridge';
 import { logout } from '@shared/lib/auth/logout';
 
 function MypageProfileManagePage() {
-  const { push, reset } = useStackNavigation();
+  const { push } = useStackNavigation();
+  const { navigateToTab } = useTabNavigation();
   const queryClient = useQueryClient();
   const [isEditingEmail, setIsEditingEmail] = useState(false);
   const [email, setEmail] = useState('');
@@ -71,7 +72,7 @@ function MypageProfileManagePage() {
                 try {
                   await logout();
                 } finally {
-                  reset();
+                  await navigateToTab('/');
                 }
               }}
             >


### PR DESCRIPTION
## Summary
- 로그아웃 처리 후 호출하던 \`useStackNavigation.reset({pathname:'/'})\`을 \`useTabNavigation.navigateToTab('/')\`으로 교체.
- 기존 흐름은 웹이 풀 URL(\`https://app.knockdog.net/\`)을 \`navReset\`으로 native에 보냈고, 모바일 \`toRoute()\`가 origin 비교에 잘못된 env 변수(\`NEXT_PUBLIC_WEB_URL\`)를 참조해 외부 URL로 오판 → Stack 분기 → 루트 네비게이션이 \`[Stack(/)]\`이 되어 탭바가 사라졌습니다.
- native fix(#447)는 다음 모바일 리비전 배포까지 사용자 폰에 반영되지 않아, 웹에서 \`navReset\` 경로 자체를 우회합니다. \`navSwitchTab\`은 동일 native 핸들러에서 env 변수에 의존하지 않고 pathname → tabName 직접 매핑으로 동작하므로 안전합니다.

## Impact
- 웹 배포만으로 즉시 적용. App Store / Play Store 심사 불필요.
- v1, v2 모바일 모두 동일 웹을 WebView로 로드하므로 양쪽 모두 효과.

## Test plan
- [ ] 모바일에서 로그인 → 마이 → 프로필 관리 → 로그아웃 → 홈 진입 시 탭바 정상 노출 확인
- [ ] 웹 브라우저에서도 동일 흐름이 정상 동작하는지 확인 (router.push로 폴백)
- [ ] 로그아웃 직후 진입한 홈에서 비로그인 상태 UI(LoginPrompt 등) 정상 노출 확인

## Notes
- 동일 패턴(\`reset({pathname: '/'})\`)을 다른 곳에서 쓰는지 추가 점검 가치 있음. 현재 변경은 logout 경로 한 군데만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)