### PR TITLE
feat: 원장 권한 해지 API 연동 및 유치원 운영 정보 UX 보완

### DIFF
--- a/apps/knockdog/src/entities/user/api/revokeOwnerRole.ts
+++ b/apps/knockdog/src/entities/user/api/revokeOwnerRole.ts
@@ -1,0 +1,22 @@
+import { api, type ApiResponse } from '@shared/api';
+
+/** BE `OwnerRoleRevokeReason` */
+type OwnerRoleRevokeReason = 'CLOSED' | 'STOP_USING_SERVICE' | 'ETC';
+
+interface RevokeOwnerRoleRequest {
+  reason: OwnerRoleRevokeReason;
+  reasonDetail?: string | null;
+}
+
+/** `POST` - 원장 권한 해지 */
+async function postRevokeOwnerRole(request: RevokeOwnerRoleRequest) {
+  return await api
+    .post('owner/role/revoke', { json: request })
+    .json<ApiResponse<null>>();
+}
+
+export {
+  postRevokeOwnerRole,
+  type OwnerRoleRevokeReason,
+  type RevokeOwnerRoleRequest,
+};

--- a/apps/knockdog/src/entities/user/api/useOwnerRoleRevokeMutation.ts
+++ b/apps/knockdog/src/entities/user/api/useOwnerRoleRevokeMutation.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useUserStore } from '../model/store/useUserStore';
+import { postRevokeOwnerRole } from './revokeOwnerRole';
+import { ownerMypageSummaryQueryKey, ownerRoleQueryKey } from './useUserQuery';
+
+function useOwnerRoleRevokeMutation() {
+  const queryClient = useQueryClient();
+  const userId = useUserStore((state) => state.user?.userId);
+
+  return useMutation({
+    mutationFn: postRevokeOwnerRole,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ownerRoleQueryKey(userId) }),
+        queryClient.invalidateQueries({ queryKey: ownerMypageSummaryQueryKey(userId) }),
+      ]);
+    },
+  });
+}
+
+export { useOwnerRoleRevokeMutation };

--- a/apps/knockdog/src/entities/user/index.ts
+++ b/apps/knockdog/src/entities/user/index.ts
@@ -10,10 +10,16 @@ export {
   type SocialLoginProvider,
 } from './api/user';
 export {
+  postRevokeOwnerRole,
+  type OwnerRoleRevokeReason,
+  type RevokeOwnerRoleRequest,
+} from './api/revokeOwnerRole';
+export {
   useUserRegisterMutation,
   useUserUpdateNicknameMutation,
   useUserUpdateUserEmailMutation,
 } from './api/useUserMutation';
