### PR TITLE
fix(auth): 게스트 진입용 DEV_LOGIN_ID 46 → 69 교체

### DIFF
--- a/apps/knockdog/src/shared/api/endpoint/auth.ts
+++ b/apps/knockdog/src/shared/api/endpoint/auth.ts
@@ -15,8 +15,10 @@ export const postTokenReissue = async () => {
   return await api.post('auth/refresh');
 };
 
-/** `GET` - DEV 로그인 API */
+/** `GET` - DEV 로그인 API (게스트 둘러보기 진입에 사용) */
 export const fetchDevLogin = async <T>(): Promise<ApiResponse<T>> => {
-  const DEV_LOGIN_ID = 46;
+  // 게스트 전용 ACTIVE 계정. 기존 id=46이 2026-05-28 WITHDRAWN 처리되어 교체.
+  // BE 별도 트랙으로 /auth/dev/* 차단 + /auth/guest 신설 예정 → 그때 엔드포인트 교체.
+  const DEV_LOGIN_ID = 69;
   return await api.get(`auth/dev/${DEV_LOGIN_ID}`).json<ApiResponse<T>>();
 };


### PR DESCRIPTION
## Summary

운영 게스트 둘러보기 silent fail 원인 픽스. 기존 `users.id=46`이 2026-05-28에 WITHDRAWN 처리되어 BE가 200을 주고도 `handleLoginSuccess`의 `if (data.status === ACTIVE)` 조건에 막혀 아무 동작도 안 하던 문제.

## 변경
`apps/knockdog/src/shared/api/endpoint/auth.ts:19`
- `DEV_LOGIN_ID = 46` → `69` (BE가 신규 생성한 게스트 전용 ACTIVE 계정)
- 코멘트로 사유 + 후속 트랙(`/auth/guest` 신설) 명시

## 검증 (BE 확인 사항)
- BE 컨테이너에서 `GET /api/v0/auth/dev/69` 직접 호출 → 200 + 정상 토큰 발급 확인 완료
- `id=69, user_id=GUEST001, nickname=게스트, status=ACTIVE`

## Test plan
- [ ] 머지 후 Vercel Production 배포 자동 진행 확인
- [ ] 운영 로그인 화면에서 "게스트로 둘러보기" 클릭 → 메인으로 진입되는지
- [ ] BE access log에서 `/auth/dev/69` 200 응답 확인

## 후속 트랙 (이 PR 범위 외)
- BE: `/auth/dev/*` 운영 차단 + 정식 `/auth/guest` 엔드포인트 신설 (P1)
- FE: 위 완료 시 본 파일의 엔드포인트 교체
- FE: 단일 게스트 계정 공유로 인한 bookmark/memo 데이터 노출 정책 검토

## 관련
- 이전 PR #454 (게스트 로그인 실패 토스트)는 catch 경로에만 작동. BE 200 + status≠ACTIVE는 sync 흐름이라 catch가 안 잡는 dead path였음. 이번 픽스로 즉시 해결되지만, 같은 함정 방지를 위해 `handleLoginSuccess`에 `status !== ACTIVE` 분기 추가는 별도 PR로 제안 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)