### PR TITLE
feat: 원장 마이페이지 프로필 조회 및 수정하기 API 연동

### DIFF
--- a/apps/knockdog/src/entities/user/api/usePutOwnerProfileMutation.ts
+++ b/apps/knockdog/src/entities/user/api/usePutOwnerProfileMutation.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useUserStore } from '../model/store/useUserStore';
+import { putOwnerProfile } from './user';
+import {
+  ownerMypageSummaryQueryKey,
+  ownerProfileQueryKey,
+  ownerRoleQueryKey,
+} from './useUserQuery';
+
+function usePutOwnerProfileMutation() {
+  const queryClient = useQueryClient();
+  const userId = useUserStore((state) => state.user?.userId);
+
+  return useMutation({
+    mutationFn: putOwnerProfile,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ownerProfileQueryKey(userId) }),
+        queryClient.invalidateQueries({ queryKey: ownerMypageSummaryQueryKey(userId) }),
+        queryClient.invalidateQueries({ queryKey: ownerRoleQueryKey(userId) }),
+      ]);
+    },
+  });
+}
+
+export { usePutOwnerProfileMutation };

--- a/apps/knockdog/src/entities/user/api/useUserQuery.ts
+++ b/apps/knockdog/src/entities/user/api/useUserQuery.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getUserInfo, getOwnerRole, getOwnerMypageSummary } from './user';
+import { getUserInfo, getOwnerRole, getOwnerMypageSummary, getOwnerProfile } from './user';
 
 const useUserInfoQuery = () => {
   return useQuery({
@@ -53,6 +53,26 @@ const useOwnerMypageSummaryQuery = ({
   });
 };
 
+const OWNER_PROFILE_QUERY_KEY = 'ownerProfile';
+
+/** 유저별로 캐시를 분리해 계정 전환 시 이전 원장 프로필이 남지 않도록 함 */
+const ownerProfileQueryKey = (userId?: string) => [OWNER_PROFILE_QUERY_KEY, userId] as const;
+
+interface UseOwnerProfileQueryOptions {
+  userId?: string;
+  enabled?: boolean;
+}
+
+const useOwnerProfileQuery = ({ userId, enabled = true }: UseOwnerProfileQueryOptions = {}) => {
+  return useQuery({
+    queryKey: ownerProfileQueryKey(userId),
+    queryFn: getOwnerProfile,
+    select: (data) => data.data,
+    enabled,
+    staleTime: 0,
+  });
+};
+
 export {
   useUserInfoQuery,
   useOwnerRoleQuery,
@@ -61,4 +81,7 @@ export {
   useOwnerMypageSummaryQuery,
   OWNER_MYPAGE_SUMMARY_QUERY_KEY,
   ownerMypageSummaryQueryKey,
+  useOwnerProfileQuery,
+  OWNER_PROFILE_QUERY_KEY,
+  ownerProfileQueryKey,
 };

--- a/apps/knockdog/src/entities/user/api/user.ts
+++ b/apps/knockdog/src/entities/user/api/user.ts
@@ -92,6 +92,19 @@ const getOwnerMypageSummary = async () => {
   return await api.get(`owner/mypage/summary`).json<ApiResponse<OwnerMypageSummary>>();
 };
 
+/** BE `GET /owner/mypage/profile` 응답 data */
+interface OwnerProfile {
+  representativeName: string;
+  representativePhoneNumber: string;
+  loginEmail: string;
+  profileImageUrl: string | null;
+}
+
+/** `GET` - 원장 프로필 조회 API (원장 전용, 비원장 403) */
+const getOwnerProfile = async () => {
+  return await api.get(`owner/mypage/profile`).json<ApiResponse<OwnerProfile>>();
+};
+
 export {
   type RegisterUserRequest,
   type WithdrawRequest,
@@ -99,6 +112,7 @@ export {
   type OwnerRole,
   type OwnerKindergartenType,
   type OwnerMypageSummary,
+  type OwnerProfile,
   type SocialLoginProvider,
   postRegisterUser,
   postWithdraw,
@@ -107,4 +121,5 @@ export {
   postUpdateUserEmail,
   getOwnerRole,
   getOwnerMypageSummary,
+  getOwnerProfile,
 };

--- a/apps/knockdog/src/entities/user/api/user.ts
+++ b/apps/knockdog/src/entities/user/api/user.ts
@@ -105,6 +105,19 @@ const getOwnerProfile = async () => {
   return await api.get(`owner/mypage/profile`).json<ApiResponse<OwnerProfile>>();
 };
 
+interface PutOwnerProfileRequest {
+  representativeName: string;
+  representativePhoneNumber: string;
+  profileImageUrl: string;
+}
+
+/** `PUT` - 원장 프로필 수정 API (원장 전용, 비원장 403) */
+const putOwnerProfile = async (request: PutOwnerProfileRequest) => {
+  return await api
+    .put(`owner/mypage/profile`, { json: request })
+    .json<ApiResponse<null>>();
+};
+
 export {
   type RegisterUserRequest,
   type WithdrawRequest,
@@ -113,6 +126,7 @@ export {
   type OwnerKindergartenType,
   type OwnerMypageSummary,
   type OwnerProfile,
+  type PutOwnerProfileRequest,
   type SocialLoginProvider,
   postRegisterUser,
   postWithdraw,
@@ -122,4 +136,5 @@ export {
   getOwnerRole,
   getOwnerMypageSummary,
   getOwnerProfile,
+  putOwnerProfile,
 };

--- a/apps/knockdog/src/entities/user/index.ts
+++ b/apps/knockdog/src/entities/user/index.ts
@@ -4,11 +4,13 @@ export {
   getOwnerRole,
   getOwnerMypageSummary,
   getOwnerProfile,
+  putOwnerProfile,
   type WithdrawRequest,
   type OwnerRole,
   type OwnerKindergartenType,
   type OwnerMypageSummary,
   type OwnerProfile,
+  type PutOwnerProfileRequest,
   type SocialLoginProvider,
 } from './api/user';
 export {
@@ -22,6 +24,7 @@ export {
   useUserUpdateUserEmailMutation,
 } from './api/useUserMutation';
 export { useOwnerRoleRevokeMutation } from './api/useOwnerRoleRevokeMutation';
+export { usePutOwnerProfileMutation } from './api/usePutOwnerProfileMutation';
 export {
   useAddUserAddressMutation,
   useUpdateUserAddressMutation,

--- a/apps/knockdog/src/entities/user/index.ts
+++ b/apps/knockdog/src/entities/user/index.ts
@@ -3,10 +3,12 @@ export {
   postWithdraw,
   getOwnerRole,
   getOwnerMypageSummary,
+  getOwnerProfile,
   type WithdrawRequest,
   type OwnerRole,
   type OwnerKindergartenType,
   type OwnerMypageSummary,
+  type OwnerProfile,
   type SocialLoginProvider,
 } from './api/user';
 export {
@@ -34,6 +36,9 @@ export {
   useOwnerMypageSummaryQuery,
   OWNER_MYPAGE_SUMMARY_QUERY_KEY,
   ownerMypageSummaryQueryKey,
+  useOwnerProfileQuery,
+  OWNER_PROFILE_QUERY_KEY,
+  ownerProfileQueryKey,
 } from './api/useUserQuery';
 export { usePushSettingQuery } from './api/usePushSettingQuery';
 export { usePushSettingMutation } from './api/usePushSettingMutation';

--- a/apps/knockdog/src/features/role-conversion/model/useOwnerProfile.ts
+++ b/apps/knockdog/src/features/role-conversion/model/useOwnerProfile.ts
@@ -15,7 +15,7 @@ function useOwnerProfile() {
   const user = useUserStore((state) => state.user);
   const { isOwner } = useOwnerRole();
 
-  const { data } = useOwnerProfileQuery({
+  const { data, isPending } = useOwnerProfileQuery({
     userId: user?.userId,
     enabled: isOwner,
   });
@@ -29,7 +29,11 @@ function useOwnerProfile() {
     };
   }, [data]);
 
-  return { profile };
+  return {
+    profile,
+    /** 원장이 아니면 즉시 true. 원장이면 프로필 첫 조회가 끝날 때까지 false */
+    isReady: !isOwner || !isPending,
+  };
 }
 
 export { useOwnerProfile };

--- a/apps/knockdog/src/features/role-conversion/model/useOwnerProfile.ts
+++ b/apps/knockdog/src/features/role-conversion/model/useOwnerProfile.ts
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMemo, useSyncExternalStore } from 'react';
+import { useMemo } from 'react';
 
-import { getOwnerProfileSnapshot, subscribeOwnerProfile, type OwnerProfile } from '../model/ownerProfile';
+import type { OwnerProfile } from '../model/ownerProfile';
 import { useOwnerRole } from './useOwnerRole';
 
 import { useOwnerProfileQuery, useUserStore } from '@entities/user';
@@ -12,12 +12,6 @@ import { useOwnerProfileQuery, useUserStore } from '@entities/user';
  * owner-role로 원장 확정(isOwner=true)된 뒤에만 호출한다(비원장 403).
  */
 function useOwnerProfile() {
-  const storedProfile = useSyncExternalStore(
-    subscribeOwnerProfile,
-    getOwnerProfileSnapshot,
-    () => null
-  );
-
   const user = useUserStore((state) => state.user);
   const { isOwner } = useOwnerRole();
 
@@ -28,12 +22,12 @@ function useOwnerProfile() {
 
   const profile = useMemo((): OwnerProfile => {
     return {
-      name: storedProfile?.name || (data?.representativeName ?? '').trim(),
-      phoneNumber: storedProfile?.phoneNumber || (data?.representativePhoneNumber ?? '').trim(),
-      email: storedProfile?.email || data?.loginEmail || '',
-      profileImageUrl: storedProfile?.profileImageUrl ?? data?.profileImageUrl ?? undefined,
+      name: (data?.representativeName ?? '').trim(),
+      phoneNumber: (data?.representativePhoneNumber ?? '').trim(),
+      email: data?.loginEmail || '',
+      profileImageUrl: data?.profileImageUrl ?? undefined,
     };
-  }, [data, storedProfile]);
+  }, [data]);
 
   return { profile };
 }

--- a/apps/knockdog/src/features/role-conversion/model/useOwnerProfile.ts
+++ b/apps/knockdog/src/features/role-conversion/model/useOwnerProfile.ts
@@ -5,11 +5,13 @@ import { useMemo, useSyncExternalStore } from 'react';
 import { getOwnerProfileSnapshot, subscribeOwnerProfile, type OwnerProfile } from '../model/ownerProfile';
 import { useOwnerRole } from './useOwnerRole';
 
-import { useSocialUserStore } from '@entities/social-user';
-import { useUserStore } from '@entities/user';
+import { useOwnerProfileQuery, useUserStore } from '@entities/user';
 
+/**
+ * BE `GET /owner/mypage/profile` 기반 원장 프로필.
+ * owner-role로 원장 확정(isOwner=true)된 뒤에만 호출한다(비원장 403).
+ */
 function useOwnerProfile() {
-  // @todo 프로필 수정 API 연동 후 로컬 편집값 없애기
   const storedProfile = useSyncExternalStore(
     subscribeOwnerProfile,
     getOwnerProfileSnapshot,
@@ -17,17 +19,21 @@ function useOwnerProfile() {
   );
 
   const user = useUserStore((state) => state.user);
-  const socialUser = useSocialUserStore((state) => state.socialUser);
-  const { owner } = useOwnerRole();
+  const { isOwner } = useOwnerRole();
+
+  const { data } = useOwnerProfileQuery({
+    userId: user?.userId,
+    enabled: isOwner,
+  });
 
   const profile = useMemo((): OwnerProfile => {
     return {
-      name: storedProfile?.name || owner?.name || '',
-      phoneNumber: storedProfile?.phoneNumber || owner?.phoneNumber || '',
-      email: storedProfile?.email || socialUser?.email || '',
-      profileImageUrl: storedProfile?.profileImageUrl ?? user?.profileImageUrl,
+      name: storedProfile?.name || (data?.representativeName ?? '').trim(),
+      phoneNumber: storedProfile?.phoneNumber || (data?.representativePhoneNumber ?? '').trim(),
+      email: storedProfile?.email || data?.loginEmail || '',
+      profileImageUrl: storedProfile?.profileImageUrl ?? data?.profileImageUrl ?? undefined,
     };
-  }, [owner?.name, owner?.phoneNumber, socialUser?.email, storedProfile, user?.profileImageUrl]);
+  }, [data, storedProfile]);
 
   return { profile };
 }

--- a/apps/knockdog/src/features/role-conversion/model/useOwnerProfileForm.ts
+++ b/apps/knockdog/src/features/role-conversion/model/useOwnerProfileForm.ts
@@ -3,12 +3,16 @@
 import { useEffect } from 'react';
 import { useForm, type SubmitHandler } from 'react-hook-form';
 
-import { useUserStore } from '@entities/user';
+import {
+  usePutOwnerProfileMutation,
+  useUserStore,
+} from '@entities/user';
 import { useMoveImageMutation } from '@shared/lib/media';
+import { toast } from '@shared/ui/toast';
 
 import { formatName, formatPhone } from '../lib/formatKindergartenRegisterField';
 
-import { saveOwnerProfile, type OwnerProfile } from './ownerProfile';
+import { clearOwnerProfile, type OwnerProfile } from './ownerProfile';
 
 interface OwnerProfileFormData {
   name: string;
@@ -26,6 +30,7 @@ function useOwnerProfileForm({ defaultValues, onSuccess }: UseOwnerProfileFormPr
   const { name, phoneNumber, email, profileImageUrl } = defaultValues;
   const user = useUserStore((state) => state.user);
   const { mutateAsync: moveImage } = useMoveImageMutation();
+  const { mutateAsync: putOwnerProfile } = usePutOwnerProfileMutation();
 
   const {
     control,
@@ -67,16 +72,37 @@ function useOwnerProfileForm({ defaultValues, onSuccess }: UseOwnerProfileFormPr
         finalProfileImageUrl = moveResponse.data;
       } catch (error) {
         console.error('이미지 이동 실패:', error);
+        toast({
+          type: 'default',
+          shape: 'rounded',
+          position: 'bottom',
+          title: '프로필 이미지 저장에 실패했어요',
+          description: error instanceof Error ? error.message : undefined,
+        });
+        return;
       }
     }
 
-    saveOwnerProfile({
-      name: data.name.trim(),
-      phoneNumber: data.phoneNumber.trim(),
-      email: data.email.trim(),
-      profileImageUrl: finalProfileImageUrl || undefined,
-    });
-    onSuccess?.();
+    try {
+      await putOwnerProfile({
+        representativeName: data.name.trim(),
+        representativePhoneNumber: data.phoneNumber.trim(),
+        profileImageUrl: finalProfileImageUrl,
+      });
+
+      // 수정 API 연동 전 로컬 편집값 잔존 시 제거
+      clearOwnerProfile();
+      onSuccess?.();
+    } catch (error) {
+      console.error('[owner profile save]', error);
+      toast({
+        type: 'default',
+        shape: 'rounded',
+        position: 'bottom',
+        title: '프로필 저장에 실패했어요',
+        description: error instanceof Error ? error.message : undefined,
+      });
+    }
   };
 
   return {

--- a/apps/knockdog/src/features/role-conversion/model/useOwnerProfileForm.ts
+++ b/apps/knockdog/src/features/role-conversion/model/useOwnerProfileForm.ts
@@ -48,13 +48,16 @@ function useOwnerProfileForm({ defaultValues, onSuccess }: UseOwnerProfileFormPr
   });
 
   useEffect(() => {
+    // API 응답이 늦게 도착해도 작성 중(dirty) 값은 덮어쓰지 않음
+    if (isDirty) return;
+
     reset({
       name,
       phoneNumber,
       email,
       profileImageUrl: profileImageUrl ?? '',
     });
-  }, [name, phoneNumber, email, profileImageUrl, reset]);
+  }, [name, phoneNumber, email, profileImageUrl, reset, isDirty]);
 
   const onSubmit: SubmitHandler<OwnerProfileFormData> = async (data) => {
     let finalProfileImageUrl = data.profileImageUrl || '';

--- a/apps/knockdog/src/features/role-conversion/ui/OwnerProfileForm.tsx
+++ b/apps/knockdog/src/features/role-conversion/ui/OwnerProfileForm.tsx
@@ -90,19 +90,13 @@ function OwnerProfileForm({
             <Controller
               name='email'
               control={control}
-              rules={{
-                validate: (value) => {
-                  const trimmed = value.trim();
-                  return trimmed.length === 0 || /\S+@\S+\.\S+/.test(trimmed);
-                },
-              }}
-              render={({ field, fieldState: { error } }) => (
-                <TextField label={ownerMypageContent.ownerEmailLabel} indicator='(선택)' errorMessage={error?.message}>
+              render={({ field }) => (
+                <TextField label={ownerMypageContent.ownerEmailLabel}>
                   <TextFieldInput
                     {...field}
                     type='email'
+                    readOnly
                     placeholder={ownerMypageContent.ownerEmailPlaceholder}
-                    onChange={(event) => field.onChange(event.target.value.trim())}
                   />
                 </TextField>
               )}

--- a/apps/knockdog/src/views/mypage-owner-profile-edit-page/ui/MypageOwnerProfileEditPage.tsx
+++ b/apps/knockdog/src/views/mypage-owner-profile-edit-page/ui/MypageOwnerProfileEditPage.tsx
@@ -25,7 +25,7 @@ import { useStackNavigation } from '@shared/lib/bridge';
 
 function MypageOwnerProfileEditPage() {
   const { back } = useStackNavigation();
-  const { profile } = useOwnerProfile();
+  const { profile, isReady } = useOwnerProfile();
   const isDirtyRef = useRef(false);
 
   const handleBack = () => {
@@ -63,17 +63,19 @@ function MypageOwnerProfileEditPage() {
         <Header.Title>{ownerMypageContent.profileEditPageTitle}</Header.Title>
       </Header>
 
-      <OwnerProfileForm
-        defaultValues={profile}
-        onSuccess={() => back?.()}
-        submitButtonText={ownerMypageContent.profileSaveButtonLabel}
-        onDirtyChange={(isDirty) => {
-          isDirtyRef.current = isDirty;
-        }}
-        renderProfileImage={({ value, onChange }) => (
-          <OwnerProfileImageUploader profileImage={value} imageAlt={profile.name} onImageSelect={onChange} />
-        )}
-      />
+      {isReady ? (
+        <OwnerProfileForm
+          defaultValues={profile}
+          onSuccess={() => back?.()}
+          submitButtonText={ownerMypageContent.profileSaveButtonLabel}
+          onDirtyChange={(isDirty) => {
+            isDirtyRef.current = isDirty;
+          }}
+          renderProfileImage={({ value, onChange }) => (
+            <OwnerProfileImageUploader profileImage={value} imageAlt={profile.name} onImageSelect={onChange} />
+          )}
+        />
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

원장 마이페이지 프로필 조회·수정에 `GET/PUT owner/mypage/profile`을 연동했습니다.

기존에 `owner/role`·소셜 유저·로컬 저장값을 조합하던 프로필 표시를 API 응답 기준으로 통일하고, 수정 저장도 로컬 draft 대신 서버 PUT으로 전환했습니다.

- `GET /owner/mypage/profile` — 원장 프로필 조회
- `PUT /owner/mypage/profile` — 원장 프로필 수정 (이름·전화·프로필 이미지)
- 성공 시 profile / mypage summary / owner role 쿼리 invalidate
- 수정 API 연동에 맞춰 로컬 `OWNER_PROFILE` 편집값 제거

---

## 작업 내용

### 원장 프로필 조회 API 연동
- `entities/user` — `getOwnerProfile` / `useOwnerProfileQuery` 추가
- `useOwnerProfile`을 `GET /owner/mypage/profile` 응답 매핑으로 전환
  - `representativeName` → 이름
  - `representativePhoneNumber` → 전화번호
  - `loginEmail` → 이메일
  - `profileImageUrl` → 프로필 이미지
- 원장 확정(`isOwner`) 이후에만 조회 (비원장 403 방지)

### 원장 프로필 수정 API 연동
- `entities/user` — `putOwnerProfile` / `usePutOwnerProfileMutation` 추가
- 프로필 수정 폼 저장 시 `PUT /owner/mypage/profile` 호출
  - body: `representativeName`, `representativePhoneNumber`, `profileImageUrl`
- temp 이미지 업로드 시 기존처럼 move 후 최종 URL 전송
- 저장 성공 시 관련 쿼리 invalidate + 로컬 편집값(`clearOwnerProfile`) 제거
- 실패 시 toast 안내

---

## 후속 작업 예정 및 논의 사항

- 추후, 원생 프로필 정보 퍼블리싱 및 원장 인증 QA 수정 진행할 예정입니다.

---

## 스크린샷

<img width="548" height="1226" alt="스크린샷 2026-07-17 202027" src="https://github.com/user-attachments/assets/49a696a1-01a1-4f54-9dcd-b9029d88c268" />
<img width="1368" height="434" alt="스크린샷 2026-07-17 202006" src="https://github.com/user-attachments/assets/3a63b4b5-7d17-48d5-a174-ee5009c8fd48" />

- 원장 프로필 조회

<img width="540" height="1224" alt="스크린샷 2026-07-17 202623" src="https://github.com/user-attachments/assets/01ad4f74-fb34-47af-b718-f278dd82bfff" />
<img width="1326" height="320" alt="스크린샷 2026-07-17 202440" src="https://github.com/user-attachments/assets/2fb2c2f6-4fc1-4e17-8c05-3a4c47905ed3" />

- 원장 프로필 수정·저장
