### PR TITLE
fix(knockdog): 줌아웃 시 searchLock 자동 해제 (집계 마커 노출 트랩)

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
+++ b/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
@@ -283,10 +283,19 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
 
       /**
        * 우선순위 1)
-       * bounds + lock=1 상태는 자동 전이 금지
-       * (L3 → L2 줌아웃 포함)
+       * bounds + lock=1 상태는 자동 전이 금지.
+       * 단, L3 영역 밖(L1/L2)으로 줌아웃하면 lock을 해제하고
+       * 현재 viewport로 검색 영역을 갱신해 집계 마커가 정상 노출되도록 한다.
        */
       if (nextState.scope === 'bounds' && nextState.searchLock === 1) {
+        if (to < 3) {
+          return {
+            ...nextState,
+            searchLock: 0,
+            searchedLevel: to,
+            searchBounds: viewportBounds ?? nextState.searchBounds,
+          };
+        }
         return nextState;
       }
 


### PR DESCRIPTION
## Summary
- L2 → L3 줌인 시 자동으로 켜진 \`searchLock=1\`이 줌아웃해도 풀리지 않아, 서울 전체가 보일 정도로 줌아웃해도 집계 마커가 비노출되고 점 마커가 계속 그려지는 버그.
- \`MAP_INTERACTION_END\` 전이의 우선순위 1 동결 규칙에 예외 추가: 줌이 L3 미만으로 떨어지면 \`searchLock=0\`, \`searchedLevel\`/\`searchBounds\`를 현재 값으로 갱신.

## Bug trace
1. 앱 진입(zoom 15, L3, lock=0) → 점 마커 (정상)
2. 줌 아웃 to L2/L1 → 집계 마커 (정상)
3. 다시 줌 인 12 → 13(L2→L3) → \`searchLock=1\` 자동 켜짐 (\`searchMachine.ts:297-307\`)
4. 다시 줌 아웃 → 우선순위 1에서 동결되어 \`searchLock=1\`이 유지 → \`showAggregationMarkers=false\` → **여기서 막힘**
5. URL에도 \`searchLock=1\`이 박혀 새로고침해도 동일

## Fix
\`\`\`ts
if (nextState.scope === 'bounds' && nextState.searchLock === 1) {
  if (to < 3) {
    return {
      ...nextState,
      searchLock: 0,
      searchedLevel: to,
      searchBounds: viewportBounds ?? nextState.searchBounds,
    };
  }
  return nextState;
}
\`\`\`

L2→L3 자동 lock 자체는 유지(영역 한정 검색 의도 보존), 줌아웃 케이스만 풀어줌.

## Test plan
- [ ] 진입 직후 줌아웃 → 집계 마커 정상 노출 (이미 동작하던 케이스 회귀 없음)
- [ ] 줌인 12→13으로 lock 켠 뒤 다시 줌아웃 → 집계 마커 노출 확인
- [ ] URL 쿼리에 \`searchLock=1\`이 박힌 채 새로고침 → 줌아웃 시 정상 해제 확인
- [ ] \"현 지도에서 검색\" 버튼으로 명시 lock한 경우 → L3 안에서는 lock 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)