+export { useOwnerRoleRevokeMutation } from './api/useOwnerRoleRevokeMutation';
 export {
   useAddUserAddressMutation,
   useUpdateUserAddressMutation,

--- a/apps/knockdog/src/features/role-conversion/model/useOwnerKindergarten.ts
+++ b/apps/knockdog/src/features/role-conversion/model/useOwnerKindergarten.ts
@@ -9,7 +9,6 @@ import {
   kindergartenQueries,
 } from '@entities/kindergarten';
 import {
-  buildFullAddress,
   mapOwnerSchoolProfilePricing,
   mapOwnerSchoolProfileToBasic,
   resolveThumbnailUrl,
@@ -91,22 +90,18 @@ function useOwnerKindergarten() {
     ''
   ).trim();
 
-  /** 수정 폼 프리필용 (상세주소 분리) */
+  /** 수정 폼 프리필·표시용 기본 주소 (상세 제외) */
   const streetAddress = (
-    (isSelected ? placeBasic?.roadAddress : null) ??
-    profile?.address ??
-    kindergarten?.address ??
+    profile?.address?.trim() ||
+    (isSelected ? placeBasic?.roadAddress : null) ||
+    kindergarten?.address ||
     ''
   ).trim();
 
-  /** 탭/카드 표시용 */
-  const address = (
-    (isSelected ? streetAddress : null) ??
-    (profile ? buildFullAddress(profile.address, profile.addressDetail) : null) ??
-    streetAddress
-  ).trim();
-
   const addressDetail = (profile?.addressDetail ?? '').trim();
+
+  /** 탭/카드 표시용 기본 주소 (상세는 별도 줄) */
+  const address = streetAddress;
 
   const placePhoneNumber = ((isSelected ? main?.phoneNumber : null) ?? '').trim();
   const schoolPhoneNumber = (profile?.phoneNumber ?? '').trim();

--- a/apps/knockdog/src/features/role-conversion/model/useOwnerKindergarten.ts
+++ b/apps/knockdog/src/features/role-conversion/model/useOwnerKindergarten.ts
@@ -22,7 +22,8 @@ import { useUserStore } from '@entities/user';
  * - SELECTED: `placeId` → kindergarten/basic·main (운영·배너).
  *   요금은 place pricing, 단 원장이 PUT price로 저장한 적 있으면 school profile 우선.
  * - MANUAL: `GET owner/school/profile` (운영·요금).
- * - 자동 채우기: SELECTED 항상 / MANUAL은 schoolProfileId 있으면 (운영 정보 저장 1회+)
+ * - 자동 채우기: 저장본(schoolProfileId) 있으면 profile 최신값,
+ *   없으면 SELECTED place. MANUAL은 저장 1회+부터 노출.
  * - placeId 우선순위: owner/role.placeId → profile.kindergartenPlaceId
  */
 function useOwnerKindergarten() {
@@ -112,10 +113,44 @@ function useOwnerKindergarten() {
    */
   const phoneNumber = schoolPhoneNumber || placePhoneNumber;
 
-  /** 자동 채우기용: SELECTED는 place, MANUAL/저장본은 school */
-  const autofillPhoneNumber = isSelected
-    ? placePhoneNumber || schoolPhoneNumber
-    : schoolPhoneNumber;
+  /** MANUAL: 운영 정보 저장 1회 이상(= schoolProfileId) */
+  const hasSavedSchoolProfile = profile?.schoolProfileId != null;
+
+  /**
+   * 자동 채우기 소스: 저장본 있으면 school profile 최신값,
+   * 없으면 SELECTED place basic/main.
+   */
+  const autofillName = (
+    hasSavedSchoolProfile
+      ? profile?.name
+      : ((isSelected ? main?.title : null) ?? profile?.name ?? kindergarten?.name)
+  )?.trim() ?? '';
+
+  const autofillStreetAddress = (
+    hasSavedSchoolProfile
+      ? profile?.address
+      : ((isSelected ? placeBasic?.roadAddress : null) ??
+        profile?.address ??
+        kindergarten?.address)
+  )?.trim() ?? '';
+
+  const autofillAddressDetail = hasSavedSchoolProfile
+    ? (profile?.addressDetail ?? '').trim()
+    : '';
+
+  const autofillPhoneNumber = hasSavedSchoolProfile
+    ? schoolPhoneNumber
+    : isSelected
+      ? placePhoneNumber || schoolPhoneNumber
+      : schoolPhoneNumber;
+
+  const autofillBasic = hasSavedSchoolProfile
+    ? profileBasic
+    : isSelected
+      ? placeBasic
+      : profileBasic;
+
+  const autofillBannerKeys = hasSavedSchoolProfile ? profileBannerKeys : bannerKeys;
 
   /** SELECTED: placeId 없으면 즉시, 있으면 basic(+main) 조회 완료 후 */
   const isSelectedPrefillReady =
@@ -123,15 +158,12 @@ function useOwnerKindergarten() {
     (!resolvedPlaceId ||
       (placeBasicQuery.isFetched && (coord == null || mainQuery.isFetched)));
 
-  /** MANUAL: 운영 정보 저장 1회 이상(= schoolProfileId) */
-  const hasSavedSchoolProfile = profile?.schoolProfileId != null;
-
   /** SELECTED 항상, MANUAL은 저장 이후 — 자동 채우기 동일 UX */
   const canUseAutofill = isSelected || hasSavedSchoolProfile;
 
-  const isAutofillPrefillReady = isSelected
-    ? isSelectedPrefillReady
-    : hasSavedSchoolProfile;
+  const isAutofillPrefillReady = hasSavedSchoolProfile
+    ? profile != null
+    : isSelectedPrefillReady;
 
   return {
     ownerKindergarten: kindergarten,
@@ -146,7 +178,12 @@ function useOwnerKindergarten() {
     streetAddress,
     addressDetail,
     phoneNumber,
+    autofillName,
+    autofillStreetAddress,
+    autofillAddressDetail,
     autofillPhoneNumber,
+    autofillBasic,
+    autofillBannerKeys,
     bannerKeys,
     ownerName: owner?.name ?? '',
     ownerPhoneNumber: owner?.phoneNumber ?? '',

--- a/apps/knockdog/src/shared/api/endpoint/auth.ts
+++ b/apps/knockdog/src/shared/api/endpoint/auth.ts
@@ -20,7 +20,7 @@ export const fetchDevLogin = async <T>(): Promise<ApiResponse<T>> => {
   // 게스트 전용 ACTIVE 계정. 기존 id=46이 2026-05-28 WITHDRAWN 처리되어 교체.
   // BE 별도 트랙으로 /auth/dev/* 차단 + /auth/guest 신설 예정 → 그때 엔드포인트 교체.
   // DEV_LOGIN_ID = 70 은 2026-06-19 추가됨, 기존 69는 WITHDRAWN 처리되어 임시로 로컬 테스트를 위해 교체.
-  // 79번은 isOwner = true, schoolId = 83 으로 원장 마이페이지 테스트하면 됨.
-  const DEV_LOGIN_ID = 70;
+  // 79번은 isOwner = true, schoolId = 83 으로 원장 마이페이지 테스트하면 됨. => 탈퇴 상태 26.07.16
+  const DEV_LOGIN_ID = 71;
   return await api.get(`auth/dev/${DEV_LOGIN_ID}`).json<ApiResponse<T>>();
 };

--- a/apps/knockdog/src/views/mypage-owner-kindergarten-edit-page/model/useKindergartenEditForm.ts
+++ b/apps/knockdog/src/views/mypage-owner-kindergarten-edit-page/model/useKindergartenEditForm.ts
@@ -73,12 +73,12 @@ function useKindergartenEditForm() {
   const {
     source,
     kindergartenId,
-    name: kindergartenName,
-    streetAddress: kindergartenAddress,
-    addressDetail: kindergartenAddressDetail,
+    autofillName: kindergartenName,
+    autofillStreetAddress: kindergartenAddress,
+    autofillAddressDetail: kindergartenAddressDetail,
     autofillPhoneNumber: phoneNumber,
-    bannerKeys,
-    basic,
+    autofillBannerKeys: bannerKeys,
+    autofillBasic: basic,
     canUseAutofill,
     isAutofillPrefillReady,
   } = useOwnerKindergarten();
@@ -360,8 +360,8 @@ function useKindergartenEditForm() {
 
   /**
    * 자동 채우기 완료 시 폼 채움
-   * - SELECTED: place basic/main
-   * - MANUAL (저장 1회+): school profile
+   * - 저장본(schoolProfileId) 있으면: school profile 최신값
+   * - 없으면 SELECTED: place basic/main
    */
   const applySelectedPrefill = () => {
     const source = prefillSourceRef.current;

--- a/apps/knockdog/src/views/mypage-owner-kindergarten-page/ui/MypageOwnerKindergartenPage.tsx
+++ b/apps/knockdog/src/views/mypage-owner-kindergarten-page/ui/MypageOwnerKindergartenPage.tsx
@@ -28,15 +28,25 @@ const TAB = {
 
 interface InfoRowProps {
   label: string;
-  value: string;
+  value?: string;
+  lines?: string[];
 }
 
-function InfoRow({ label, value }: InfoRowProps) {
+function InfoRow({ label, value, lines }: InfoRowProps) {
+  const displayLines = (lines ?? (value ? [value] : [])).filter(Boolean);
+  const isMultiline = displayLines.length > 1;
+
   return (
-    <div className='flex items-center justify-between gap-x-4 p-4'>
+    <div className={`flex justify-between gap-x-4 p-4 ${isMultiline ? 'items-start' : 'items-center'}`}>
       <span className='body1-medium text-text-tertiary shrink-0'>{label}</span>
-      {value ? (
-        <span className='body1-bold text-text-primary truncate text-right'>{value}</span>
+      {displayLines.length > 0 ? (
+        <div className='flex min-w-0 flex-1 flex-col items-end'>
+          {displayLines.map((line) => (
+            <span key={line} className='body1-bold text-text-primary w-full truncate text-right'>
+              {line}
+            </span>
+          ))}
+        </div>
       ) : (
         <span className='body1-regular text-text-primary text-right'>
           {ownerMypageContent.noConfirmedInfoText}
@@ -49,28 +59,25 @@ function InfoRow({ label, value }: InfoRowProps) {
 interface BasicInfoCardProps {
   name: string;
   address: string;
+  addressDetail?: string;
   phone?: string;
 }
 
-function BasicInfoCard({ name, address, phone = '' }: BasicInfoCardProps) {
-  const rows: InfoRowProps[] = [
-    { label: ownerMypageContent.kindergartenNameLabel, value: name },
-    { label: ownerMypageContent.kindergartenAddressLabel, value: address },
-    { label: ownerMypageContent.kindergartenPhoneLabel, value: phone },
-  ];
-
+function BasicInfoCard({ name, address, addressDetail = '', phone = '' }: BasicInfoCardProps) {
   return (
     <div className='px-4 pt-6'>
       <span className='body1-bold text-text-primary'>
         {ownerMypageContent.kindergartenBasicInfoTitle}
       </span>
       <div className='mt-2 flex flex-col'>
-        {rows.map((row, index) => (
-          <div key={row.label}>
-            <InfoRow label={row.label} value={row.value} />
-            {index < rows.length - 1 ? <Divider /> : null}
-          </div>
-        ))}
+        <InfoRow label={ownerMypageContent.kindergartenNameLabel} value={name} />
+        <Divider />
+        <InfoRow
+          label={ownerMypageContent.kindergartenAddressLabel}
+          lines={[address, addressDetail]}
+        />
+        <Divider />
+        <InfoRow label={ownerMypageContent.kindergartenPhoneLabel} value={phone} />
       </div>
     </div>
   );
@@ -200,7 +207,8 @@ function MypageOwnerKindergartenPage() {
   const { push } = useStackNavigation();
   const {
     name,
-    address,
+    streetAddress,
+    addressDetail,
     phoneNumber,
     source,
     kindergartenId,
@@ -254,7 +262,12 @@ function MypageOwnerKindergartenPage() {
               </div>
             </div>
 
-            <BasicInfoCard name={name} address={address} phone={phoneNumber} />
+            <BasicInfoCard
+              name={name}
+              address={streetAddress}
+              addressDetail={addressDetail}
+              phone={phoneNumber}
+            />
             <OperationSections data={basic} />
           </TabsContent>
 

--- a/apps/knockdog/src/views/role-conversion/release-permission/lib/releasePermissionReasonDraft.ts
+++ b/apps/knockdog/src/views/role-conversion/release-permission/lib/releasePermissionReasonDraft.ts
@@ -1,0 +1,80 @@
+import type { OwnerRoleRevokeReason } from '@entities/user';
+
+import {
+  RELEASE_PERMISSION_REASON,
+  type ReleasePermissionReason,
+} from '@views/role-conversion/release-permission/config/releasePermissionContent';
+
+const RELEASE_PERMISSION_REASON_DRAFT_KEY = 'role_conversion_release_permission_reason_draft';
+
+interface ReleasePermissionReasonDraft {
+  reason: ReleasePermissionReason;
+  reasonDetail: string;
+}
+
+/** FE 해제 사유 → BE `OwnerRoleRevokeReason` */
+const FE_TO_BE_REVOKE_REASON: Record<ReleasePermissionReason, OwnerRoleRevokeReason> = {
+  [RELEASE_PERMISSION_REASON.CLOSURE]: 'CLOSED',
+  [RELEASE_PERMISSION_REASON.SERVICE_STOP]: 'STOP_USING_SERVICE',
+  [RELEASE_PERMISSION_REASON.ETC]: 'ETC',
+};
+
+function isReleasePermissionReason(value: unknown): value is ReleasePermissionReason {
+  return (
+    value === RELEASE_PERMISSION_REASON.CLOSURE ||
+    value === RELEASE_PERMISSION_REASON.SERVICE_STOP ||
+    value === RELEASE_PERMISSION_REASON.ETC
+  );
+}
+
+function saveReleasePermissionReasonDraft(draft: ReleasePermissionReasonDraft) {
+  if (typeof window === 'undefined') return;
+  sessionStorage.setItem(RELEASE_PERMISSION_REASON_DRAFT_KEY, JSON.stringify(draft));
+}
+
+function loadReleasePermissionReasonDraft(): ReleasePermissionReasonDraft | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = sessionStorage.getItem(RELEASE_PERMISSION_REASON_DRAFT_KEY);
+    if (!raw) return null;
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+
+    const record = parsed as Record<string, unknown>;
+    if (!isReleasePermissionReason(record.reason)) return null;
+    if (typeof record.reasonDetail !== 'string') return null;
+
+    return {
+      reason: record.reason,
+      reasonDetail: record.reasonDetail,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function clearReleasePermissionReasonDraft() {
+  if (typeof window === 'undefined') return;
+  sessionStorage.removeItem(RELEASE_PERMISSION_REASON_DRAFT_KEY);
+}
+
+function toRevokeOwnerRoleRequest(draft: ReleasePermissionReasonDraft) {
+  const reason = FE_TO_BE_REVOKE_REASON[draft.reason];
+  const reasonDetail =
+    draft.reason === RELEASE_PERMISSION_REASON.ETC ? draft.reasonDetail.trim() : null;
+
+  return {
+    reason,
+    reasonDetail,
+  };
+}
+
+export {
+  clearReleasePermissionReasonDraft,
+  loadReleasePermissionReasonDraft,
+  saveReleasePermissionReasonDraft,
+  toRevokeOwnerRoleRequest,
+  type ReleasePermissionReasonDraft,
+};

--- a/apps/knockdog/src/views/role-conversion/release-permission/ui/ReleasePermissionReasonPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/release-permission/ui/ReleasePermissionReasonPage.tsx
@@ -27,6 +27,7 @@ import {
   releasePermissionReasonOptions,
   type ReleasePermissionReason,
 } from '@views/role-conversion/release-permission/config/releasePermissionContent';
+import { saveReleasePermissionReasonDraft } from '@views/role-conversion/release-permission/lib/releasePermissionReasonDraft';
 
 import { Header } from '@widgets/Header';
 import { useStackNavigation } from '@shared/lib/bridge';
@@ -40,11 +41,17 @@ function ReleasePermissionReasonPage() {
   const [etcReason, setEtcReason] = useState('');
 
   const isEtc = selectedReason === RELEASE_PERMISSION_REASON.ETC;
-  const isNextEnabled = selectedReason !== '' && (!isEtc || etcReason.trim().length > 0);
+  const isNextEnabled =
+    Boolean(selectedReason) && (!isEtc || etcReason.trim().length > 0);
 
   const handleNext = () => {
     if (!isNextEnabled) return;
-    // @todo 선택 사유(selectedReason, etcReason) 전달/저장
+
+    saveReleasePermissionReasonDraft({
+      reason: selectedReason as ReleasePermissionReason,
+      reasonDetail: isEtc ? etcReason.trim() : '',
+    });
+
     push({
       pathname: route.roleConversion.releasePermission.verify.root,
       ...(source && { query: { [RELEASE_PERMISSION_SOURCE_QUERY_KEY]: source } }),

--- a/apps/knockdog/src/views/role-conversion/release-permission/ui/ReleasePermissionVerifyPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/release-permission/ui/ReleasePermissionVerifyPage.tsx
@@ -6,37 +6,72 @@ import { ActionButton, IconButton, TextField, TextFieldInput } from '@knockdog/u
 import { useSearchParams } from 'next/navigation';
 
 import { useOwnerKindergarten } from '@features/role-conversion';
+import { useOwnerRoleRevokeMutation } from '@entities/user';
+import { toast } from '@shared/ui/toast';
 
 import {
   RELEASE_PERMISSION_SOURCE,
   RELEASE_PERMISSION_SOURCE_QUERY_KEY,
   releasePermissionContent,
 } from '@views/role-conversion/release-permission/config/releasePermissionContent';
+import {
+  clearReleasePermissionReasonDraft,
+  loadReleasePermissionReasonDraft,
+  toRevokeOwnerRoleRequest,
+} from '@views/role-conversion/release-permission/lib/releasePermissionReasonDraft';
 
 import { Header } from '@widgets/Header';
 import { useStackNavigation } from '@shared/lib/bridge';
 import { route } from '@shared/constants/route';
 
 function ReleasePermissionVerifyPage() {
-  const { push } = useStackNavigation();
+  const { push, replace } = useStackNavigation();
   const searchParams = useSearchParams();
   const source = searchParams.get(RELEASE_PERMISSION_SOURCE_QUERY_KEY);
   const { name } = useOwnerKindergarten();
   const [inputName, setInputName] = useState('');
+  const { mutateAsync: revokeOwnerRoleAsync, isPending } = useOwnerRoleRevokeMutation();
 
   const isMatched = inputName.trim() === name.trim() && name.trim().length > 0;
 
-  const handleRelease = () => {
-    if (!isMatched) return;
-    // @todo 원장 권한 해제 API 연동
+  const handleRelease = async () => {
+    if (!isMatched || isPending) return;
 
-    // 탈퇴 플로우에서 진입한 경우 회원 탈퇴 분기 페이지로 이동
-    if (source === RELEASE_PERMISSION_SOURCE.WITHDRAW) {
-      push({ pathname: route.roleConversion.releasePermission.withdraw.root });
+    const draft = loadReleasePermissionReasonDraft();
+    if (!draft) {
+      toast({
+        type: 'default',
+        shape: 'rounded',
+        position: 'bottom',
+        title: '해제 사유를 다시 선택해 주세요',
+      });
+      replace({
+        pathname: route.roleConversion.releasePermission.reason.root,
+        ...(source && { query: { [RELEASE_PERMISSION_SOURCE_QUERY_KEY]: source } }),
+      });
       return;
     }
 
-    push({ pathname: route.roleConversion.releasePermission.complete.root });
+    try {
+      await revokeOwnerRoleAsync(toRevokeOwnerRoleRequest(draft));
+      clearReleasePermissionReasonDraft();
+
+      if (source === RELEASE_PERMISSION_SOURCE.WITHDRAW) {
+        push({ pathname: route.roleConversion.releasePermission.withdraw.root });
+        return;
+      }
+
+      push({ pathname: route.roleConversion.releasePermission.complete.root });
+    } catch (error) {
+      console.error('[owner role revoke]', error);
+      toast({
+        type: 'default',
+        shape: 'rounded',
+        position: 'bottom',
+        title: '권한 해제에 실패했어요',
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
   };
 
   return (
@@ -84,7 +119,7 @@ function ReleasePermissionVerifyPage() {
           variant='secondaryFill'
           size='large'
           className='w-full'
-          disabled={!isMatched}
+          disabled={!isMatched || isPending}
           onClick={handleRelease}
         >
           {releasePermissionContent.releaseButtonLabel}


### PR DESCRIPTION
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

원장 권한 해지 플로우에 `POST owner/role/revoke`를 연동하고, 유치원 정보 조회·운영 정보 수정 UX를 보완했습니다.

주소·상세주소를 각각 한 줄(최대 2줄)로 표기하고, 자동 채우기는 저장본이 있으면 최신 school profile을 우선 프리필하도록 수정했습니다.

`운영 권한 해지하기` -> 운영 권한 해제 플로우 + `탈퇴하기` -> 운영 권한 해제 플로우 -> 유저 탈퇴 플로우까지 반영하였습니다.

- `POST owner/role/revoke` — 원장 권한 해지 (사유·상세 포함)
- 해지 사유 draft(sessionStorage) → BE reason 매핑 후 유치원명 확인 단계에서 요청
- 유치원 기본정보 주소: 기본주소 / 상세주소 각각 한 줄·우측 정렬
- 자동 채우기: `schoolProfileId` 있으면 place 대신 최신 저장 profile 프리필
- DEV 로그인용 `DEV_LOGIN_ID` 게스트 탈퇴 유저(79) 주석 정리

---

## 작업 내용

### 원장 권한 해지 API 연동
- `entities/user` — `postRevokeOwnerRole` / `useOwnerRoleRevokeMutation`
- 사유 선택 페이지: draft를 sessionStorage에 저장
- FE → BE 사유 매핑
  - `CLOSURE` → `CLOSED`
  - `SERVICE_STOP` → `STOP_USING_SERVICE`
  - `ETC` → `ETC` (+ `reasonDetail`)
- 유치원명 확인(verify) 단계에서 `POST owner/role/revoke` 호출 후 플로우 진행

### 유치원 주소·상세주소 UI
- 조회 탭 BasicInfo: `streetAddress` + `addressDetail`를 각각 `truncate` 한 줄로 표시 (상세 있으면 2줄)
- 값 영역 `flex-1` + `text-right`로 두 줄 모두 우측 정렬
- 표시용 주소는 profile 저장 주소 우선, 없으면 SELECTED place 도로명

### 자동 채우기 최신 저장본 프리필
- `schoolProfileId` 존재 시 자동 채우기 소스 = school profile (이름·주소·전화·운영·배너)
- 저장 전 SELECTED만 place basic/main 유지
- `autofillName` / `autofillStreetAddress` / `autofillAddressDetail` / `autofillPhoneNumber` / `autofillBasic` / `autofillBannerKeys`로 표시 데이터와 분리

### DEV 로그인 주석
- `DEV_LOGIN_ID`에 게스트 탈퇴 유저(79) 주석 추가 (로컬 검증용)

---

## 후속 작업 예정 및 논의 사항

- 원장 프로필 수정 API 개발 및 원생 프로필 퍼블리싱 예정입니다.
- 추후 QA에서 원장 마이페이지 플로우 보완 여지가 있습니다.

---

## 스크린샷

1. 권한 해제하기 버튼 플로우
<img width="536" height="1226" alt="스크린샷 2026-07-16 101545" src="https://github.com/user-attachments/assets/17251b47-01bf-4999-b954-9580ab1587a2" />
<img width="534" height="1224" alt="스크린샷 2026-07-16 101614" src="https://github.com/user-attachments/assets/9d6f25cb-6baa-4e70-9d55-b4e72adf4446" />
<img width="540" height="1230" alt="스크린샷 2026-07-16 101644" src="https://github.com/user-attachments/assets/ad46585c-fb0b-4d4e-9877-1e885fa72a36" />
<img width="536" height="1226" alt="스크린샷 2026-07-16 101717" src="https://github.com/user-attachments/assets/ec204831-c3a4-49db-bfaa-fb354e6db191" />
<img width="1130" height="538" alt="스크린샷 2026-07-16 101732" src="https://github.com/user-attachments/assets/d641752d-50a6-4bc0-a195-2e065cb08246" />
<img width="538" height="1232" alt="스크린샷 2026-07-16 101814" src="https://github.com/user-attachments/assets/60c1b092-61f5-4a20-8e6e-6565d9d77e70" />

---

2. 탈퇴하기 버튼 플로우
<img width="538" height="1098" alt="스크린샷 2026-07-16 102534" src="https://github.com/user-attachments/assets/54cd7f63-11c3-4407-8802-4ed84084d1b2" />
<img width="536" height="1220" alt="스크린샷 2026-07-16 103442" src="https://github.com/user-attachments/assets/2d801dc9-59cb-4a3e-9f9a-bb46f0dbce2b" />
<img width="552" height="1234" alt="스크린샷 2026-07-16 103515" src="https://github.com/user-attachments/assets/d697a039-8252-4857-b806-beba553b5ab0" />
<img width="1088" height="564" alt="스크린샷 2026-07-16 103542" src="https://github.com/user-attachments/assets/cdc46ac8-0b58-4038-aa24-0e08acefa1ec" />
<img width="546" height="1216" alt="스크린샷 2026-07-16 103604" src="https://github.com/user-attachments/assets/01a51161-0d3a-4032-ab69-739fb61fb165" />
<img width="536" height="1230" alt="스크린샷 2026-07-16 103636" src="https://github.com/user-attachments/assets/fbec94cc-1f60-44b4-b48f-dfecd9f3ba57" />
<img width="970" height="534" alt="스크린샷 2026-07-16 103709" src="https://github.com/user-attachments/assets/5a14ed48-6f48-4d7e-83cc-e0d72ae7f58a" />

---
<img width="530" height="1106" alt="스크린샷 2026-07-16 110144" src="https://github.com/user-attachments/assets/b0324c6b-1cc7-4bef-9935-939af95cfabd" />

- 주소 및 상세주소 UI 수정