### PR TITLE
feat: 계정 전환 후 사업자번호 인증 페이지(1단계) 퍼블리싱 및 DEV ID -> 70으로 변경

### DIFF
--- a/apps/knockdog/app/(stack)/role-conversion/business-verification/page.tsx
+++ b/apps/knockdog/app/(stack)/role-conversion/business-verification/page.tsx
@@ -1,0 +1,3 @@
+import { BusinessVerificationPage } from '@views/role-conversion/business-verification';
+
+export default BusinessVerificationPage;

--- a/apps/knockdog/src/app/providers/ClientErrorReporter.tsx
+++ b/apps/knockdog/src/app/providers/ClientErrorReporter.tsx
@@ -18,7 +18,12 @@ const ERROR_ENDPOINT = '/api/monitoring/client-error';
 const DEDUPE_WINDOW_MS = 60_000;
 const recentReports = new Map<string, number>();
 
-function normalizeError(value: unknown) {
+interface NormalizedError {
+  message: string;
+  stack?: string;
+}
+
+function normalizeError(value: unknown): NormalizedError {
   if (value instanceof Error) {
     return {
       message: value.message,
@@ -56,7 +61,7 @@ function normalizeError(value: unknown) {
 
 function createReport(
   kind: ErrorReport['kind'],
-  error: { message: string; stack?: string },
+  error: NormalizedError,
   extra?: Partial<ErrorReport>
 ): ErrorReport {
   return {

--- a/apps/knockdog/src/shared/api/endpoint/auth.ts
+++ b/apps/knockdog/src/shared/api/endpoint/auth.ts
@@ -19,6 +19,7 @@ export const postTokenReissue = async () => {
 export const fetchDevLogin = async <T>(): Promise<ApiResponse<T>> => {
   // 게스트 전용 ACTIVE 계정. 기존 id=46이 2026-05-28 WITHDRAWN 처리되어 교체.
   // BE 별도 트랙으로 /auth/dev/* 차단 + /auth/guest 신설 예정 → 그때 엔드포인트 교체.
-  const DEV_LOGIN_ID = 69;
+  // DEV_LOGIN_ID = 70 은 2026-06-19 추가됨, 기존 69는 WITHDRAWN 처리되어 임시로 로컬 테스트를 위해 교체.
+  const DEV_LOGIN_ID = 70;
   return await api.get(`auth/dev/${DEV_LOGIN_ID}`).json<ApiResponse<T>>();
 };

--- a/apps/knockdog/src/shared/constants/route.ts
+++ b/apps/knockdog/src/shared/constants/route.ts
@@ -73,6 +73,12 @@ const route = {
       },
     },
   },
+  roleConversion: {
+    businessVerification: {
+      /** 관리자 전환 - 사업자번호 인증 */
+      root: '/role-conversion/business-verification',
+    },
+  },
 };
 
 export { route };

--- a/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationContent.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationContent.ts
@@ -6,4 +6,5 @@ export const businessVerificationContent = Object.freeze({
   inputPlaceholder: '사업자 등록번호를 입력해 주세요',
   verifyButtonLabel: '인증',
   nextButtonLabel: '다음',
+  successMessage: '인증이 완료됐어요',
 });

--- a/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationContent.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationContent.ts
@@ -1,0 +1,9 @@
+export const businessVerificationContent = Object.freeze({
+  headerTitle: '사업자번호 인증',
+  titleLine1: '관리자 계정 전환을 위해',
+  titleLine2: '사업자등록번호를 인증해 주세요',
+  fieldLabel: '사업자 등록번호 인증',
+  inputPlaceholder: '사업자 등록번호를 입력해 주세요',
+  verifyButtonLabel: '인증',
+  nextButtonLabel: '다음',
+});

--- a/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationDevStub.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationDevStub.ts
@@ -1,0 +1,22 @@
+import { BUSINESS_VERIFICATION_ERROR_CODE } from './businessVerificationError';
+
+/** @todo BE API 연동 후 삭제 — 인증 stub 테스트용 사업자번호 */
+export const businessVerificationDevStub = Object.freeze({
+  /** 인증 성공 */
+  success: '1234567890',
+  /** 중복 사업자번호 */
+  duplicate: '1111111111',
+  /** 사업자번호 형식 오류 */
+  invalidFormat: '2222222222',
+  /** 휴/폐업 사업자 */
+  closedOrSuspended: '3333333333',
+  /** 외부 API/통신 장애 */
+  temporary: '4444444444',
+});
+
+export const devStubErrorByBizNo = Object.freeze({
+  [businessVerificationDevStub.duplicate]: BUSINESS_VERIFICATION_ERROR_CODE.DUPLICATE,
+  [businessVerificationDevStub.invalidFormat]: BUSINESS_VERIFICATION_ERROR_CODE.INVALID_FORMAT,
+  [businessVerificationDevStub.closedOrSuspended]: BUSINESS_VERIFICATION_ERROR_CODE.CLOSED_OR_SUSPENDED,
+  [businessVerificationDevStub.temporary]: 'UNKNOWN_ERROR',
+} as const);

--- a/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationError.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationError.ts
@@ -1,0 +1,12 @@
+export const BUSINESS_VERIFICATION_ERROR_CODE = Object.freeze({
+  DUPLICATE: 'DUPLICATE_BUSINESS_NUMBER',
+  INVALID_FORMAT: 'INVALID_BUSINESS_NUMBER_FORMAT',
+  CLOSED_OR_SUSPENDED: 'CLOSED_OR_SUSPENDED_BUSINESS',
+} as const);
+
+export const businessVerificationError = Object.freeze({
+  duplicate: '이미 등록된 사업자등록번호입니다. 고객센터로 문의해 주세요',
+  invalidFormat: '올바른 숫자를 입력해 주세요',
+  closedOrSuspended: '휴업 또는 폐업 상태인 번호는 인증할 수 없습니다',
+  temporary: '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요',
+});

--- a/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationError.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationError.ts
@@ -5,8 +5,10 @@ export const BUSINESS_VERIFICATION_ERROR_CODE = Object.freeze({
 } as const);
 
 export const businessVerificationError = Object.freeze({
-  duplicate: '이미 등록된 사업자등록번호입니다. 고객센터로 문의해 주세요',
+  duplicateLine1: '이미 등록된 사업자등록번호입니다.',
+  duplicateLine2: '고객센터로 문의해 주세요',
   invalidFormat: '올바른 숫자를 입력해 주세요',
   closedOrSuspended: '휴업 또는 폐업 상태인 번호는 인증할 수 없습니다',
-  temporary: '일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요',
+  temporaryLine1: '일시적인 오류가 발생했습니다.',
+  temporaryLine2: '잠시 후 다시 시도해 주세요',
 });

--- a/apps/knockdog/src/views/role-conversion/business-verification/config/roleConversionProgress.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/config/roleConversionProgress.ts
@@ -1,0 +1,4 @@
+export const roleConversionProgress = Object.freeze({
+  totalSteps: 3,
+  businessVerificationStep: 1,
+});

--- a/apps/knockdog/src/views/role-conversion/business-verification/index.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/index.ts
@@ -1,0 +1,1 @@
+export { BusinessVerificationPage } from './ui/BusinessVerificationPage';

--- a/apps/knockdog/src/views/role-conversion/business-verification/model/getBusinessVerificationErrorMessage.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/model/getBusinessVerificationErrorMessage.ts
@@ -1,0 +1,25 @@
+import { ApiError } from '@shared/api';
+
+import {
+  BUSINESS_VERIFICATION_ERROR_CODE,
+  businessVerificationError,
+} from '../config/businessVerificationError';
+
+function getBusinessVerificationErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    switch (error.code) {
+      case BUSINESS_VERIFICATION_ERROR_CODE.DUPLICATE:
+        return businessVerificationError.duplicate;
+      case BUSINESS_VERIFICATION_ERROR_CODE.INVALID_FORMAT:
+        return businessVerificationError.invalidFormat;
+      case BUSINESS_VERIFICATION_ERROR_CODE.CLOSED_OR_SUSPENDED:
+        return businessVerificationError.closedOrSuspended;
+      default:
+        return businessVerificationError.temporary;
+    }
+  }
+
+  return businessVerificationError.temporary;
+}
+
+export { getBusinessVerificationErrorMessage };

--- a/apps/knockdog/src/views/role-conversion/business-verification/model/getBusinessVerificationErrorMessage.tsx
+++ b/apps/knockdog/src/views/role-conversion/business-verification/model/getBusinessVerificationErrorMessage.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react';
+
 import { ApiError } from '@shared/api';
 
 import {
@@ -5,21 +7,37 @@ import {
   businessVerificationError,
 } from '../config/businessVerificationError';
 
-function getBusinessVerificationErrorMessage(error: unknown) {
+function getTemporaryErrorMessage() {
+  return (
+    <>
+      {businessVerificationError.temporaryLine1}
+      <br />
+      {businessVerificationError.temporaryLine2}
+    </>
+  );
+}
+
+function getBusinessVerificationErrorMessage(error: unknown): ReactNode {
   if (error instanceof ApiError) {
     switch (error.code) {
       case BUSINESS_VERIFICATION_ERROR_CODE.DUPLICATE:
-        return businessVerificationError.duplicate;
+        return (
+          <>
+            {businessVerificationError.duplicateLine1}
+            <br />
+            {businessVerificationError.duplicateLine2}
+          </>
+        );
       case BUSINESS_VERIFICATION_ERROR_CODE.INVALID_FORMAT:
         return businessVerificationError.invalidFormat;
       case BUSINESS_VERIFICATION_ERROR_CODE.CLOSED_OR_SUSPENDED:
         return businessVerificationError.closedOrSuspended;
       default:
-        return businessVerificationError.temporary;
+        return getTemporaryErrorMessage();
     }
   }
 
-  return businessVerificationError.temporary;
+  return getTemporaryErrorMessage();
 }
 
 export { getBusinessVerificationErrorMessage };

--- a/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+import { useMutation } from '@tanstack/react-query';
+
+const BIZ_NO_LEN = 10;
+
+function useBusinessVerificationPage() {
+  const [bizNo, setBizNo] = useState('');
+  const [isVerified, setIsVerified] = useState(false);
+
+  const { mutate: verifyBizNo, isPending } = useMutation({
+    // @todo BE API 연동
+    mutationFn: async (_bizNo: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    },
+    onSuccess: () => setIsVerified(true),
+  });
+
+  const handleInputChange = (value: string) => {
+    const digits = value.replace(/\D/g, '').slice(0, BIZ_NO_LEN);
+    setBizNo(digits);
+    setIsVerified(false);
+  };
+
+  const handleVerifyClick = () => {
+    verifyBizNo(bizNo);
+  };
+
+  const handleNextClick = () => {
+    // @todo 다음 단계 라우팅
+  };
+
+  const isVerifyEnabled = bizNo.length === BIZ_NO_LEN && !isVerified && !isPending;
+
+  return {
+    bizNo,
+    isVerifyEnabled,
+    isNextEnabled: isVerified,
+    handleInputChange,
+    handleVerifyClick,
+    handleNextClick,
+  };
+}
+
+export { useBusinessVerificationPage };

--- a/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
@@ -1,20 +1,30 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import { useMutation } from '@tanstack/react-query';
 
+import { ApiError } from '@shared/api';
+
+import { devStubErrorByBizNo } from '../config/businessVerificationDevStub';
 import { getBusinessVerificationErrorMessage } from './getBusinessVerificationErrorMessage';
 
 const BIZ_NO_LEN = 10;
 
 function useBusinessVerificationPage() {
   const [bizNo, setBizNo] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ReactNode | null>(null);
   const [isVerified, setIsVerified] = useState(false);
 
   const { mutate: verifyBizNo, isPending } = useMutation({
-    // @todo BE API 연동
-    mutationFn: async (_bizNo: string) => {
+    // @todo BE API 연동 시 stub 제거 (26.06.19 작성)
+    // stub는 로컬 테스트 시 발생하는 에러 처리 확인을 위해 작성됨
+    mutationFn: async (bizNoValue: string) => {
       await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const stubErrorCode = devStubErrorByBizNo[bizNoValue as keyof typeof devStubErrorByBizNo];
+
+      if (stubErrorCode) {
+        throw new ApiError(400, stubErrorCode, '');
+      }
     },
     onSuccess: () => {
       setError(null);

--- a/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
@@ -2,10 +2,13 @@ import { useState } from 'react';
 
 import { useMutation } from '@tanstack/react-query';
 
+import { getBusinessVerificationErrorMessage } from './getBusinessVerificationErrorMessage';
+
 const BIZ_NO_LEN = 10;
 
 function useBusinessVerificationPage() {
   const [bizNo, setBizNo] = useState('');
+  const [error, setError] = useState<string | null>(null);
   const [isVerified, setIsVerified] = useState(false);
 
   const { mutate: verifyBizNo, isPending } = useMutation({
@@ -13,12 +16,20 @@ function useBusinessVerificationPage() {
     mutationFn: async (_bizNo: string) => {
       await new Promise((resolve) => setTimeout(resolve, 500));
     },
-    onSuccess: () => setIsVerified(true),
+    onSuccess: () => {
+      setError(null);
+      setIsVerified(true);
+    },
+    onError: (err) => {
+      setIsVerified(false);
+      setError(getBusinessVerificationErrorMessage(err));
+    },
   });
 
   const handleInputChange = (value: string) => {
     const digits = value.replace(/\D/g, '').slice(0, BIZ_NO_LEN);
     setBizNo(digits);
+    setError(null);
     setIsVerified(false);
   };
 
@@ -34,6 +45,8 @@ function useBusinessVerificationPage() {
 
   return {
     bizNo,
+    error,
+    isVerified,
     isVerifyEnabled,
     isNextEnabled: isVerified,
     handleInputChange,

--- a/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
@@ -17,8 +17,16 @@ import { roleConversionProgress } from '../config/roleConversionProgress';
 import { useBusinessVerificationPage } from '../model/useBusinessVerificationPage';
 
 function BusinessVerificationPage() {
-  const { bizNo, isVerifyEnabled, isNextEnabled, handleInputChange, handleVerifyClick, handleNextClick } =
-    useBusinessVerificationPage();
+  const {
+    bizNo,
+    error,
+    isVerified,
+    isVerifyEnabled,
+    isNextEnabled,
+    handleInputChange,
+    handleVerifyClick,
+    handleNextClick,
+  } = useBusinessVerificationPage();
 
   return (
     <div className='flex h-full flex-col'>
@@ -50,7 +58,12 @@ function BusinessVerificationPage() {
 
             <div className='flex items-start gap-2'>
               <div className='min-w-0 flex-1'>
-                <TextField>
+                <TextField
+                  invalid={!!error}
+                  valid={isVerified}
+                  errorMessage={error ?? undefined}
+                  successMessage={isVerified ? businessVerificationContent.successMessage : undefined}
+                >
                   <TextFieldInput
                     inputMode='numeric'
                     maxLength={10}

--- a/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import {
+  ActionButton,
+  Field,
+  FieldLabel,
+  FieldLabelIndicator,
+  ProgressBar,
+  TextField,
+  TextFieldInput,
+} from '@knockdog/ui';
+
+import { Header } from '@widgets/Header';
+
+import { businessVerificationContent } from '../config/businessVerificationContent';
+import { roleConversionProgress } from '../config/roleConversionProgress';
+import { useBusinessVerificationPage } from '../model/useBusinessVerificationPage';
+
+function BusinessVerificationPage() {
+  const { bizNo, isVerifyEnabled, isNextEnabled, handleInputChange, handleVerifyClick, handleNextClick } =
+    useBusinessVerificationPage();
+
+  return (
+    <div className='flex h-full flex-col'>
+      <Header>
+        <Header.BackButton />
+        <Header.Title>{businessVerificationContent.headerTitle}</Header.Title>
+      </Header>
+
+      <div className='shrink-0 px-4 py-2'>
+        <ProgressBar
+          totalSteps={roleConversionProgress.totalSteps}
+          value={roleConversionProgress.businessVerificationStep}
+        />
+      </div>
+
+      <div className='flex flex-1 flex-col px-4 pt-3 pb-5'>
+        <div className='flex flex-col gap-5'>
+          <h1 className='h1-extrabold'>
+            {businessVerificationContent.titleLine1}
+            <br />
+            {businessVerificationContent.titleLine2}
+          </h1>
+
+          <Field className='flex-col gap-2 py-2'>
+            <FieldLabel className='body2-bold text-text-primary w-fit gap-px'>
+              {businessVerificationContent.fieldLabel}
+              <FieldLabelIndicator type='required' className='ml-0' />
+            </FieldLabel>
+
+            <div className='flex items-start gap-2'>
+              <div className='min-w-0 flex-1'>
+                <TextField>
+                  <TextFieldInput
+                    inputMode='numeric'
+                    maxLength={10}
+                    placeholder={businessVerificationContent.inputPlaceholder}
+                    value={bizNo}
+                    onChange={(e) => handleInputChange(e.target.value)}
+                  />
+                </TextField>
+              </div>
+
+              <ActionButton
+                type='button'
+                className='max-w-20 shrink-0'
+                variant='secondaryFill'
+                disabled={!isVerifyEnabled}
+                onClick={handleVerifyClick}
+              >
+                {businessVerificationContent.verifyButtonLabel}
+              </ActionButton>
+            </div>
+          </Field>
+        </div>
+
+        <div className='mt-auto py-5'>
+          <ActionButton
+            type='button'
+            variant='secondaryFill'
+            size='large'
+            className='w-full'
+            disabled={!isNextEnabled}
+            onClick={handleNextClick}
+          >
+            {businessVerificationContent.nextButtonLabel}
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { BusinessVerificationPage };


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

사업자등록번호 인증 페이지 퍼블리싱 및 인증 상태 처리 로직을 구현했습니다.
`/role-conversion/business-verification`

기존 프로젝트 내 이메일 인증 플로우와 TextField 패턴을 재사용하여 인증 성공/실패 상태에 따른 UI 피드백을 제공하도록 구성했습니다. 또한 백엔드 연동 시 사용할 사업자등록번호 인증 에러 코드별 메시지 매핑 로직을 추가하여 사용자에게 적절한 안내 문구가 노출될 수 있도록 구현했습니다.

추가 사항으로, 로컬 환경에서 개발 진행 중에 기존의 DEV_LOGIN_ID = 69 가 WITHDRAWN 처리가 되어, 70으로 변경하였습니다. 이는 로컬 테스트를 위한 임시 방안으로 추후 보완할 계획입니다.

---

## 작업 내용

### UI 구현

- 사업자등록번호 인증 페이지 퍼블리싱
- 인증 상태에 따른 TextField UI 반영
  - 성공 시 `valid` 상태 및 성공 메시지 표시
  - 실패 시 `invalid` 상태 및 에러 메시지 표시

### 상태 관리

- `isVerified` 상태 추가
- 인증 성공 시
  - 에러 상태 초기화
  - 인증 완료 상태 처리
- 인증 실패 시
  - 에러 메시지 상태 설정
- 입력값 변경 시
  - 인증 상태 초기화
  - 에러 상태 초기화

### 에러 처리

- 사업자등록번호 인증 에러 코드별 메시지 매핑 로직 추가

```ts
DUPLICATE_BUSINESS_NUMBER
INVALID_BUSINESS_NUMBER_FORMAT
CLOSED_OR_SUSPENDED_BUSINESS
```

## 논의할 점
-기존 인증 플로우 패턴을 참고하여 구현했는데, 프로젝트 컨벤션과 맞지 않는 부분이 있다면 피드백 부탁드립니다.
-현재 에러 메시지 매핑은 프론트 기준으로 우선 정의했습니다.

## 스크린샷
<img width="832" height="250" alt="스크린샷 2026-06-19 153323" src="https://github.com/user-attachments/assets/45ffc0fd-6cde-4d2f-b054-ffe02bfde713" />
(기존 DEV_LOGIN_ID = 69 로 진입 시)
<img width="1880" height="254" alt="dev 70" src="https://github.com/user-attachments/assets/6bc11daf-2282-4f69-b94a-bb7df205bb9d" />
(임시로 DEV_LOGIN_ID = 70으로 변경)

------

<img width="576" height="1250" alt="스크린샷 2026-06-19 140811" src="https://github.com/user-attachments/assets/d5663e0a-3057-4eb8-b270-e10bd4135672" />
<img width="760" height="1450" alt="스크린샷 2026-06-19 145147" src="https://github.com/user-attachments/assets/42ed28de-7c10-4589-88ba-8069d1645cd4" />
