### PR TITLE
fix: 모바일 원장전환 주소 및 유치원 선택 정보 미반영 수정

### DIFF
--- a/apps/knockdog/src/entities/owner-verification/model/ownerVerification.ts
+++ b/apps/knockdog/src/entities/owner-verification/model/ownerVerification.ts
@@ -2,6 +2,7 @@ interface SelectRequest {
   kindergartenId: number;
   representativeName: string;
   representativePhoneNumber: string;
+  kindergartenAddressDetail: string | null;
 }
 
 interface ManualRequest {

--- a/apps/knockdog/src/shared/lib/bridge/index.ts
+++ b/apps/knockdog/src/shared/lib/bridge/index.ts
@@ -6,3 +6,4 @@ export { useOpenExternalLink } from './useOpenExternalLink';
 export { StackLink } from './StackLink';
 export { navigateToLogin } from './navigateToLogin';
 export { openSystemSetting } from './openSystemSetting';
+export { waitForNavParams } from './waitForNavParams';

--- a/apps/knockdog/src/shared/lib/bridge/queryUtils.ts
+++ b/apps/knockdog/src/shared/lib/bridge/queryUtils.ts
@@ -45,3 +45,16 @@ export function buildHref(pathname: string, query?: Query): string {
   const queryString = params.toString();
   return queryString ? `${pathname}?${queryString}` : pathname;
 }
+
+/** 네이티브 WebView: 현재 origin 기준 (Tab/Stack origin 불일치 방지) */
+export function buildNativeFullPath(pathname: string): string {
+  if (pathname.startsWith('http://') || pathname.startsWith('https://')) {
+    return pathname;
+  }
+
+  const normalizedPath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
+  const baseUrl =
+    typeof window !== 'undefined' ? window.location.origin : (process.env.NEXT_PUBLIC_WEB_URL ?? '');
+
+  return `${baseUrl}/${normalizedPath}`;
+}

--- a/apps/knockdog/src/shared/lib/bridge/useStackNavigation.ts
+++ b/apps/knockdog/src/shared/lib/bridge/useStackNavigation.ts
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useBridge } from './BridgeProvider';
 import { isNativeWebView } from '@shared/lib/device';
 import { METHODS, makeId, BridgeEventMap } from '@knockdog/bridge-core';
-import { buildHref, type Query } from './queryUtils';
+import { buildHref, buildNativeFullPath, type Query } from './queryUtils';
 import { getCurrentTxId } from './useNavigationResult';
 
 type Params = Record<string, unknown>;
