### PR TITLE
fix(auth): 비-ACTIVE 사용자 silent fail 방지 + GuestLoginButton 'use client' 명시

### DIFF
--- a/apps/knockdog/src/features/auth/model/useLogin.ts
+++ b/apps/knockdog/src/features/auth/model/useLogin.ts
@@ -68,23 +68,34 @@ export const useLogin = (options?: { redirectTo?: string }) => {
   };
 
   const handleLoginSuccess = (data: User) => {
-    if (data.status === USER_STATUS.ACTIVE) {
-      setUser(data);
+    // BE가 200을 주더라도 status가 ACTIVE가 아니면 silent 진행 금지.
+    // 정식 흐름에선 handleLoginError에서 잡히지만, dev/guest 라우트처럼
+    // status 체크 없이 user를 그대로 반환하는 엔드포인트 대비 안전망.
+    if (data.status !== USER_STATUS.ACTIVE) {
+      console.error('[useLogin] 비-ACTIVE 유저 응답', { status: data.status });
+      toast({
+        title: '로그인할 수 없는 계정입니다. 잠시 후 다시 시도해주세요.',
+        shape: 'square',
+        position: 'top',
+      });
+      return;
+    }
 
-      // pushForResult로 열린 경우 결과 전송
-      try {
-        navResult.send(true);
-      } catch (error) {
-        // _txId가 없으면 일반 로그인 플로우 (에러 무시)
-        console.log('[useLogin] pushForResult 컨텍스트가 아닙니다, 일반 로그인 플로우 진행');
-      }
+    setUser(data);
 
-      if (redirectTo) {
-        replace({ pathname: redirectTo });
-      } else {
-        console.log('[useLogin] back');
-        back();
-      }
+    // pushForResult로 열린 경우 결과 전송
+    try {
+      navResult.send(true);
+    } catch (error) {
+      // _txId가 없으면 일반 로그인 플로우 (에러 무시)
+      console.log('[useLogin] pushForResult 컨텍스트가 아닙니다, 일반 로그인 플로우 진행');
+    }
+
+    if (redirectTo) {
+      replace({ pathname: redirectTo });
+    } else {
+      console.log('[useLogin] back');
+      back();
     }
   };
 

--- a/apps/knockdog/src/features/auth/ui/GuestLoginButton.tsx
+++ b/apps/knockdog/src/features/auth/ui/GuestLoginButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icon } from '@knockdog/ui';
 import { useLogin } from '../model/useLogin';
 import { useStackNavigation } from '@shared/lib';


### PR DESCRIPTION
## Summary

PR #455(`DEV_LOGIN_ID 46 → 69`)로 게스트 로그인 즉시 해결됐지만, **같은 함정이 재발하지 않도록 안전망 추가** + 사소한 hydration 안정성 보강.

## 배경
- PR #455 머지 직전 운영 증상: 게스트 버튼 눌러도 아무 일도 안 일어남
- 원인: BE가 `/auth/dev/46`에 200 응답을 줬는데 `users.id=46`이 WITHDRAWN 상태였고, `handleLoginSuccess`가 `if (data.status === ACTIVE)`로만 분기되어 있어 그 외 경로에서 **silent return** (catch도 안 잡힘, toast도 안 뜸)
- 같은 함정: 향후 어떤 인증 엔드포인트라도 200 + 비-ACTIVE 응답을 주면 동일한 dead path 재발 가능

## 변경 사항

### 1. `apps/knockdog/src/features/auth/model/useLogin.ts`
`handleLoginSuccess`에 비-ACTIVE 가드 추가
- `data.status !== ACTIVE`이면 `console.error` + toast 안내 후 early return
- 정식 흐름은 `handleLoginError`의 `WITHDRAWN_USER` / `REJOINING_RESTRICTION_PERIOD` 분기가 처리하므로 본 분기는 **dev/guest 라우트 같은 비정식 응답 안전망**
- 기존 정상 경로(ACTIVE) 로직은 그대로 유지

### 2. `apps/knockdog/src/features/auth/ui/GuestLoginButton.tsx`
`'use client'` 디렉티브 명시
- `useStackNavigation`, `useLogin` 등 client-only hooks 사용 + `onClick` 핸들러 보유
- 부모 `page.tsx`가 client component라 자동 인식되긴 하지만, hydration 경계를 명시적으로 두는 게 안전

## Test plan
- [ ] 정상 ACTIVE 사용자 로그인 시 기존 흐름 그대로 (setUser → navResult.send → back/replace)
- [ ] 게스트 로그인(현재 id=69) 정상 진입
- [ ] 인위적으로 WITHDRAWN 응답이 도달했을 때 toast 노출 + 화면 멈춤 없음

## 관련
- PR #455 (`DEV_LOGIN_ID 46 → 69`) — 즉시 해결책
- 본 PR — 재발 방지 안전망
- BE 후속 트랙: `/auth/dev/*` 차단 + `/auth/guest` 신설 (P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)