### PR TITLE
feat: 관리자 계정 전환 후 유치원 검색 초안 퍼블리싱(~4a) 및 사업자번호 인증 라벨 추가

### DIFF
--- a/apps/knockdog/app/(stack)/role-conversion/kindergarten-register/page.tsx
+++ b/apps/knockdog/app/(stack)/role-conversion/kindergarten-register/page.tsx
@@ -1,0 +1,3 @@
+import { KindergartenRegisterPage } from '@views/role-conversion/kindergarten-register';
+
+export default KindergartenRegisterPage;

--- a/apps/knockdog/app/(stack)/role-conversion/kindergarten-search/page.tsx
+++ b/apps/knockdog/app/(stack)/role-conversion/kindergarten-search/page.tsx
@@ -1,0 +1,3 @@
+import { KindergartenSearchPage } from '@views/role-conversion/kindergarten-search';
+
+export default KindergartenSearchPage;

--- a/apps/knockdog/src/shared/constants/route.ts
+++ b/apps/knockdog/src/shared/constants/route.ts
@@ -78,6 +78,10 @@ const route = {
       /** 관리자 전환 - 사업자번호 인증 */
       root: '/role-conversion/business-verification',
     },
+    kindergartenSearch: {
+      /** 관리자 전환 - 유치원 검색 */
+      root: '/role-conversion/kindergarten-search',
+    },
   },
 };
 

--- a/apps/knockdog/src/shared/constants/route.ts
+++ b/apps/knockdog/src/shared/constants/route.ts
@@ -82,6 +82,10 @@ const route = {
       /** 관리자 전환 - 유치원 검색 */
       root: '/role-conversion/kindergarten-search',
     },
+    kindergartenRegister: {
+      /** 관리자 전환 - 유치원 직접 등록 */
+      root: '/role-conversion/kindergarten-register',
+    },
   },
 };
 

