### PR TITLE
revert: "fix(knockdog): 줌아웃 시 searchLock 자동 해제" (#451)

### DIFF
--- a/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
+++ b/apps/knockdog/src/features/kindergarten-map/lib/searchMachine.ts
@@ -283,19 +283,10 @@ export function transition(current: SearchState, event: SearchEvent, ctx: Search
 
       /**
        * 우선순위 1)
-       * bounds + lock=1 상태는 자동 전이 금지.
-       * 단, L3 영역 밖(L1/L2)으로 줌아웃하면 lock을 해제하고
-       * 현재 viewport로 검색 영역을 갱신해 집계 마커가 정상 노출되도록 한다.
+       * bounds + lock=1 상태는 자동 전이 금지
+       * (L3 → L2 줌아웃 포함)
        */
       if (nextState.scope === 'bounds' && nextState.searchLock === 1) {
-        if (to < 3) {
-          return {
-            ...nextState,
-            searchLock: 0,
-            searchedLevel: to,
-            searchBounds: viewportBounds ?? nextState.searchBounds,
-          };
-        }
         return nextState;
       }
 


### PR DESCRIPTION
## Summary
- #451 머지 후 줌아웃 시 데이터가 아예 표시되지 않는 회귀 발생.
- 점 마커도 안 보이고 집계 마커도 안 보임 → revert로 즉시 원상복구.

## 추정 원인 (추후 별도 PR로 정리)
- #451은 \`searchLock=1\`을 풀고 \`scope='bounds'\`를 유지한 채 \`searchBounds\`를 현재 viewport(서울 전체)로 갱신.
- 그 결과 점 마커는 사라졌으나, 집계 마커도 \`useAggregationQuery\`에서 빈 배열로 잡힘.
- 의심 지점: \`sigunAggregations || sidoAggregations || []\` 폴백. 빈 배열은 truthy이므로 서버가 \`{sigunAggregations: [], sidoAggregations: [...]}\` 형태로 응답하면 빈 시군 집계를 골라버려 화면이 0건이 됨.
- 또는 서버가 새 파라미터 조합(scope=bounds + 서울 전체 bounds + zoom=10)에 대해 의도한 응답을 주지 않을 가능성.

## 다음 단계
- 실제 API 응답 확인 후 \`useAggregationQuery\` 폴백 로직 및 scope/bounds 처리 다시 설계.
- 그 다음 #451의 의도(L3 lock의 줌아웃 해제)를 안전하게 다시 도입.

🤖 Generated with [Claude Code](https://claude.com/claude-code)