@@ -36,16 +36,8 @@ function useStackNavigation() {
     ) => {
       const { pathname, query, params, replace, scroll } = options;
 
-      // 외부 URL인지 확인 (http:// 또는 https://로 시작)
       const isExternalUrl = pathname.startsWith('http://') || pathname.startsWith('https://');
-
-      // 외부 URL이면 그대로 사용, 아니면 내부 경로로 변환
-      const fullPath = isExternalUrl
-        ? pathname
-        : (() => {
-            const normalizedPath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
-            return `${process.env.NEXT_PUBLIC_WEB_URL}/${normalizedPath}`;
-          })();
+      const fullPath = isExternalUrl ? pathname : buildNativeFullPath(pathname);
 
       // forcedTxId가 제공되면 사용, params가 있으면 새로 생성, 아니면 null
       const txId = forcedTxId !== undefined ? forcedTxId : params ? makeId() : null;
@@ -124,16 +116,8 @@ function useStackNavigation() {
 
   const reset = useCallback(
     async (pathname: string = '/', query?: Query, params?: Params) => {
-      // 외부 URL인지 확인 (http:// 또는 https://로 시작)
       const isExternalUrl = pathname.startsWith('http://') || pathname.startsWith('https://');
-
-      // 외부 URL이면 그대로 사용, 아니면 내부 경로로 변환
-      const fullPath = isExternalUrl
-        ? pathname
-        : (() => {
-            const normalizedPath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
-            return `${process.env.NEXT_PUBLIC_WEB_URL}/${normalizedPath}`;
-          })();
+      const fullPath = isExternalUrl ? pathname : buildNativeFullPath(pathname);
 
       // params가 있으면 txId 생성
       const txId = params ? makeId() : null;
@@ -277,17 +261,18 @@ function useStackNavigation() {
 
           // 웹 전용 경로: 뒤로 돌아왔을 때 sessionStorage에서 복구
           const onPop = () => {
-            // 현재 URL의 _txId 확인
+            // 부모 화면으로 돌아온 경우 URL에는 _txId가 없을 수 있어 먼저 결과를 확인한다.
+            if (resolveFromStorage()) {
+              return;
+            }
+
             const currentTxId = getCurrentTxId();
 
-            // 현재 페이지가 pushForResult로 열린 페이지가 아니면 무시
             if (currentTxId !== txId) {
               return;
             }
 
-            // 결과가 있으면 resolve/reject, 없으면 에러 던지기
-            const hasResult = resolveFromStorage();
-            if (!hasResult && !settled) {
+            if (!settled) {
               settled = true;
               cleanup();
               reject(new Error('Navigation cancelled: User navigated back without providing result'));

--- a/apps/knockdog/src/shared/lib/bridge/useStackNavigation.ts
+++ b/apps/knockdog/src/shared/lib/bridge/useStackNavigation.ts
@@ -6,7 +6,6 @@ import { useBridge } from './BridgeProvider';
 import { isNativeWebView } from '@shared/lib/device';
 import { METHODS, makeId, BridgeEventMap } from '@knockdog/bridge-core';
 import { buildHref, buildNativeFullPath, type Query } from './queryUtils';
-import { getCurrentTxId } from './useNavigationResult';
 
 type Params = Record<string, unknown>;
 
@@ -266,12 +265,7 @@ function useStackNavigation() {
               return;
             }
 
-            const currentTxId = getCurrentTxId();
-
-            if (currentTxId !== txId) {
-              return;
-            }
-
+            // 결과 없이 back → 즉시 cancel로 settle 
             if (!settled) {
               settled = true;
               cleanup();

--- a/apps/knockdog/src/shared/lib/bridge/waitForNavParams.ts
+++ b/apps/knockdog/src/shared/lib/bridge/waitForNavParams.ts
@@ -1,0 +1,48 @@
+import { isNativeWebView } from '@shared/lib/device';
+
+interface WaitForNavParamsOptions {
+  /** 네이티브에서 params 주입을 기다리는 최대 시간 */
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+/**
+ * 네이티브 WebView는 Android에서 history.state(_params) 주입이
+ * content load 이후에 올 수 있어, 첫 렌더의 getParams()가 null일 수 있다.
+ * 웹/이미 준비된 네이티브는 즉시 콜백한다.
+ */
+function waitForNavParams<T>(
+  read: () => T | null,
+  onResolve: (value: T | null) => void,
+  options: WaitForNavParamsOptions = {}
+): () => void {
+  const { timeoutMs = 2000, intervalMs = 50 } = options;
+
+  if (typeof window === 'undefined') {
+    onResolve(null);
+    return () => {};
+  }
+
+  const immediate = read();
+
+  if (immediate || !isNativeWebView()) {
+    onResolve(immediate);
+    return () => {};
+  }
+
+  const startedAt = Date.now();
+  const timerId = window.setInterval(() => {
+    const next = read();
+
+    if (next || Date.now() - startedAt >= timeoutMs) {
+      window.clearInterval(timerId);
+      onResolve(next);
+    }
+  }, intervalMs);
+
+  return () => {
+    window.clearInterval(timerId);
+  };
+}
+
+export { waitForNavParams };

--- a/apps/knockdog/src/views/role-conversion/kindergarten-confirm/lib/toManualRequest.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-confirm/lib/toManualRequest.ts
@@ -7,7 +7,7 @@ function toManualRequest(info: RoleConversionKindergartenInfo): ManualRequest | 
   return {
     kindergartenName: info.name,
     kindergartenAddress: info.address,
-    kindergartenAddressDetail: null,
+    kindergartenAddressDetail: (info.addressDetail ?? '').trim() || null,
     kindergartenPhoneNumber: info.kindergartenNumber,
     representativeName: info.ownerName,
     representativePhoneNumber: info.phoneNumber,

--- a/apps/knockdog/src/views/role-conversion/kindergarten-confirm/lib/toSelectRequest.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-confirm/lib/toSelectRequest.ts
@@ -11,6 +11,7 @@ function toSelectRequest(info: RoleConversionKindergartenInfo): SelectRequest | 
     kindergartenId,
     representativeName: info.ownerName,
     representativePhoneNumber: info.phoneNumber,
+    kindergartenAddressDetail: (info.addressDetail ?? '').trim() || null,
   };
 }
 

--- a/apps/knockdog/src/views/role-conversion/kindergarten-confirm/model/useKindergartenConfirmPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-confirm/model/useKindergartenConfirmPage.ts
@@ -1,8 +1,9 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { postKindergartenManual, postKindergartenSelect, saveSession } from '@entities/owner-verification';
 import { route } from '@shared/constants/route';
-import { useStackNavigation } from '@shared/lib/bridge';
+import { useStackNavigation, waitForNavParams } from '@shared/lib/bridge';
+import { isNativeWebView } from '@shared/lib/device';
 import { toast } from '@shared/ui/toast';
 import {
   clearDraft,
@@ -10,14 +11,37 @@ import {
   readParams,
   saveSearchPrefill,
 } from '@views/role-conversion/model/kindergartenConfirmParams';
-import { toDisplayItems } from '@views/role-conversion/model/kindergartenInfo';
+import {
+  toDisplayItems,
+  type RoleConversionKindergartenInfo,
+} from '@views/role-conversion/model/kindergartenInfo';
 import { handleOwnerVerificationAuthError } from '@views/role-conversion/complete/lib/handleOwnerVerificationAuthError';
 import { toManualRequest } from '../lib/toManualRequest';
 import { toSelectRequest } from '../lib/toSelectRequest';
 
 function useKindergartenConfirmPage() {
   const { back, getParams, push, replace } = useStackNavigation();
-  const kindergartenInfo = useMemo(() => readParams(getParams), [getParams]);
+  const [kindergartenInfo, setKindergartenInfo] = useState<RoleConversionKindergartenInfo | null>(() =>
+    readParams(getParams)
+  );
+  const [isParamsResolved, setIsParamsResolved] = useState(() => {
+    if (!isNativeWebView()) return true;
+    return !!readParams(getParams);
+  });
+
+  // 네이티브: confirm으로 push된 params가 첫 렌더에 없으면 잠깐 대기 (즉시 back 방지)
+  useEffect(() => {
+    if (isParamsResolved) return;
+
+    return waitForNavParams(
+      () => readParams(getParams),
+      (info) => {
+        if (info) setKindergartenInfo(info);
+        setIsParamsResolved(true);
+      }
+    );
+  }, [getParams, isParamsResolved]);
+
   const displayItems = useMemo(
     () => (kindergartenInfo ? toDisplayItems(kindergartenInfo) : []),
     [kindergartenInfo]
@@ -85,10 +109,11 @@ function useKindergartenConfirmPage() {
   const isPending = isSelectPending || isManualPending;
 
   useEffect(() => {
+    if (!isParamsResolved) return;
     if (!kindergartenInfo) {
       back();
     }
-  }, [back, kindergartenInfo]);
+  }, [back, isParamsResolved, kindergartenInfo]);
 
   const handleNo = () => {
     clearDraft();

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/config/kindergartenRegisterContent.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/config/kindergartenRegisterContent.ts
@@ -8,6 +8,7 @@ export const kindergartenRegisterContent = Object.freeze({
   addressRegisterHeaderTitle: '주소 검색하기',
   addressPlaceholder: '유치원 주소를 입력해 주세요',
   addressSearchPlaceholder: '유치원 주소를 검색해 주세요',
+  addressDetailPlaceholder: '상세 주소를 입력해 주세요',
   numberLabel: '유치원 전화번호',
   numberPlaceholder: '유치원 전화번호를 입력해 주세요',
   ownerNameLabel: '대표자명',

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/lib/registerFormDraft.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/lib/registerFormDraft.ts
@@ -49,6 +49,7 @@ function loadRegisterFormDraft(): KindergartenRegisterForm | null {
   }
 }
 
+/** 웹: 주소 페이지(동일 탭 sessionStorage) → 등록 폼 remount 복원용 */
 function updateRegisterFormDraftAddress(address: string) {
   const draft = loadRegisterFormDraft();
 

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/lib/registerFormDraft.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/lib/registerFormDraft.ts
@@ -22,6 +22,7 @@ function isKindergartenRegisterForm(value: unknown): value is KindergartenRegist
     (record.placeId === undefined || typeof record.placeId === 'string') &&
     typeof record.name === 'string' &&
     typeof record.address === 'string' &&
+    (record.addressDetail === undefined || typeof record.addressDetail === 'string') &&
     typeof record.kindergartenNumber === 'string' &&
     typeof record.ownerName === 'string' &&
     typeof record.phoneNumber === 'string'
@@ -43,7 +44,12 @@ function loadRegisterFormDraft(): KindergartenRegisterForm | null {
     if (!raw) return null;
 
     const parsed: unknown = JSON.parse(raw);
-    return isKindergartenRegisterForm(parsed) ? parsed : null;
+    if (!isKindergartenRegisterForm(parsed)) return null;
+
+    return {
+      ...parsed,
+      addressDetail: parsed.addressDetail ?? '',
+    };
   } catch {
     return null;
   }

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterAddressPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterAddressPage.ts
@@ -1,16 +1,21 @@
 import { Address } from '@entities/address';
-import { useStackNavigation } from '@shared/lib/bridge';
+import { useNavigationResult, useStackNavigation } from '@shared/lib/bridge';
 
 import { formatAddress } from '@features/role-conversion/lib/formatKindergartenRegisterField';
 import { updateRegisterFormDraftAddress } from '@views/role-conversion/kindergarten-register/lib/registerFormDraft';
 
 function useKindergartenRegisterAddressPage() {
+  const { send } = useNavigationResult<string>();
   const { back } = useStackNavigation();
 
   async function handleSelect(address: Address) {
     const selectedAddress = formatAddress(address.roadAddress || address.address);
 
+    // 네이티브: WebView 간 sessionStorage 미공유 → bridge result
+    send(selectedAddress);
+    // 웹: 등록 폼 remount 시 draft로 복원
     updateRegisterFormDraftAddress(selectedAddress);
+
     await back();
   }
 

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { route } from '@shared/constants/route';
 import { useStackNavigation, waitForNavParams } from '@shared/lib/bridge';
+import { isNativeWebView } from '@shared/lib/device';
 
 import {
   emptyRegisterForm,
@@ -14,7 +15,9 @@ import {
 import {
   clearSearchPrefill,
   consumeSearchPrefillInit,
+  readNavSearchPrefill,
   saveDraft,
+  saveSearchPrefill,
 } from '@views/role-conversion/model/kindergartenConfirmParams';
 import {
   clearRegisterFormDraft,
@@ -58,20 +61,40 @@ function resolveInitialForm(
 }
 
 function useKindergartenRegisterPage(mode: KindergartenRegisterSource) {
-  const { getParams, push, pushForResult } = useStackNavigation();
+  const { getParams, push, pushForResult, back } = useStackNavigation();
   const [form, setForm] = useState<KindergartenRegisterForm>(() => resolveInitialForm(mode, getParams));
-  const hasSearchPrefillRef = useRef(form.source === 'search' && form.name.trim().length > 0);
+  // stored prefill만으로 resolved 처리하지 않음 — native params 도착 전 stale 값에 고정되는 것 방지
+  const hasSearchPrefillRef = useRef(mode === 'search' && !!readNavSearchPrefill(getParams));
 
   // 네이티브(특히 Android): history.state._params 주입이 첫 렌더보다 늦을 수 있음
   useEffect(() => {
     if (mode !== 'search' || hasSearchPrefillRef.current) return;
 
-    return waitForNavParams(
-      () => consumeSearchPrefillInit(getParams),
-      (prefill) => {
-        if (!prefill) return;
+    if (!isNativeWebView()) {
+      const prefill = consumeSearchPrefillInit(getParams);
+      if (prefill) {
         hasSearchPrefillRef.current = true;
         setForm(fromSearchPrefill(prefill));
+      }
+      return;
+    }
+
+    return waitForNavParams(
+      () => readNavSearchPrefill(getParams),
+      (navPrefill) => {
+        if (navPrefill) {
+          saveSearchPrefill(navPrefill);
+          hasSearchPrefillRef.current = true;
+          setForm(fromSearchPrefill(navPrefill));
+          return;
+        }
+
+        // timeout: stored/cache prefill fallback
+        const fallback = consumeSearchPrefillInit(() => null);
+        if (fallback) {
+          hasSearchPrefillRef.current = true;
+          setForm(fromSearchPrefill(fallback));
+        }
       }
     );
   }, [getParams, mode]);
@@ -130,6 +153,14 @@ function useKindergartenRegisterPage(mode: KindergartenRegisterSource) {
     });
   };
 
+  const handleBack = () => {
+    // 등록 페이지를 완전히 나가면 draft 제거 (주소 검색 왕복은 pushForResult라 unmount/back 아님)
+    if (mode === 'manual') {
+      clearRegisterFormDraft();
+    }
+    back?.();
+  };
+
   const handleNextClick = () => {
     const kindergarten = toKindergartenInfo(form);
 
@@ -152,6 +183,7 @@ function useKindergartenRegisterPage(mode: KindergartenRegisterSource) {
     handleFieldChange,
     handleAddressSearch,
     handleClearAddress,
+    handleBack,
     handleNextClick,
   };
 }

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
@@ -41,30 +41,50 @@ const requiredFields = ['name', 'address', 'kindergartenNumber', 'ownerName', 'p
 function resolveInitialForm(
   mode: KindergartenRegisterSource,
   getParams: () => { searchPrefill?: SearchPrefill } | null
-): KindergartenRegisterForm {
+): { form: KindergartenRegisterForm; fromNavPrefill: boolean } {
   if (mode === 'manual') {
     const draft = loadRegisterFormDraft();
     if (draft?.source === 'manual') {
-      return draft;
+      return { form: draft, fromNavPrefill: false };
     }
 
-    return emptyRegisterForm;
+    return { form: emptyRegisterForm, fromNavPrefill: false };
+  }
+
+  // 네이티브: 첫 렌더에서 storage/cache fallback으로 stale prefill을 확정하지 않음
+  // (params 주입이 늦을 수 있어 waitForNavParams 이후 fallback)
+  if (isNativeWebView()) {
+    const navPrefill = readNavSearchPrefill(getParams);
+
+    if (navPrefill) {
+      saveSearchPrefill(navPrefill);
+      return { form: fromSearchPrefill(navPrefill), fromNavPrefill: true };
+    }
+
+    return { form: emptyRegisterForm, fromNavPrefill: false };
   }
 
   const prefill = consumeSearchPrefillInit(getParams);
 
   if (prefill) {
-    return fromSearchPrefill(prefill);
+    return { form: fromSearchPrefill(prefill), fromNavPrefill: !!readNavSearchPrefill(getParams) };
   }
 
-  return emptyRegisterForm;
+  return { form: emptyRegisterForm, fromNavPrefill: false };
 }
 
 function useKindergartenRegisterPage(mode: KindergartenRegisterSource) {
   const { getParams, push, pushForResult, back } = useStackNavigation();
-  const [form, setForm] = useState<KindergartenRegisterForm>(() => resolveInitialForm(mode, getParams));
-  // stored prefill만으로 resolved 처리하지 않음 — native params 도착 전 stale 값에 고정되는 것 방지
-  const hasSearchPrefillRef = useRef(mode === 'search' && !!readNavSearchPrefill(getParams));
+  const initialResolvedRef = useRef<ReturnType<typeof resolveInitialForm> | null>(null);
+  const [form, setForm] = useState<KindergartenRegisterForm>(() => {
+    const resolved = resolveInitialForm(mode, getParams);
+    initialResolvedRef.current = resolved;
+    return resolved.form;
+  });
+  // nav params로 확정된 경우만 resolved — storage/cache만으로는 wait 스킵하지 않음
+  const hasSearchPrefillRef = useRef(
+    mode === 'search' && (initialResolvedRef.current?.fromNavPrefill ?? false)
+  );
 
   // 네이티브(특히 Android): history.state._params 주입이 첫 렌더보다 늦을 수 있음
   useEffect(() => {

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { route } from '@shared/constants/route';
-import { useStackNavigation } from '@shared/lib/bridge';
+import { useStackNavigation, waitForNavParams } from '@shared/lib/bridge';
 
 import {
   emptyRegisterForm,
@@ -19,7 +19,6 @@ import {
 import {
   clearRegisterFormDraft,
   loadRegisterFormDraft,
-  REGISTER_FORM_DRAFT_UPDATED_EVENT,
   saveRegisterFormDraft,
 } from '@views/role-conversion/kindergarten-register/lib/registerFormDraft';
 
@@ -58,33 +57,23 @@ function resolveInitialForm(
 }
 
 function useKindergartenRegisterPage(mode: KindergartenRegisterSource) {
-  const { getParams, push } = useStackNavigation();
+  const { getParams, push, pushForResult } = useStackNavigation();
   const [form, setForm] = useState<KindergartenRegisterForm>(() => resolveInitialForm(mode, getParams));
+  const hasSearchPrefillRef = useRef(form.source === 'search' && form.name.trim().length > 0);
 
+  // 네이티브(특히 Android): history.state._params 주입이 첫 렌더보다 늦을 수 있음
   useEffect(() => {
-    if (mode !== 'manual') return;
+    if (mode !== 'search' || hasSearchPrefillRef.current) return;
 
-    function syncDraftFromStorage() {
-      if (document.visibilityState === 'hidden') return;
-
-      const draft = loadRegisterFormDraft();
-      if (draft?.source === 'manual') {
-        setForm(draft);
+    return waitForNavParams(
+      () => consumeSearchPrefillInit(getParams),
+      (prefill) => {
+        if (!prefill) return;
+        hasSearchPrefillRef.current = true;
+        setForm(fromSearchPrefill(prefill));
       }
-    }
-
-    syncDraftFromStorage();
-
-    window.addEventListener('pageshow', syncDraftFromStorage);
-    window.addEventListener(REGISTER_FORM_DRAFT_UPDATED_EVENT, syncDraftFromStorage);
-    document.addEventListener('visibilitychange', syncDraftFromStorage);
-
-    return () => {
-      window.removeEventListener('pageshow', syncDraftFromStorage);
-      window.removeEventListener(REGISTER_FORM_DRAFT_UPDATED_EVENT, syncDraftFromStorage);
-      document.removeEventListener('visibilitychange', syncDraftFromStorage);
-    };
-  }, [mode]);
+    );
+  }, [getParams, mode]);
 
   const isNextEnabled = useMemo(
     () => requiredFields.every((field) => form[field].trim().length > 0),
@@ -107,11 +96,25 @@ function useKindergartenRegisterPage(mode: KindergartenRegisterSource) {
   };
 
   const handleAddressSearch = async () => {
+    // 웹 remount 복원용. 네이티브 주소 반환은 pushForResult (WebView 간 sessionStorage 미공유).
     saveRegisterFormDraft(form);
 
-    await push({
-      pathname: route.roleConversion.kindergartenRegister.address.root,
-    });
+    try {
+      const selectedAddress = await pushForResult<string>(
+        {
+          pathname: route.roleConversion.kindergartenRegister.address.root,
+        },
+        600_000
+      );
+
+      setForm((prev) => {
+        const next = { ...prev, address: selectedAddress };
+        saveRegisterFormDraft(next);
+        return next;
+      });
+    } catch {
+      // 결과 없이 back — no-op
+    }
   };
 
   const handleClearAddress = () => {

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/model/useKindergartenRegisterPage.ts
@@ -27,6 +27,7 @@ import { formatAddress, formatName, formatPhone } from '@features/role-conversio
 const fieldFormatters = {
   name: formatName,
   address: formatAddress,
+  addressDetail: formatAddress,
   kindergartenNumber: formatPhone,
   ownerName: formatName,
   phoneNumber: formatPhone,
@@ -119,7 +120,7 @@ function useKindergartenRegisterPage(mode: KindergartenRegisterSource) {
 
   const handleClearAddress = () => {
     setForm((prev) => {
-      const next = { ...prev, address: '' };
+      const next = { ...prev, address: '', addressDetail: '' };
 
       if (mode === 'manual') {
         saveRegisterFormDraft(next);

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
@@ -30,13 +30,14 @@ function RegisterPageContent({ mode }: { mode: KindergartenRegisterSource }) {
     handleFieldChange,
     handleAddressSearch,
     handleClearAddress,
+    handleBack,
     handleNextClick,
   } = useKindergartenRegisterPage(mode);
 
   return (
     <div className='flex h-full flex-col'>
       <Header>
-        <Header.BackButton />
+        <Header.BackButton onClick={handleBack} />
         <Header.Title>{kindergartenRegisterContent.headerTitle}</Header.Title>
       </Header>
 

--- a/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-register/ui/KindergartenRegisterPage.tsx
@@ -77,49 +77,58 @@ function RegisterPageContent({ mode }: { mode: KindergartenRegisterSource }) {
                   {kindergartenRegisterContent.addressLabel}
                   <FieldLabelIndicator type='required' className='ml-0' />
                 </FieldLabel>
-                {isManualMode ? (
-                  <button
-                    type='button'
-                    className='w-full text-left'
-                    onClick={handleAddressSearch}
-                    aria-label='주소 검색'
-                  >
-                    <TextField
-                      variant='secondary'
-                      className='h-x13'
-                      prefix={<Icon icon='Search' className='text-text-tertiary' />}
-                      suffix={
-                        form.address ? (
-                          <IconButton
-                            type='button'
-                            icon='DeleteInput'
-                            className='text-text-tertiary'
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              handleClearAddress();
-                            }}
-                            aria-label='선택한 주소 삭제'
-                          />
-                        ) : undefined
-                      }
+                <div className='flex flex-col gap-2'>
+                  {isManualMode ? (
+                    <button
+                      type='button'
+                      className='w-full text-left'
+                      onClick={handleAddressSearch}
+                      aria-label='주소 검색'
                     >
+                      <TextField
+                        variant='secondary'
+                        className='h-x13'
+                        prefix={<Icon icon='Search' className='text-text-tertiary' />}
+                        suffix={
+                          form.address ? (
+                            <IconButton
+                              type='button'
+                              icon='DeleteInput'
+                              className='text-text-tertiary'
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                handleClearAddress();
+                              }}
+                              aria-label='선택한 주소 삭제'
+                            />
+                          ) : undefined
+                        }
+                      >
+                        <TextFieldInput
+                          readOnly
+                          tabIndex={-1}
+                          placeholder={kindergartenRegisterContent.addressSearchPlaceholder}
+                          value={form.address}
+                        />
+                      </TextField>
+                    </button>
+                  ) : (
+                    <TextField className='h-x13'>
                       <TextFieldInput
-                        readOnly
-                        tabIndex={-1}
-                        placeholder={kindergartenRegisterContent.addressSearchPlaceholder}
+                        placeholder={kindergartenRegisterContent.addressPlaceholder}
                         value={form.address}
+                        onChange={(e) => handleFieldChange('address', e.target.value)}
                       />
                     </TextField>
-                  </button>
-                ) : (
+                  )}
                   <TextField className='h-x13'>
                     <TextFieldInput
-                      placeholder={kindergartenRegisterContent.addressPlaceholder}
-                      value={form.address}
-                      onChange={(e) => handleFieldChange('address', e.target.value)}
+                      placeholder={kindergartenRegisterContent.addressDetailPlaceholder}
+                      value={form.addressDetail ?? ''}
+                      onChange={(e) => handleFieldChange('addressDetail', e.target.value)}
                     />
                   </TextField>
-                )}
+                </div>
               </Field>
 
               <Field className='flex-col gap-2 py-4'>

--- a/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchEmptyResult.tsx
+++ b/apps/knockdog/src/views/role-conversion/kindergarten-search/ui/KindergartenSearchEmptyResult.tsx
@@ -3,6 +3,7 @@ import { route } from '@shared/constants/route';
 import { useStackNavigation } from '@shared/lib/bridge';
 
 import { clearSearchPrefill } from '@views/role-conversion/model/kindergartenConfirmParams';
+import { clearRegisterFormDraft } from '@views/role-conversion/kindergarten-register/lib/registerFormDraft';
 
 import { kindergartenSearchContent } from '@views/role-conversion/kindergarten-search/config/kindergartenSearchContent';
 
@@ -11,6 +12,7 @@ function KindergartenSearchEmptyResult() {
 
   const handleRegisterClick = () => {
     clearSearchPrefill();
+    clearRegisterFormDraft();
     push({ pathname: route.roleConversion.kindergartenRegister.root });
   };
   return (

--- a/apps/knockdog/src/views/role-conversion/model/kindergartenConfirmParams.ts
+++ b/apps/knockdog/src/views/role-conversion/model/kindergartenConfirmParams.ts
@@ -120,6 +120,14 @@ function consumeSearchPrefillInit(
   return null;
 }
 
+/** 네이티브 history.state._params의 searchPrefill만 읽음 (sessionStorage fallback 없음) */
+function readNavSearchPrefill(
+  getParams: () => { searchPrefill?: SearchPrefill } | null
+): SearchPrefill | null {
+  const navPrefill = getParams()?.searchPrefill;
+  return navPrefill && isSearchPrefill(navPrefill) ? navPrefill : null;
+}
+
 function clearSearchPrefill() {
   if (typeof window === 'undefined') return;
 
@@ -161,6 +169,7 @@ export {
   clearSearchPrefill,
   consumeSearchPrefillInit,
   loadSearchPrefill,
+  readNavSearchPrefill,
   readParams,
   saveDraft,
   saveSearchPrefill,

--- a/apps/knockdog/src/views/role-conversion/model/kindergartenConfirmParams.ts
+++ b/apps/knockdog/src/views/role-conversion/model/kindergartenConfirmParams.ts
@@ -30,10 +30,20 @@ function isKindergartenInfo(value: unknown): value is RoleConversionKindergarten
     (record.placeId === undefined || typeof record.placeId === 'string') &&
     typeof record.name === 'string' &&
     typeof record.address === 'string' &&
+    (record.addressDetail === undefined || typeof record.addressDetail === 'string') &&
     typeof record.kindergartenNumber === 'string' &&
     typeof record.ownerName === 'string' &&
     typeof record.phoneNumber === 'string'
   );
+}
+
+function normalizeKindergartenInfo(
+  info: RoleConversionKindergartenInfo
+): RoleConversionKindergartenInfo {
+  return {
+    ...info,
+    addressDetail: info.addressDetail ?? '',
+  };
 }
 
 function saveDraft(info: RoleConversionKindergartenInfo) {
@@ -56,7 +66,7 @@ function loadDraft(): RoleConversionKindergartenInfo | null {
     if (!raw) return null;
 
     const parsed: unknown = JSON.parse(raw);
-    return isKindergartenInfo(parsed) ? parsed : null;
+    return isKindergartenInfo(parsed) ? normalizeKindergartenInfo(parsed) : null;
   } catch {
     return null;
   }
@@ -127,7 +137,7 @@ function readParams(
   if (txId && paramsCache.has(txId)) {
     const cached = paramsCache.get(txId);
     if (cached && isKindergartenInfo(cached)) {
-      return cached;
+      return normalizeKindergartenInfo(cached);
     }
   }
 
@@ -135,11 +145,12 @@ function readParams(
   const kindergarten = navParams?.kindergarten;
 
   if (kindergarten && isKindergartenInfo(kindergarten)) {
+    const normalized = normalizeKindergartenInfo(kindergarten);
     if (txId) {
-      paramsCache.set(txId, kindergarten);
+      paramsCache.set(txId, normalized);
     }
 
-    return kindergarten;
+    return normalized;
   }
 
   return loadDraft();

--- a/apps/knockdog/src/views/role-conversion/model/kindergartenInfo.ts
+++ b/apps/knockdog/src/views/role-conversion/model/kindergartenInfo.ts
@@ -7,6 +7,8 @@ interface KindergartenRegisterForm {
   placeId?: string;
   name: string;
   address: string;
+  /** 선택 */
+  addressDetail: string;
   kindergartenNumber: string;
   ownerName: string;
   phoneNumber: string;
@@ -24,6 +26,8 @@ interface RoleConversionKindergartenInfo {
   placeId?: string;
   name: string;
   address: string;
+  /** 선택 */
+  addressDetail: string;
   kindergartenNumber: string;
   ownerName: string;
   phoneNumber: string;
@@ -38,6 +42,7 @@ const emptyRegisterForm: KindergartenRegisterForm = {
   source: 'manual',
   name: '',
   address: '',
+  addressDetail: '',
   kindergartenNumber: '',
   ownerName: '',
   phoneNumber: '',
@@ -49,6 +54,7 @@ function fromSearchPrefill(prefill: SearchPrefill): KindergartenRegisterForm {
     placeId: prefill.placeId,
     name: prefill.name,
     address: prefill.address,
+    addressDetail: '',
     kindergartenNumber: prefill.kindergartenNumber,
     ownerName: '',
     phoneNumber: '',
@@ -61,6 +67,7 @@ function toKindergartenInfo(form: KindergartenRegisterForm): RoleConversionKinde
     placeId: form.placeId,
     name: form.name,
     address: form.address,
+    addressDetail: (form.addressDetail ?? '').trim(),
     kindergartenNumber: form.kindergartenNumber,
     ownerName: form.ownerName,
     phoneNumber: form.phoneNumber,
@@ -68,9 +75,12 @@ function toKindergartenInfo(form: KindergartenRegisterForm): RoleConversionKinde
 }
 
 function toDisplayItems(info: RoleConversionKindergartenInfo): KindergartenInfoDisplayItem[] {
+  const addressDetail = (info.addressDetail ?? '').trim();
+  const addressValue = addressDetail ? `${info.address}\n${addressDetail}` : info.address;
+
   return [
     { label: kindergartenRegisterContent.nameLabel, value: info.name },
-    { label: kindergartenRegisterContent.addressLabel, value: info.address },
+    { label: kindergartenRegisterContent.addressLabel, value: addressValue },
     { label: kindergartenRegisterContent.numberLabel, value: info.kindergartenNumber },
     { label: kindergartenRegisterContent.ownerNameLabel, value: info.ownerName },
     { label: kindergartenRegisterContent.phoneLabel, value: info.phoneNumber },

--- a/apps/knockdog/src/views/role-conversion/ui/KindergartenInfoSummary.tsx
+++ b/apps/knockdog/src/views/role-conversion/ui/KindergartenInfoSummary.tsx
@@ -14,7 +14,7 @@ function KindergartenInfoSummary({ items }: KindergartenInfoSummaryProps) {
           <Field key={item.label} className='flex-col gap-0'>
             <FieldContent className='gap-0'>
               <span className='body1-regular text-text-secondary'>{item.label}</span>
-              <span className='h3-semibold text-text-primary'>{item.value}</span>
+              <span className='h3-semibold text-text-primary whitespace-pre-line'>{item.value}</span>
             </FieldContent>
           </Field>
         ))}


### PR DESCRIPTION
![PR-banner](https://github.com/user-attachments/assets/e9a3d5a0-d8ab-4486-ac39-38b59c211172)

## 작업 개요

모바일(WebView)에서 원장 전환 플로우의 주소 선택·유치원 검색 선택 정보가 다음 화면에 반영되지 않던 문제를 수정했습니다.

웹은 동일 탭 `sessionStorage` / 즉시 `history.state`로 동작했지만, 네이티브는 스택마다 WebView가 분리되거나 params 주입이 첫 렌더보다 늦어 값이 유실되었습니다. 웹 배포만으로 반영되도록 FE 브릿지 및 등록 플로우를 수정했습니다.

- 직접등록 주소: `sessionStorage` draft 대신 `pushForResult` / `send`로 전달
- 유치원 검색 선택: `waitForNavParams`로 params 주입 지연 대기 후 등록·확인 화면 반영
- 네이티브 스택 경로 origin 및 웹 `pushForResult` 복구 안정화

---

## 작업 내용

### 직접등록 주소 선택 미반영 수정
- 원인:주소 선택값을 자식 WebView의 `sessionStorage` draft에만 저장 → 부모 WebView와 미공유
- 등록 폼: 주소 검색을 `pushForResult<string>`로 대기 후 `setForm`
- 주소 페이지: `useNavigationResult.send(selectedAddress)` 후 `back`
- 웹 리마운트 대비 draft address 업데이트는 유지

### 유치원 검색 선택 정보 미반영 수정

- `waitForNavParams` 추가 — 네이티브에서 params가 올 때까지 짧게 재시도
- 확인 페이지: params resolve 전까지 `back` 보류

### 스택 네비게이션 안정화
- `buildNativeFullPath` — 네이티브 push/reset 경로를 `window.location.origin` 기준으로 생성 (Tab/Stack origin 불일치 방지)
- 웹 `pushForResult` popstate: 부모 복귀 시 URL에 `_txId`가 없어도 `sessionStorage` 결과를 우선 resolve

---

## 후속 작업 예정 및 논의 사항

- 베포 이후 이슈 해결 여부 확인 과정이 필요합니다.
- 해당 이슈와 같이 동일하게 `sessionStorage`만 쓰는 플로우가 있으면 같은 패턴으로 점검이 필요할 수 있으며 추후 QA를 통해 수정 여부가 있습니다.

---

## 스크린샷


<img width="540" height="1074" alt="image" src="https://github.com/user-attachments/assets/698de830-af9e-4c79-8cbb-8eed11d8e62c" />

- 직접등록 — 주소 검색 → 선택 → 등록 폼 주소 반영

<img width="540" height="1074" alt="image" src="https://github.com/user-attachments/assets/df09b1cc-135a-4e36-87b2-76ee27ed95ab" />

- 유치원 검색 — 선택 → 등록/확인 화면 정보 반영

