### PR TITLE
fix(auth): 게스트 로그인 실패 시 토스트 노출 및 진단 로그 추가

### DIFF
--- a/apps/knockdog/src/features/auth/model/useLogin.ts
+++ b/apps/knockdog/src/features/auth/model/useLogin.ts
@@ -19,6 +19,7 @@ import { TypedStorage } from '@shared/lib';
 import { route } from '@shared/constants/route';
 import { useBridge, useStackNavigation, useNavigationResult } from '@shared/lib/bridge';
 import { toast } from '@shared/ui/toast';
+import { HTTPError } from 'ky';
 
 const SOCIAL_LOGIN_METHOD_MAP = {
   [SOCIAL_PROVIDER.KAKAO]: METHODS.kakaoLogin,
@@ -138,8 +139,26 @@ export const useLogin = (options?: { redirectTo?: string }) => {
 
   /** 게스트 로그인 (DEV) */
   const guestLogin = async () => {
-    const response = await fetchDevLogin<User>();
-    handleLoginSuccess(response.data);
+    try {
+      const response = await fetchDevLogin<User>();
+      handleLoginSuccess(response.data);
+    } catch (error) {
+      // 원인 분기: HTTPError(status 포함) vs 네트워크/기타
+      if (error instanceof HTTPError) {
+        console.error('[useLogin] 게스트 로그인 HTTP 실패', {
+          status: error.response.status,
+          url: error.response.url,
+          name: error.name,
+        });
+      } else {
+        console.error('[useLogin] 게스트 로그인 실패(비 HTTP)', error);
+      }
+      toast({
+        title: '게스트 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.',
+        shape: 'square',
+        position: 'top',
+      });
+    }
   };
 
   return { login, guestLogin };


### PR DESCRIPTION
## Summary

운영에서 "최초 로그인 화면의 게스트로 둘러보기 버튼이 안 먹는다"는 신고에 대한 응급 패치 + 원인 진단용 로그 추가.

### 배경
- 현재 `guestLogin`은 `fetchDevLogin` → `GET /api/v0/auth/dev/46` 호출
- 실패해도 `try-catch`가 없어 unhandled rejection으로 silent fail → 사용자 입장에서 "막힌 버튼"으로 보임
- BE 측 확인: 라우트는 운영에 살아있음 (`UserAuthController.java:130-137`). 별도 게스트 엔드포인트는 없음
- 따라서 원인은 다음 셋 중 하나: ① FE가 호출 자체를 안 함 ② BE 200인데 FE 후처리 실패 ③ BE 4xx (`users.id=46` 비정상)

## 변경 사항

### `apps/knockdog/src/features/auth/model/useLogin.ts`
- `guestLogin`을 try-catch로 감싸 사용자에게 "게스트 로그인에 실패했습니다..." toast 노출
- HTTP 에러(`HTTPError` from ky)인 경우 `status`, `url`을 console.error에 구조적으로 남김 → BE 결과와 대조하여 원인 즉시 분기 가능
- 비 HTTP(네트워크/기타) 에러는 원본 그대로 로깅

## 진단 활용 방법
- 토스트가 뜨고 console에 `[useLogin] 게스트 로그인 HTTP 실패 { status: 404, ... }` → BE 라우트 또는 user.id=46 비정상
- 토스트가 뜨고 console에 `비 HTTP` → 네트워크/CORS/타임아웃
- 토스트가 아예 안 뜨면 → 호출 자체가 안 나가는 것 (브릿지/이벤트 핸들러 문제)

## Test plan
- [ ] 정상 케이스(BE 200 + users.id=46 정상) — 토스트 없이 기존처럼 로그인 진행
- [ ] BE 라우트 404 시뮬레이션 — 토스트 노출 + console에 status 기록
- [ ] 네트워크 끊긴 상태에서 클릭 — 토스트 노출 + 비 HTTP 에러 기록

## 관련
- PR #453 (소셜 로그인 name 폴백 + OIDC 실패 토스트) 와 별개 트랙
- BE 측에 운영 nginx access log / curl 응답 / users.id=46 row 상태 확인 요청 진행 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)