### PR TITLE
fix(auth): 소셜 로그인 name 폴백 및 OIDC 실패 토스트 추가

### DIFF
--- a/apps/knockdog/src/features/auth/model/useLogin.ts
+++ b/apps/knockdog/src/features/auth/model/useLogin.ts
@@ -18,6 +18,7 @@ import { STORAGE_KEYS } from '@shared/constants';
 import { TypedStorage } from '@shared/lib';
 import { route } from '@shared/constants/route';
 import { useBridge, useStackNavigation, useNavigationResult } from '@shared/lib/bridge';
+import { toast } from '@shared/ui/toast';
 
 const SOCIAL_LOGIN_METHOD_MAP = {
   [SOCIAL_PROVIDER.KAKAO]: METHODS.kakaoLogin,
@@ -42,14 +43,27 @@ export const useLogin = (options?: { redirectTo?: string }) => {
 
   /** OIDC 인증 */
   const oidcAuth = async (provider: SocialProvider) => {
-    const response = await bridge.request<SocialLoginResult>(SOCIAL_LOGIN_METHOD_MAP[provider], undefined, {
-      timeoutMs: 120_000,
-    });
+    try {
+      const response = await bridge.request<SocialLoginResult>(SOCIAL_LOGIN_METHOD_MAP[provider], undefined, {
+        timeoutMs: 120_000,
+      });
 
-    // OIDC 검증 요청 (IDToken)
-    const { code } = await oidcMutateAsync({ provider, ...response }, { onSuccess: ({ data }) => setSocialUser(data) });
+      // OIDC 검증 요청 (IDToken)
+      const { code } = await oidcMutateAsync(
+        { provider, ...response },
+        { onSuccess: ({ data }) => setSocialUser(data) }
+      );
 
-    return code;
+      return code;
+    } catch (error) {
+      console.error('[useLogin] OIDC 인증 실패:', error);
+      toast({
+        title: '로그인에 실패했습니다. 잠시 후 다시 시도해주세요.',
+        shape: 'square',
+        position: 'top',
+      });
+      throw error;
+    }
   };
 
   const handleLoginSuccess = (data: User) => {
@@ -85,7 +99,13 @@ export const useLogin = (options?: { redirectTo?: string }) => {
 
   /** 로그인 */
   const login = async (provider: SocialProvider) => {
-    const code = await oidcAuth(provider);
+    let code: Awaited<ReturnType<typeof oidcAuth>> | undefined;
+    try {
+      code = await oidcAuth(provider);
+    } catch {
+      // oidcAuth 내부에서 사용자 안내 toast를 이미 노출함
+      return;
+    }
 
     // OIDC 인증 성공
     if (code === VERIFY_OIDC_RESULT_CODE.SUCCESS) {

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -39,10 +39,15 @@ const appleLogin = async () => {
     ],
   });
 
+  // Apple은 최초 로그인에만 fullName/email을 반환함 (documented behavior).
+  // 두 번째 이후 로그인에서는 null이 들어오므로 가능한 값으로 폴백.
+  const composedName = [fullName?.givenName, fullName?.familyName].filter(Boolean).join(' ').trim();
+  const emailPrefix = email?.split('@')[0] ?? '';
+
   return {
     idToken: identityToken,
-    name: fullName?.givenName + ' ' + fullName?.familyName,
-    email,
+    name: composedName || emailPrefix || '',
+    email: email ?? '',
     picture: '',
   };
 };

--- a/apps/mobile/lib/auth.ts
+++ b/apps/mobile/lib/auth.ts
@@ -2,16 +2,21 @@ import { login, me } from '@react-native-kakao/user';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 import * as AppleAuthentication from 'expo-apple-authentication';
 
+const resolveName = (name: string | null | undefined, email: string | null | undefined) => {
+  if (name && name.trim()) return name.trim();
+  return email?.split('@')[0] ?? '';
+};
+
 const kakaoLogin = async () => {
   try {
     const { idToken } = await login();
     const { email, nickname, profileImageUrl } = await me();
-    return { idToken, email, name: nickname, picture: profileImageUrl };
+    return { idToken, email: email ?? '', name: resolveName(nickname, email), picture: profileImageUrl ?? '' };
   } catch {
     // 카카오톡 앱 로그인 실패 시, 웹뷰로 로그인
     const { idToken } = await login({ useKakaoAccountLogin: true });
     const { email, nickname, profileImageUrl } = await me();
-    return { idToken, email, name: nickname, picture: profileImageUrl };
+    return { idToken, email: email ?? '', name: resolveName(nickname, email), picture: profileImageUrl ?? '' };
   }
 };
 
@@ -25,9 +30,9 @@ const googleLogin = async () => {
 
   return {
     idToken,
-    name: user.name,
-    email: user.email,
-    picture: user.photo,
+    name: resolveName(user.name, user.email),
+    email: user.email ?? '',
+    picture: user.photo ?? '',
   };
 };
 
@@ -41,12 +46,11 @@ const appleLogin = async () => {
 
   // Apple은 최초 로그인에만 fullName/email을 반환함 (documented behavior).
   // 두 번째 이후 로그인에서는 null이 들어오므로 가능한 값으로 폴백.
-  const composedName = [fullName?.givenName, fullName?.familyName].filter(Boolean).join(' ').trim();
-  const emailPrefix = email?.split('@')[0] ?? '';
+  const composedName = [fullName?.givenName, fullName?.familyName].filter(Boolean).join(' ');
 
   return {
     idToken: identityToken,
-    name: composedName || emailPrefix || '',
+    name: resolveName(composedName, email),
     email: email ?? '',
     picture: '',
   };

--- a/packages/bridge-core/src/domains/auth/types.ts
+++ b/packages/bridge-core/src/domains/auth/types.ts
@@ -1,7 +1,8 @@
 type SocialLoginResult = {
   idToken: string;
   email: string;
-  name?: string;
+  // 네이티브 측에서 항상 채워서 보내야 함. 값이 없으면 빈 문자열로 보내 백엔드 폴백을 유도.
+  name: string;
   picture?: string;
 };
 


### PR DESCRIPTION
## Summary

iOS WKWebView 환경에서 카카오/구글/애플 소셜 로그인이 간헐적으로 실패한다는 신고에 대한 FE 측 픽스.

### 배경
백엔드 운영 로그 7일치 조사 결과 `/api/v0/auth/verify/oidc`에서 발생한 400 11건이 **전부 iOS WKWebView** 환경이었고, 사유는 모두 동일하게 `Field 'name': rejected value [null]`. Apple은 최초 로그인에만 `fullName`을 반환하는 documented behavior가 있어, 두 번째 이후 로그인에서 `name`이 비정상 문자열(`undefined undefined`)이나 null로 전송되던 게 직접 원인. Kakao/Google도 nickname/name이 빈 값일 때 폴백이 없어 같은 위험이 잠재.

## 변경 사항

### P0-1 · `apps/mobile/lib/auth.ts` — Apple name 폴백
- AS-IS: `fullName?.givenName + ' ' + fullName?.familyName` → 두 번째 로그인부터 `"undefined undefined"` 또는 `null + ' ' + null`
- TO-BE: `composedName || email prefix || ''` 순으로 폴백

### P0-2 · `apps/knockdog/src/features/auth/model/useLogin.ts` — OIDC 실패 토스트
- `oidcAuth` 실패 시 unhandled rejection으로 silent fail되던 동작 개선
- `try-catch`로 감싸 사용자에게 `로그인에 실패했습니다. 잠시 후 다시 시도해주세요.` toast 노출
- `login`에서도 `oidcAuth` 예외를 잡아 toast 중복 노출 방지

### P1-1 · `apps/mobile/lib/auth.ts` — Kakao/Google 동일 폴백 통합
- `resolveName(name, email)` 헬퍼 도입. 값이 없으면 email prefix로 폴백
- Kakao `nickname`, Google `user.name`, Apple `composedName` 모두 동일 헬퍼로 통일
- `email`, `picture`도 `?? ''`로 안전 처리

### P1-2 · `packages/bridge-core/src/domains/auth/types.ts` — SocialLoginResult.name required
- `name?: string` → `name: string`. 네이티브 측이 항상 채워 보내도록 컨트랙트 강제
- 호출부에서 폴백 누락 시 타입 에러로 잡힘

## Test plan
- [ ] iOS 디바이스에서 Apple 첫 로그인 → 가입/로그인 정상
- [ ] 같은 계정으로 로그아웃 후 Apple 재로그인 → 400 발생하지 않음 (`name`이 이메일 prefix로 폴백)
- [ ] Kakao 로그인 회귀 없는지 확인 (nickname 정상 사용자/비어있는 사용자 모두)
- [ ] Google 로그인 회귀 없는지 확인
- [ ] verify/oidc 실패를 인위 발생시켰을 때 토스트 노출 확인

## 관련
백엔드 PR #308 (`name` `@NotBlank` 제거 + 폴백)와 별개로, FE에서 정상값을 채워 보내는 게 본질적 해결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)