--- a/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationContent.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/config/businessVerificationContent.ts
@@ -1,9 +1,10 @@
 export const businessVerificationContent = Object.freeze({
   headerTitle: '사업자번호 인증',
-  titleLine1: '관리자 계정 전환을 위해',
+  titleLine1: '유치원 인증을 위해',
   titleLine2: '사업자등록번호를 인증해 주세요',
   fieldLabel: '사업자 등록번호 인증',
   inputPlaceholder: '사업자 등록번호를 입력해 주세요',
+  hintLabel: '숫자 10자리를 하이픈(-) 없이 입력해 주세요',
   verifyButtonLabel: '인증',
   nextButtonLabel: '다음',
   successMessage: '인증이 완료됐어요',

--- a/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
@@ -62,6 +62,7 @@ function useBusinessVerificationPage() {
     isVerified,
     isVerifyEnabled,
     isNextEnabled: isVerified,
+    isVerifyPending: isPending,
     handleInputChange,
     handleVerifyClick,
     handleNextClick,

--- a/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
+++ b/apps/knockdog/src/views/role-conversion/business-verification/model/useBusinessVerificationPage.ts
@@ -3,6 +3,8 @@ import { useState, type ReactNode } from 'react';
 import { useMutation } from '@tanstack/react-query';
 
 import { ApiError } from '@shared/api';
+import { route } from '@shared/constants/route';
+import { useStackNavigation } from '@shared/lib/bridge';
 
 import { devStubErrorByBizNo } from '../config/businessVerificationDevStub';
 import { getBusinessVerificationErrorMessage } from './getBusinessVerificationErrorMessage';
@@ -10,6 +12,7 @@ import { getBusinessVerificationErrorMessage } from './getBusinessVerificationEr
 const BIZ_NO_LEN = 10;
 
 function useBusinessVerificationPage() {
+  const { push } = useStackNavigation();
   const [bizNo, setBizNo] = useState('');
   const [error, setError] = useState<ReactNode | null>(null);
   const [isVerified, setIsVerified] = useState(false);
@@ -48,7 +51,7 @@ function useBusinessVerificationPage() {
   };
 
   const handleNextClick = () => {
-    // @todo 다음 단계 라우팅
+    push({ pathname: route.roleConversion.kindergartenSearch.root });
   };
 
   const isVerifyEnabled = bizNo.length === BIZ_NO_LEN && !isVerified && !isPending;

--- a/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
@@ -13,7 +13,7 @@ import {
 import { Header } from '@widgets/Header';
 
 import { businessVerificationContent } from '../config/businessVerificationContent';
-import { roleConversionProgress } from '../config/roleConversionProgress';
+import { roleConversionProgress } from '@views/role-conversion/config/roleConversionProgress';
 import { useBusinessVerificationPage } from '../model/useBusinessVerificationPage';
 
 function BusinessVerificationPage() {
@@ -39,6 +39,7 @@ function BusinessVerificationPage() {
         <ProgressBar
           totalSteps={roleConversionProgress.totalSteps}
           value={roleConversionProgress.businessVerificationStep}
+          className='h-1.5'
         />
       </div>
 

--- a/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
@@ -23,10 +23,13 @@ function BusinessVerificationPage() {
     isVerified,
     isVerifyEnabled,
     isNextEnabled,
+    isVerifyPending,
     handleInputChange,
     handleVerifyClick,
     handleNextClick,
   } = useBusinessVerificationPage();
+
+  const showHintLabel = !isVerifyPending && !isVerified && !error;
 
   return (
     <div className='flex h-full flex-col'>
@@ -72,6 +75,11 @@ function BusinessVerificationPage() {
                     onChange={(e) => handleInputChange(e.target.value)}
                   />
                 </TextField>
+                {showHintLabel && (
+                  <span className='body2-regular text-text-tertiary mt-2 block'>
+                    {businessVerificationContent.hintLabel}
+                  </span>
+                )}
               </div>
 
               <ActionButton

--- a/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/business-verification/ui/BusinessVerificationPage.tsx
@@ -39,7 +39,6 @@ function BusinessVerificationPage() {
         <ProgressBar
           totalSteps={roleConversionProgress.totalSteps}
           value={roleConversionProgress.businessVerificationStep}
-          className='h-1.5'
         />
       </div>
 

--- a/apps/knockdog/src/views/role-conversion/config/roleConversionProgress.ts
+++ b/apps/knockdog/src/views/role-conversion/config/roleConversionProgress.ts
@@ -1,4 +1,5 @@
 export const roleConversionProgress = Object.freeze({
   totalSteps: 3,
   businessVerificationStep: 1,
+  kindergartenSearchStep: 2,
 });

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/config/kindergartenRegisterContent.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/config/kindergartenRegisterContent.ts
@@ -1,0 +1,14 @@
+export const kindergartenRegisterContent = Object.freeze({
+  headerTitle: '유치원 검색',
+  titleLine1: '유치원 정보를',
+  titleLine2: '입력해 주세요',
+  nameLabel: '유치원명',
+  namePlaceholder: '유치원명',
+  addressLabel: '주소',
+  addressPlaceholder: '유치원 주소',
+  numberLabel: '유치원 번호',
+  numberPlaceholder: '유치원 번호',
+  phoneLabel: '대표 전화번호',
+  phonePlaceholder: '대표 전화번호',
+  nextButtonLabel: '다음',
+});

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/config/kindergartenRegisterContent.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/config/kindergartenRegisterContent.ts
@@ -1,5 +1,5 @@
 export const kindergartenRegisterContent = Object.freeze({
-  headerTitle: '유치원 검색',
+  headerTitle: '유치원 정보 입력',
   titleLine1: '유치원 정보를',
   titleLine2: '입력해 주세요',
   nameLabel: '유치원명',

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/index.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/index.ts
@@ -1,0 +1,1 @@
+export { KindergartenRegisterPage } from './ui/KindergartenRegisterPage';

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/lib/formatKindergartenRegisterField.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/lib/formatKindergartenRegisterField.ts
@@ -1,0 +1,56 @@
+const NAME_MAX_LENGTH = 30;
+const ADDRESS_MAX_LENGTH = 50;
+const ALLOWED_TEXT_PATTERN = /[\uAC00-\uD7A3\u3131-\u318Ea-zA-Z0-9!-/:-@\[-`{-~\s]/g;
+function extractAllowedText(value: string, maxLength: number) {
+  return (value.match(ALLOWED_TEXT_PATTERN) ?? []).join('').slice(0, maxLength);
+}
+
+function formatName(value: string) {
+  return extractAllowedText(value, NAME_MAX_LENGTH);
+}
+
+function formatAddress(value: string) {
+  return extractAllowedText(value, ADDRESS_MAX_LENGTH);
+}
+
+function formatPhone(value: string) {
+  const digits = value.replace(/\D/g, '');
+
+  if (digits.startsWith('050')) {
+    const phone = digits.slice(0, 12);
+
+    if (phone.length <= 4) return phone;
+    if (phone.length <= 7) return `${phone.slice(0, 4)}-${phone.slice(4)}`;
+    if (phone.length <= 11) return `${phone.slice(0, 4)}-${phone.slice(4, 7)}-${phone.slice(7)}`;
+
+    return `${phone.slice(0, 4)}-${phone.slice(4, 8)}-${phone.slice(8, 12)}`;
+  }
+
+  if (digits.startsWith('02')) {
+    const phone = digits.slice(0, 10);
+
+    if (phone.length <= 2) return phone;
+    if (phone.length <= 5) return `${phone.slice(0, 2)}-${phone.slice(2)}`;
+    if (phone.length <= 9) return `${phone.slice(0, 2)}-${phone.slice(2, 5)}-${phone.slice(5)}`;
+
+    return `${phone.slice(0, 2)}-${phone.slice(2, 6)}-${phone.slice(6, 10)}`;
+  }
+
+  if (digits.startsWith('15') || digits.startsWith('16') || digits.startsWith('18')) {
+    const phone = digits.slice(0, 8);
+
+    if (phone.length <= 4) return phone;
+
+    return `${phone.slice(0, 4)}-${phone.slice(4, 8)}`;
+  }
+
+  const phone = digits.slice(0, 11);
+
+  if (phone.length <= 3) return phone;
+  if (phone.length <= 6) return `${phone.slice(0, 3)}-${phone.slice(3)}`;
+  if (phone.length <= 10) return `${phone.slice(0, 3)}-${phone.slice(3, 6)}-${phone.slice(6)}`;
+
+  return `${phone.slice(0, 3)}-${phone.slice(3, 7)}-${phone.slice(7, 11)}`;
+}
+
+export { formatAddress, formatName, formatPhone };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
@@ -1,11 +1,19 @@
 import { useState } from 'react';
 
+import { formatAddress, formatName, formatPhone } from '../lib/formatKindergartenRegisterField';
 interface KindergartenRegisterForm {
   name: string;
   address: string;
   kindergartenNumber: string;
   phoneNumber: string;
 }
+
+const fieldFormatters = {
+  name: formatName,
+  address: formatAddress,
+  kindergartenNumber: formatPhone,
+  phoneNumber: formatPhone,
+} as const;
 
 function useKindergartenRegisterPage() {
   const [form, setForm] = useState<KindergartenRegisterForm>({
@@ -16,7 +24,7 @@ function useKindergartenRegisterPage() {
   });
 
   const handleFieldChange = (field: keyof KindergartenRegisterForm, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
+    setForm((prev) => ({ ...prev, [field]: fieldFormatters[field](value) }));
   };
 
   const isNextEnabled = Object.values(form).every((value) => value.trim().length > 0);

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+interface KindergartenRegisterForm {
+  name: string;
+  address: string;
+  kindergartenNumber: string;
+  phoneNumber: string;
+}
+
+function useKindergartenRegisterPage() {
+  const [form, setForm] = useState<KindergartenRegisterForm>({
+    name: '',
+    address: '',
+    kindergartenNumber: '',
+    phoneNumber: '',
+  });
+
+  const handleFieldChange = (field: keyof KindergartenRegisterForm, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const isNextEnabled = Object.values(form).every((value) => value.trim().length > 0);
+
+  const handleNextClick = () => {
+    // @todo 3단계 개인정보 수집 및 이용 동의 라우팅(26/06/20)
+  };
+
+  return {
+    form,
+    isNextEnabled,
+    handleFieldChange,
+    handleNextClick,
+  };
+}
+
+export { useKindergartenRegisterPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
@@ -78,7 +78,7 @@ function KindergartenRegisterPage() {
               </FieldLabel>
               <TextField>
                 <TextFieldInput
-                  inputMode='numeric'
+                  inputMode='tel'
                   placeholder={kindergartenRegisterContent.numberPlaceholder}
                   value={form.kindergartenNumber}
                   onChange={(e) => handleFieldChange('kindergartenNumber', e.target.value)}

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import {
+  ActionButton,
+  Field,
+  FieldLabel,
+  FieldLabelIndicator,
+  ProgressBar,
+  TextField,
+  TextFieldInput,
+} from '@knockdog/ui';
+
+import { Header } from '@widgets/Header';
+
+import { roleConversionProgress } from '@views/role-conversion/config/roleConversionProgress';
+import { kindergartenRegisterContent } from '../config/kindergartenRegisterContent';
+import { useKindergartenRegisterPage } from '../model/useKindergartenRegisterPage';
+
+function KindergartenRegisterPage() {
+  const { form, isNextEnabled, handleFieldChange, handleNextClick } = useKindergartenRegisterPage();
+
+  return (
+    <div className='flex h-full flex-col'>
+      <Header>
+        <Header.BackButton />
+        <Header.Title>{kindergartenRegisterContent.headerTitle}</Header.Title>
+      </Header>
+
+      <div className='shrink-0 px-4 py-2'>
+        <ProgressBar
+          totalSteps={roleConversionProgress.totalSteps}
+          value={roleConversionProgress.kindergartenSearchStep}
+          className='h-1.5'
+        />
+      </div>
+
+      <div className='flex min-h-0 flex-1 flex-col px-4 pt-3 pb-5'>
+        <div className='flex flex-col gap-5'>
+          <h1 className='h1-extrabold'>
+            {kindergartenRegisterContent.titleLine1}
+            <br />
+            {kindergartenRegisterContent.titleLine2}
+          </h1>
+
+          <div className='flex flex-col'>
+            <Field className='flex-col gap-2 py-4'>
+              <FieldLabel className='body2-bold text-text-primary w-fit gap-px'>
+                {kindergartenRegisterContent.nameLabel}
+                <FieldLabelIndicator type='required' className='ml-0' />
+              </FieldLabel>
+              <TextField>
+                <TextFieldInput
+                  placeholder={kindergartenRegisterContent.namePlaceholder}
+                  value={form.name}
+                  onChange={(e) => handleFieldChange('name', e.target.value)}
+                />
+              </TextField>
+            </Field>
+
+            <Field className='flex-col gap-2 py-4'>
+              <FieldLabel className='body2-bold text-text-primary w-fit gap-px'>
+                {kindergartenRegisterContent.addressLabel}
+                <FieldLabelIndicator type='required' className='ml-0' />
+              </FieldLabel>
+              <TextField>
+                <TextFieldInput
+                  placeholder={kindergartenRegisterContent.addressPlaceholder}
+                  value={form.address}
+                  onChange={(e) => handleFieldChange('address', e.target.value)}
+                />
+              </TextField>
+            </Field>
+
+            <Field className='flex-col gap-2 py-4'>
+              <FieldLabel className='body2-bold text-text-primary w-fit gap-px'>
+                {kindergartenRegisterContent.numberLabel}
+                <FieldLabelIndicator type='required' className='ml-0' />
+              </FieldLabel>
+              <TextField>
+                <TextFieldInput
+                  inputMode='numeric'
+                  placeholder={kindergartenRegisterContent.numberPlaceholder}
+                  value={form.kindergartenNumber}
+                  onChange={(e) => handleFieldChange('kindergartenNumber', e.target.value)}
+                />
+              </TextField>
+            </Field>
+
+            <Field className='flex-col gap-2 py-4'>
+              <FieldLabel className='body2-bold text-text-primary w-fit gap-px'>
+                {kindergartenRegisterContent.phoneLabel}
+                <FieldLabelIndicator type='required' className='ml-0' />
+              </FieldLabel>
+              <TextField>
+                <TextFieldInput
+                  inputMode='tel'
+                  placeholder={kindergartenRegisterContent.phonePlaceholder}
+                  value={form.phoneNumber}
+                  onChange={(e) => handleFieldChange('phoneNumber', e.target.value)}
+                />
+              </TextField>
+            </Field>
+          </div>
+        </div>
+
+        <div className='mt-auto py-5'>
+          <ActionButton
+            type='button'
+            variant='secondaryFill'
+            size='large'
+            className='w-full'
+            disabled={!isNextEnabled}
+            onClick={handleNextClick}
+          >
+            {kindergartenRegisterContent.nextButtonLabel}
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { KindergartenRegisterPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
@@ -3,5 +3,4 @@ export const kindergartenSearchContent = Object.freeze({
   titleLine1: '운영하고 계신 유치원을',
   titleLine2: '검색해 주세요',
   searchPlaceholder: '업체 또는 주소를 검색하세요',
-  nextButtonLabel: '다음',
 });

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
@@ -1,0 +1,7 @@
+export const kindergartenSearchContent = Object.freeze({
+  headerTitle: '유치원 검색',
+  titleLine1: '운영하고 계신 유치원을',
+  titleLine2: '검색해 주세요',
+  searchPlaceholder: '업체 또는 주소를 검색하세요',
+  nextButtonLabel: '다음',
+});

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
@@ -3,4 +3,7 @@ export const kindergartenSearchContent = Object.freeze({
   titleLine1: '운영하고 계신 유치원을',
   titleLine2: '검색해 주세요',
   searchPlaceholder: '업체 또는 주소를 검색하세요',
+  emptyTitle: '운영 중인 유치원이 검색되지 않나요?',
+  emptyDescription: '직접 등록해서 관리자 권한을 요청해 보세요.',
+  registerButtonLabel: '유치원 직접 등록하기',
 });

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContent.ts
@@ -1,5 +1,5 @@
 export const kindergartenSearchContent = Object.freeze({
-  headerTitle: '유치원 검색',
+  headerTitle: '유치원 정보 입력',
   titleLine1: '운영하고 계신 유치원을',
   titleLine2: '검색해 주세요',
   searchPlaceholder: '업체 또는 주소를 검색하세요',

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContentInset.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/config/kindergartenSearchContentInset.ts
@@ -1,0 +1,1 @@
+export const kindergartenSearchContentInset = 'px-3';

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/index.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/index.ts
@@ -1,0 +1,1 @@
+export { KindergartenSearchPage } from './ui/KindergartenSearchPage';

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/model/useKindergartenSearchPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/model/useKindergartenSearchPage.ts
@@ -25,9 +25,6 @@ function useKindergartenSearchPage() {
 
   const handlePlaceSelect = (place: AutocompletePlace) => {
     setSelectedPlace(place);
-  };
-
-  const handleNextClick = () => {
     // @todo 3단계 개인정보 수집 및 이용 동의 라우팅 (26-06-20)
   };
 
@@ -35,11 +32,8 @@ function useKindergartenSearchPage() {
     query,
     places,
     selectedPlaceId: selectedPlace?.id ?? null,
-    isNextEnabled: !!selectedPlace,
     handleQueryChange,
     handlePlaceSelect,
-    handleNextClick,
-  };
-}
+  };}
 
 export { useKindergartenSearchPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/model/useKindergartenSearchPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/model/useKindergartenSearchPage.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+import { useBasePoint } from '@entities/user';
+import type { AutocompletePlace } from '@entities/kindergarten';
+import { searchQueryOptions } from '@features/search';
+
+function useKindergartenSearchPage() {
+  const [query, setQuery] = useState('');
+  const [selectedPlace, setSelectedPlace] = useState<AutocompletePlace | null>(null);
+
+  const { coord } = useBasePoint();
+  const trimmedQuery = query.trim();
+
+  const { data } = useQuery({
+    ...searchQueryOptions.autocomplete({ query: trimmedQuery, coord }),
+  });
+
+  const places = data?.place ?? [];
+
+  const handleQueryChange = (value: string) => {
+    setQuery(value);
+    setSelectedPlace(null);
+  };
+
+  const handlePlaceSelect = (place: AutocompletePlace) => {
+    setSelectedPlace(place);
+  };
+
+  const handleNextClick = () => {
+    // @todo 3단계 개인정보 수집 및 이용 동의 라우팅 (26-06-20)
+  };
+
+  return {
+    query,
+    places,
+    selectedPlaceId: selectedPlace?.id ?? null,
+    isNextEnabled: !!selectedPlace,
+    handleQueryChange,
+    handlePlaceSelect,
+    handleNextClick,
+  };
+}
+
+export { useKindergartenSearchPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/model/useKindergartenSearchPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/model/useKindergartenSearchPage.ts
@@ -12,11 +12,12 @@ function useKindergartenSearchPage() {
   const { coord } = useBasePoint();
   const trimmedQuery = query.trim();
 
-  const { data } = useQuery({
+  const { data, isFetching, isFetched } = useQuery({
     ...searchQueryOptions.autocomplete({ query: trimmedQuery, coord }),
   });
 
   const places = data?.place ?? [];
+  const isSearchEmpty = trimmedQuery.length > 0 && isFetched && !isFetching && places.length === 0;
 
   const handleQueryChange = (value: string) => {
     setQuery(value);
@@ -32,8 +33,10 @@ function useKindergartenSearchPage() {
     query,
     places,
     selectedPlaceId: selectedPlace?.id ?? null,
+    isSearchEmpty,
     handleQueryChange,
     handlePlaceSelect,
-  };}
+  };
+}
 
 export { useKindergartenSearchPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchEmptyResult.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchEmptyResult.tsx
@@ -1,0 +1,30 @@
+import { ActionButton, Icon } from '@knockdog/ui';
+
+import { kindergartenSearchContent } from '../config/kindergartenSearchContent';
+
+function KindergartenSearchEmptyResult() {
+  const handleRegisterClick = () => {
+    // @todo 유치원 직접 등록 라우팅
+  };
+
+  return (
+    <div className='flex flex-col gap-5 py-5'>
+      <div className='flex flex-col gap-1 text-center'>
+        <p className='h3-semibold text-text-primary'>{kindergartenSearchContent.emptyTitle}</p>
+        <p className='body1-regular text-text-secondary'>{kindergartenSearchContent.emptyDescription}</p>
+      </div>
+
+      <ActionButton
+        type='button'
+        variant='secondaryFill'
+        size='large'
+        className='w-full'
+        onClick={handleRegisterClick}
+      >
+        {kindergartenSearchContent.registerButtonLabel}
+      </ActionButton>
+    </div>
+  );
+}
+
+export { KindergartenSearchEmptyResult };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchEmptyResult.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchEmptyResult.tsx
@@ -1,12 +1,16 @@
-import { ActionButton, Icon } from '@knockdog/ui';
-
+import { ActionButton } from '@knockdog/ui';
+import { route } from '@shared/constants/route';
+import { useStackNavigation } from '@shared/lib/bridge';
 import { kindergartenSearchContent } from '../config/kindergartenSearchContent';
 
 function KindergartenSearchEmptyResult() {
-  const handleRegisterClick = () => {
-    // @todo 유치원 직접 등록 라우팅
-  };
 
+  const { push } = useStackNavigation();
+  const handleRegisterClick = () => {
+
+    push({ pathname: route.roleConversion.kindergartenRegister.root });
+
+  };
   return (
     <div className='flex flex-col gap-5 py-5'>
       <div className='flex flex-col gap-1 text-center'>

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchHint.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchHint.tsx
@@ -1,0 +1,37 @@
+import { kindergartenSearchContentInset } from '../config/kindergartenSearchContentInset';
+import { cn } from '@knockdog/ui/lib';
+
+function KindergartenSearchHint() {
+  return (
+    <ul
+      className={cn(
+        'text-text-tertiary body2-regular flex list-none flex-col gap-2 p-0',
+        kindergartenSearchContentInset
+      )}
+    >
+      <li className='flex gap-2'>
+        <span aria-hidden className='shrink-0'>
+          •
+        </span>
+        <span>
+          시/군/구 + 도로명, 동명 또는 건물명 <br />
+          예) 동해시 중앙로, 여수 중앙동, 대전 현대아파트
+        </span>
+      </li>
+      <li className='flex gap-2'>
+        <span aria-hidden className='shrink-0'>
+          •
+        </span>
+        <span>도로명 + 건물번호 예) 종로 6</span>
+      </li>
+      <li className='flex gap-2'>
+        <span aria-hidden className='shrink-0'>
+          •
+        </span>
+        <span>읍/면/동/리 + 지번 예) 서린동 154-1</span>
+      </li>
+    </ul>
+  );
+}
+
+export { KindergartenSearchHint };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPage.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { ActionButton, Icon, ProgressBar, TextField, TextFieldInput } from '@knockdog/ui';
+
+import { Header } from '@widgets/Header';
+
+import { roleConversionProgress } from '@views/role-conversion/config/roleConversionProgress';
+import { kindergartenSearchContent } from '../config/kindergartenSearchContent';
+import { useKindergartenSearchPage } from '../model/useKindergartenSearchPage';
+import { KindergartenSearchPlaceList } from './KindergartenSearchPlaceList';
+
+function KindergartenSearchPage() {
+  const {
+    query,
+    places,
+    selectedPlaceId,
+    isNextEnabled,
+    handleQueryChange,
+    handlePlaceSelect,
+    handleNextClick,
+  } = useKindergartenSearchPage();
+
+  const hasQuery = query.trim().length > 0;
+
+  return (
+    <div className='flex h-full flex-col'>
+      <Header>
+        <Header.BackButton />
+        <Header.Title>{kindergartenSearchContent.headerTitle}</Header.Title>
+      </Header>
+
+      <div className='shrink-0 px-4 py-2'>
+        <ProgressBar
+          totalSteps={roleConversionProgress.totalSteps}
+          value={roleConversionProgress.kindergartenSearchStep}
+        />
+      </div>
+
+      <div className='flex min-h-0 flex-1 flex-col px-4 pt-3 pb-5'>
+        <div className='flex shrink-0 flex-col gap-5'>
+          <h1 className='h1-extrabold'>
+            {kindergartenSearchContent.titleLine1}
+            <br />
+            {kindergartenSearchContent.titleLine2}
+          </h1>
+
+          <div className='relative min-w-0'>
+            <TextField
+              prefix={<Icon icon='Search' className='size-x6 text-fill-secondary-700' />}
+              className='bg-fill-secondary-50 h-x12 min-w-0 border-0'
+            >
+              <TextFieldInput
+                type='search'
+                placeholder={kindergartenSearchContent.searchPlaceholder}
+                aria-label='유치원 검색어 입력'
+                autoFocus
+                value={query}
+                onChange={(e) => handleQueryChange(e.target.value)}
+              />
+              {query && (
+                <button
+                  type='button'
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    handleQueryChange('');
+                  }}
+                  aria-label='검색어 초기화'
+                  className='absolute top-1/2 right-4 flex -translate-y-1/2 cursor-pointer items-center justify-center'
+                >
+                  <Icon icon='DeleteInput' className='size-x5 text-primitive-neutral-700' />
+                </button>
+              )}
+            </TextField>
+          </div>
+        </div>
+
+        <div className='min-h-0 flex-1 overflow-y-auto pt-4'>
+          {hasQuery && (
+            <KindergartenSearchPlaceList
+              places={places}
+              query={query}
+              selectedPlaceId={selectedPlaceId}
+              onPlaceSelect={handlePlaceSelect}
+            />
+          )}
+        </div>
+
+        <div className='shrink-0 py-5'>
+          <ActionButton
+            type='button'
+            variant='secondaryFill'
+            size='large'
+            className='w-full'
+            disabled={!isNextEnabled}
+            onClick={handleNextClick}
+          >
+            {kindergartenSearchContent.nextButtonLabel}
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { KindergartenSearchPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPage.tsx
@@ -1,25 +1,16 @@
 'use client';
 
-import { ActionButton, Icon, ProgressBar, TextField, TextFieldInput } from '@knockdog/ui';
-
+import { Icon, ProgressBar, TextField, TextFieldInput } from '@knockdog/ui';
 import { Header } from '@widgets/Header';
 
 import { roleConversionProgress } from '@views/role-conversion/config/roleConversionProgress';
 import { kindergartenSearchContent } from '../config/kindergartenSearchContent';
 import { useKindergartenSearchPage } from '../model/useKindergartenSearchPage';
+import { KindergartenSearchHint } from './KindergartenSearchHint';
 import { KindergartenSearchPlaceList } from './KindergartenSearchPlaceList';
 
 function KindergartenSearchPage() {
-  const {
-    query,
-    places,
-    selectedPlaceId,
-    isNextEnabled,
-    handleQueryChange,
-    handlePlaceSelect,
-    handleNextClick,
-  } = useKindergartenSearchPage();
-
+  const { query, places, selectedPlaceId, handleQueryChange, handlePlaceSelect } = useKindergartenSearchPage();
   const hasQuery = query.trim().length > 0;
 
   return (
@@ -33,6 +24,7 @@ function KindergartenSearchPage() {
         <ProgressBar
           totalSteps={roleConversionProgress.totalSteps}
           value={roleConversionProgress.kindergartenSearchStep}
+          className='h-1.5'
         />
       </div>
 
@@ -72,6 +64,8 @@ function KindergartenSearchPage() {
               )}
             </TextField>
           </div>
+
+          {!hasQuery && <KindergartenSearchHint />}
         </div>
 
         <div className='min-h-0 flex-1 overflow-y-auto pt-4'>
@@ -84,22 +78,8 @@ function KindergartenSearchPage() {
             />
           )}
         </div>
-
-        <div className='shrink-0 py-5'>
-          <ActionButton
-            type='button'
-            variant='secondaryFill'
-            size='large'
-            className='w-full'
-            disabled={!isNextEnabled}
-            onClick={handleNextClick}
-          >
-            {kindergartenSearchContent.nextButtonLabel}
-          </ActionButton>
-        </div>
       </div>
-    </div>
-  );
+    </div>  );
 }
 
 export { KindergartenSearchPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPage.tsx
@@ -6,11 +6,13 @@ import { Header } from '@widgets/Header';
 import { roleConversionProgress } from '@views/role-conversion/config/roleConversionProgress';
 import { kindergartenSearchContent } from '../config/kindergartenSearchContent';
 import { useKindergartenSearchPage } from '../model/useKindergartenSearchPage';
+import { KindergartenSearchEmptyResult } from './KindergartenSearchEmptyResult';
 import { KindergartenSearchHint } from './KindergartenSearchHint';
 import { KindergartenSearchPlaceList } from './KindergartenSearchPlaceList';
 
 function KindergartenSearchPage() {
-  const { query, places, selectedPlaceId, handleQueryChange, handlePlaceSelect } = useKindergartenSearchPage();
+  const { query, places, selectedPlaceId, isSearchEmpty, handleQueryChange, handlePlaceSelect } =
+    useKindergartenSearchPage();
   const hasQuery = query.trim().length > 0;
 
   return (
@@ -66,10 +68,11 @@ function KindergartenSearchPage() {
           </div>
 
           {!hasQuery && <KindergartenSearchHint />}
+          {isSearchEmpty && <KindergartenSearchEmptyResult />}
         </div>
 
-        <div className='min-h-0 flex-1 overflow-y-auto pt-4'>
-          {hasQuery && (
+        <div className='scrollbar-hide min-h-0 flex-1 overflow-y-auto pt-4'>
+          {hasQuery && places.length > 0 && (
             <KindergartenSearchPlaceList
               places={places}
               query={query}
@@ -79,7 +82,8 @@ function KindergartenSearchPage() {
           )}
         </div>
       </div>
-    </div>  );
+    </div>
+  );
 }
 
 export { KindergartenSearchPage };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPlaceList.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPlaceList.tsx
@@ -1,0 +1,45 @@
+import type { AutocompletePlace } from '@entities/kindergarten';
+import { HighlightedText } from '@features/search/ui/HighlightedText';
+import { cn } from '@knockdog/ui/lib';
+
+interface KindergartenSearchPlaceListProps {
+  places: AutocompletePlace[];
+  query: string;
+  selectedPlaceId: string | null;
+  onPlaceSelect: (place: AutocompletePlace) => void;
+}
+
+function KindergartenSearchPlaceList({
+  places,
+  query,
+  selectedPlaceId,
+  onPlaceSelect,
+}: KindergartenSearchPlaceListProps) {
+  if (places.length === 0) return null;
+
+  return (
+    <ul className='flex flex-col'>
+      {places.map((place) => (
+        <li key={place.id}>
+          <button
+            type='button'
+            onClick={() => onPlaceSelect(place)}
+            className={cn(
+              'hover:rounded-r2 hover:bg-fill-secondary-50 w-full text-left',
+              selectedPlaceId === place.id && 'bg-fill-secondary-50 rounded-r2'
+            )}
+          >
+            <div className='gap-x2 border-primitive-neutral-100 py-x4 flex w-full items-center border-b px-0'>
+              <div className='gap-x1 flex min-w-0 shrink-0 grow flex-col overflow-hidden'>
+                <p className='body2-semibold text-text-primary truncate'>
+                  <HighlightedText text={place.title} query={query} />
+                </p>                <span className='label-medium text-text-tertiary truncate'>{place.roadAddress}</span>
+              </div>
+            </div>
+          </button>        </li>
+      ))}
+    </ul>
+  );
+}
+
+export { KindergartenSearchPlaceList };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPlaceList.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchPlaceList.tsx
@@ -2,6 +2,8 @@ import type { AutocompletePlace } from '@entities/kindergarten';
 import { HighlightedText } from '@features/search/ui/HighlightedText';
 import { cn } from '@knockdog/ui/lib';
 
+import { kindergartenSearchContentInset } from '../config/kindergartenSearchContentInset';
+
 interface KindergartenSearchPlaceListProps {
   places: AutocompletePlace[];
   query: string;
@@ -18,7 +20,7 @@ function KindergartenSearchPlaceList({
   if (places.length === 0) return null;
 
   return (
-    <ul className='flex flex-col'>
+    <ul className={cn('flex flex-col', kindergartenSearchContentInset)}>
       {places.map((place) => (
         <li key={place.id}>
           <button
@@ -33,10 +35,12 @@ function KindergartenSearchPlaceList({
               <div className='gap-x1 flex min-w-0 shrink-0 grow flex-col overflow-hidden'>
                 <p className='body2-semibold text-text-primary truncate'>
                   <HighlightedText text={place.title} query={query} />
-                </p>                <span className='label-medium text-text-tertiary truncate'>{place.roadAddress}</span>
+                </p>
+                <span className='label-medium text-text-tertiary truncate'>{place.roadAddress}</span>
               </div>
             </div>
-          </button>        </li>
+          </button>
+        </li>
       ))}
     </ul>
   );


### PR DESCRIPTION
<!-- 이 PR을 요약한 내용으로 위 제목 폼을 채워 주세요. -->
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

관리자 전환 플로우 유치원 검색 초기 UI를 구현했습니다. (해당 퍼블리싱된 페이지는 [피그마](https://www.figma.com/design/93NxP3OOpa3BfnGTH0dNl2/%EB%94%94%EC%9E%90%EC%9D%B8_Only--%EC%82%AD%EC%A0%9C-X-?node-id=833-55419&t=9xnlEYSUNo5nsVZL-1) 수정안 26.06.21 이전에 구현된 초안 버전으로 추후 상세 수정할 계획입니다)

- `/role-conversion/kindergarten-search` — 유치원 검색
- `/role-conversion/kindergarten-register` — 유치원 직접 등록

유치원  검색 결과가 없을 때 직접 등록 페이지로 진입할 수 있는 분기를 추가했습니다. 
기존 장소 검색(`searchQueryOptions.autocomplete`) 및 `TextField`/`HighlightedText` 패턴을 재사용했습니다.

---

## 작업 내용

### 라우팅·플로우 연결

- `route.roleConversion.kindergartenSearch`, `kindergartenRegister` 추가
- 검색 결과 없음 CTA → 유치원 직접 등록 페이지 이동
- `roleConversionProgress`를 공통 config로 분리 (`kindergartenSearchStep: 2`)

### 유치원 검색 페이지 

- 헤더, ProgressBar, 검색 입력 UI 퍼블리싱
- `useBasePoint` 좌표 기반 장소 자동완성 검색 연동
- 검색어 미입력 시 검색 힌트 노출 (`KindergartenSearchHint`)
- 검색 결과 목록 표시 및 선택 상태 UI (`KindergartenSearchPlaceList`)
- 검색어 초기화 버튼
- 검색 결과 없음(empty) 상태 UI 및 직접 등록 CTA (`KindergartenSearchEmptyResult`)

### 유치원 직접 등록 페이지 (3a)

- 유치원명 / 주소 / 유치원 번호 / 대표 전화번호 입력 폼
- 필수값 모두 입력 시 `다음` CTA 활성화
- 입력값 포맷팅
  - 유치원명·주소: 허용 문자 필터 + 최대 길이 제한 (30 / 50자)
  - 유치원 번호·대표 전화번호: 전화번호 하이픈 자동 포맷 (02 / 050 / 15·16·18 / 일반 휴대폰)
- 전화번호 필드 `inputMode='tel'` 적용
- 26.06.21 수정안 이후 추가된 `대표자명` 필드 추가 예정

### 사업자번호 인증 페이지 보완

- 타이틀 문구 수정 (`유치원 인증을 위해`)
- 입력 힌트 라벨 추가 (`숫자 10자리를 하이픈(-) 없이 입력해 주세요`)
- 인증 대기·완료·에러 시 힌트 숨김 처리

### 기타 수정

- 유치원 검색 페이지 불필요 CTA 삭제 및 힌트 레이아웃 분리/정리

---

## 퍼블리싱 후속 작업 예정

- 수정안(26.06.21) 디자인에 맞춰 퍼블리싱 수정할 예정입니다.
  - 유치원 정보 입력(1단계) -> 사업자번호 인증(2단계) 로 라우팅 및 progressBar 단계 수정
  - 유치원 직접 등록 `다음` CTA 후속 라우팅(4a~5a)
  - 검색 결과 있을 때의 페이지 퍼블리싱(2b~4b)
  - 유치원 정보 입력 페이지 `대표자명` 필드 추가

---

## 논의할 점

- 유치원 검색은 기존 `features/search` autocomplete API를 그대로 사용하였습니다.
- 직접 등록 폼 포맷팅 규칙(허용 문자, 전화번호 패턴)은 프론트 기준으로 우선 정의했습니다.
- 장소 선택, 직접 등록 후 공통으로 이어질 3단계(개인정보 동의) 스펙이 확정되면 후속 작업 이후 구현할 예정입니다.
- 해당 퍼블리싱 페이지에서는 `유치원 검색 후 선택`, `유치원 정보 등록 API`가 필요할 것으로 예상됩니다.
  - `사업자번호 인증 API`와 함께 해당 API들 필요 스펙 정리 후 Jira에 생성하도록 하겠습니다.

## 스크린샷
<img width="766" height="1428" alt="image" src="https://github.com/user-attachments/assets/6476c522-885d-4660-bc85-aca2f0928a7c" />
<img width="764" height="1272" alt="image" src="https://github.com/user-attachments/assets/6816833e-b698-4459-b635-1ec644ac2497" />
<img width="776" height="1316" alt="image" src="https://github.com/user-attachments/assets/a45fb3af-43ae-4cfe-a982-e2e88256f4c2" />
<img width="772" height="1236" alt="image" src="https://github.com/user-attachments/assets/bad6edfe-ef45-49ea-8bf8-72bf770d004e" />
<img width="772" height="1434" alt="image" src="https://github.com/user-attachments/assets/94396d17-1172-49c3-8377-46771b85109f" />
<img width="754" height="1434" alt="image" src="https://github.com/user-attachments/assets/718b0ada-de74-4c87-84f7-2c716c01a19c" />





